### PR TITLE
feat: copyable quickstart install command on hero + /get-started

### DIFF
--- a/src/components/InstallCommand.jsx
+++ b/src/components/InstallCommand.jsx
@@ -1,3 +1,7 @@
+/* eslint-disable react/prop-types --
+ * The rest of this codebase ships without PropTypes (e.g. OptimizationTable);
+ * the prop contract for this component is documented in the JSDoc below.
+ */
 import React, { useState } from "react";
 import { Check, Copy } from "lucide-react";
 
@@ -5,15 +9,15 @@ import { Check, Copy } from "lucide-react";
  * A single-line install command with a copy-to-clipboard affordance.
  *
  * The bundled `traigent quickstart` is the load-bearing demo on the
- * funnel: zero API keys, zero successful network calls, ~6 seconds to
- * a results table on a fresh laptop. This component is what lets a
- * visitor copy the command in one click without leaving the page.
+ * funnel: no API keys, no LLM provider calls, ~6 seconds to a results
+ * table on a fresh laptop. This component is what lets a visitor copy
+ * the command in one click without leaving the page.
  *
- * Props:
- *   command        — the shell string to display + copy
- *   label          — optional short label rendered above the block
- *   secondary      — optional second line rendered below (e.g. "or `pip install` only")
- *   className      — extra wrapper classes
+ * @param {object}  props
+ * @param {string}  props.command    — the shell string to display + copy
+ * @param {string}  [props.label]    — optional short label rendered above the block
+ * @param {string}  [props.secondary]— optional caption rendered below
+ * @param {string}  [props.className]— extra wrapper classes
  */
 export default function InstallCommand({
   command,

--- a/src/components/InstallCommand.jsx
+++ b/src/components/InstallCommand.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+/**
+ * A single-line install command with a copy-to-clipboard affordance.
+ *
+ * The bundled `traigent quickstart` is the load-bearing demo on the
+ * funnel: zero API keys, zero successful network calls, ~6 seconds to
+ * a results table on a fresh laptop. This component is what lets a
+ * visitor copy the command in one click without leaving the page.
+ *
+ * Props:
+ *   command        — the shell string to display + copy
+ *   label          — optional short label rendered above the block
+ *   secondary      — optional second line rendered below (e.g. "or `pip install` only")
+ *   className      — extra wrapper classes
+ */
+export default function InstallCommand({
+  command,
+  label,
+  secondary,
+  className = "",
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable (insecure context, etc.) — silent fallback.
+    }
+  };
+
+  return (
+    <div className={className}>
+      {label && (
+        <div className="text-sm text-slate-400 mb-2 font-medium">{label}</div>
+      )}
+      <div className="group relative flex items-start gap-3 bg-slate-900/80 border border-slate-700 rounded-lg px-4 py-3 font-mono text-sm md:text-[0.95rem]">
+        <span className="text-slate-500 select-none pt-0.5">$</span>
+        <code className="text-slate-100 flex-1 break-all whitespace-pre-wrap">
+          {command}
+        </code>
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label={copied ? "Copied" : "Copy install command"}
+          className="flex-shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-md border border-slate-600 bg-slate-800 hover:bg-slate-700 hover:border-slate-500 text-slate-200 transition-colors"
+        >
+          {copied ? (
+            <Check className="w-4 h-4 text-emerald-400" />
+          ) : (
+            <Copy className="w-4 h-4" />
+          )}
+        </button>
+      </div>
+      {secondary && (
+        <div className="text-xs text-slate-500 mt-2">{secondary}</div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -44,7 +44,7 @@ export default function GetStarted() {
           <div className="p-6 rounded-xl bg-slate-900/60 border border-slate-800 flex flex-col">
             <h2 className="text-xl font-semibold mb-2">Traigent SDK</h2>
             <p className="text-slate-300 mb-4 flex-grow">
-              Attach to your existing AI calls with a decorator, run governed optimization on real workloads, and apply the best config. The bundled <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent quickstart</code> demo runs locally in mock mode — no API keys, no network — so you can validate the pipeline before pointing it at real LLMs.
+              Attach to your existing AI calls with a decorator, run governed optimization on real workloads, and apply the best config. The bundled <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent quickstart</code> demo runs locally in mock mode — no API keys, no LLM provider calls — so you can validate the pipeline before pointing it at real LLMs.
             </p>
             <InstallCommand
               command='pip install "traigent[recommended]" && traigent quickstart'

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import { Link } from "react-router-dom";
+import InstallCommand from "../components/InstallCommand";
 
 const createPageUrl = (path) => path;
 
@@ -42,9 +43,13 @@ export default function GetStarted() {
 
           <div className="p-6 rounded-xl bg-slate-900/60 border border-slate-800 flex flex-col">
             <h2 className="text-xl font-semibold mb-2">Traigent SDK</h2>
-            <p className="text-slate-300 mb-6 flex-grow">
-              Attach to your existing AI calls with a decorator, run governed optimization on real workloads, and apply the best config. Follow the SDK docs to install and get started.
+            <p className="text-slate-300 mb-4 flex-grow">
+              Attach to your existing AI calls with a decorator, run governed optimization on real workloads, and apply the best config. The bundled <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent quickstart</code> demo runs locally in mock mode — no API keys, no network — so you can validate the pipeline before pointing it at real LLMs.
             </p>
+            <InstallCommand
+              command='pip install "traigent[recommended]" && traigent quickstart'
+              className="mb-4"
+            />
             <div className="flex flex-wrap gap-3">
               <a
                 href="https://github.com/Traigent/Traigent"
@@ -52,11 +57,22 @@ export default function GetStarted() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center justify-center font-medium bg-white text-slate-900 hover:bg-gray-100 px-5 py-3 rounded-lg"
               >
-                Try out our SDK - it's free!
+                View on GitHub
                 <ExternalLink className="ml-2 h-4 w-4" />
               </a>
             </div>
           </div>
+        </div>
+
+        <div className="mt-10 p-6 rounded-xl bg-slate-900/60 border border-slate-800">
+          <h2 className="text-xl font-semibold mb-2">Drive it from your coding agent</h2>
+          <p className="text-slate-300 mb-4 max-w-3xl">
+            Claude Code, Cursor, Codex, Gemini CLI and 30+ other agents pick up the Traigent skill bundle automatically. They&apos;ll guide you through dry-run-first setup, generate the eval dataset, and apply the best config — without you leaving your editor.
+          </p>
+          <InstallCommand
+            command="npx skills add Traigent/agents-skills"
+            secondary="Pick the traigent-* skills from the interactive list. The bundle includes a dry-run-first orchestrator that validates the full pipeline at zero cost before any real spend."
+          />
         </div>
 
         <div className="mt-12 p-6 rounded-xl bg-gradient-to-br from-indigo-600/20 to-purple-700/20 border border-white/10">

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -219,7 +219,7 @@ export default function Homepage() {
             <InstallCommand
               command='pip install "traigent[recommended]" && traigent quickstart'
               label="Run the keyless demo on your laptop in under a minute"
-              secondary="Zero API keys. Zero outbound network calls to providers. Just python."
+              secondary="No API keys. No LLM provider calls. No spend. Just python."
             />
           </motion.div>
 

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -6,6 +6,7 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 import versionInfo from "../version.json";
 import OptimizationTable from "../components/OptimizationTable";
+import InstallCommand from "../components/InstallCommand";
 
 // Placeholder for the Button component
 const Button = ({ children, className, onClick, size }) => (
@@ -208,19 +209,33 @@ export default function Homepage() {
             <OptimizationTable autoPlay={true} embedded={true} />
           </motion.div>
 
+          {/* One-line install — primary onramp */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.38 }}
+            className="max-w-2xl mx-auto mt-10"
+          >
+            <InstallCommand
+              command='pip install "traigent[recommended]" && traigent quickstart'
+              label="Run the keyless demo on your laptop in under a minute"
+              secondary="Zero API keys. Zero outbound network calls to providers. Just python."
+            />
+          </motion.div>
+
           {/* CTA Buttons */}
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.4 }}
-            className="flex flex-wrap justify-center gap-4 mt-12"
+            className="flex flex-wrap justify-center gap-4 mt-8"
           >
             <Button
               size="lg"
               className="bg-[#1A6BF5] text-white hover:bg-[#4D8EF8] px-8 py-4 text-lg rounded-lg border border-[#1A6BF5] hover:border-[#4D8EF8] transition-all"
               onClick={() => window.open("https://github.com/Traigent/Traigent", "_blank")}
             >
-              Try out our SDK - it's free!
+              View on GitHub
               <ArrowRight className="ml-2 h-5 w-5" />
             </Button>
             <Button


### PR DESCRIPTION
## Summary

Wire the new keyless `traigent quickstart` demo (SDK PR #799) into the visitor funnel. Visitors can now copy a single install command from the homepage hero or `/get-started` and have a working optimization run on their laptop in under a minute — no calendar gate, no API keys, no provider network calls.

## What changed

- **New `InstallCommand` component** — single-line, copy-to-clipboard shell block with a `$` prompt prefix, a copy button that flashes a green check on success, and optional label / secondary description. Long commands wrap in narrow containers instead of horizontally scrolling.
- **Homepage hero** — install command lives between the optimization-table preview and the CTA buttons. Primary GitHub button renamed from "Try out our SDK - it's free!" to "View on GitHub" since the install command itself is now the primary onramp. Calendar "Book a demo" button stays.
- **`/get-started` SDK card** — adds the install command inline plus a short note about mock mode. New "Drive it from your coding agent" section below surfaces the agent-skills install command (`npx skills add Traigent/agents-skills`).

## Why now

Until SDK PR #799 landed (`8ba5e157` on develop), `traigent quickstart` would fail at the first LLM call because `MockAdapter.is_mock_enabled` was hard-wired off. Now the bundled demo runs hermetically (verified by a subprocess CI test that blocks `socket` before any traigent import) with model-correlated non-zero scores. So the website finally has something safe to advertise on the hero.

## Test plan

- [x] `npm run build` clean.
- [x] Dev server + Playwright screenshots verified: hero install block fits one line, /get-started card wraps the long command to two lines without truncation, copy buttons reachable in both contexts.
- [ ] Tap-test on actual mobile.
- [ ] Click copy buttons in real browser to confirm clipboard write succeeds.

## Companion changes (already shipped)

- [Traigent/Traigent#799](https://github.com/Traigent/Traigent/pull/799) — `traigent quickstart` CLI + mock-mode API.
- [Traigent/agents-skills@6bc9bd0](https://github.com/Traigent/agents-skills) — canonical agent-skills bundle.
- [Traigent/agent-skills@6f42742](https://github.com/Traigent/agent-skills) — deprecation notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)