### PR TITLE
Fix asset paths for custom domain (traigent.ai)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/traigent-web/', // For GitHub Pages: achi-traigent.github.io/traigent-web/
+  base: '/', // Use root path for custom domain (traigent.ai)
 }) 


### PR DESCRIPTION
## Summary
- Change Vite base from `/traigent-web/` to `/` so assets load correctly on the custom domain

## Problem
The site at traigent.ai is broken because assets are being loaded from `/traigent-web/assets/...` instead of `/assets/...`

## Fix
Update `vite.config.js` to use root path `/` instead of subdirectory path `/traigent-web/`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)