### PR TITLE
Add CSP policy and headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+# Unix artifact from Windows-style `2>nul` redirections
+nul
+
 # Node
 node_modules
 dist

--- a/index.html
+++ b/index.html
@@ -6,23 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Traigent - AI Agent Optimization Platform</title>
     <meta name="description" content="Systematically optimize your AI agents for peak performance. Reduce costs, improve latency, and boost accuracy with Traigent." />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; upgrade-insecure-requests" />
     
     <!-- GitHub Pages SPA routing fix -->
-    <script type="text/javascript">
-      // Single Page Apps for GitHub Pages
-      // MIT License
-      // https://github.com/rafgraph/spa-github-pages
-      (function(l) {
-        if (l.search[1] === '/' ) {
-          var decoded = l.search.slice(1).split('&').map(function(s) { 
-            return s.replace(/~and~/g, '&')
-          }).join('?');
-          window.history.replaceState(null, null,
-              l.pathname.slice(0, -1) + decoded + l.hash
-          );
-        }
-      }(window.location))
-    </script>
+    <script type="text/javascript" src="./spa-github-pages.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,3 @@
+/*
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; upgrade-insecure-requests
+

--- a/public/spa-github-pages.js
+++ b/public/spa-github-pages.js
@@ -1,0 +1,20 @@
+// Single Page Apps for GitHub Pages
+// MIT License
+// https://github.com/rafgraph/spa-github-pages
+(function (l) {
+  if (l.search[1] === "/") {
+    var decoded = l.search
+      .slice(1)
+      .split("&")
+      .map(function (s) {
+        return s.replace(/~and~/g, "&");
+      })
+      .join("?");
+    window.history.replaceState(
+      null,
+      null,
+      l.pathname.slice(0, -1) + decoded + l.hash,
+    );
+  }
+})(window.location);
+


### PR DESCRIPTION
Fixes #1. Adds a CSP meta fallback, moves the GitHub Pages SPA script to an external file, and adds a _headers file for hosts that support setting HTTP headers.