### PR TITLE
fix: switch install command from pip to uv tool install

### DIFF
--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -47,7 +47,8 @@ export default function GetStarted() {
               Attach to your existing AI calls with a decorator, run governed optimization on real workloads, and apply the best config. The bundled <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent quickstart</code> demo runs locally in mock mode — no API keys, no LLM provider calls — so you can validate the pipeline before pointing it at real LLMs.
             </p>
             <InstallCommand
-              command='pip install "traigent[recommended]" && traigent quickstart'
+              command='uv tool install "traigent[recommended]" && traigent quickstart'
+              secondary="Prefer pip? `pip install` is a drop-in replacement."
               className="mb-4"
             />
             <div className="flex flex-wrap gap-3">

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -217,9 +217,9 @@ export default function Homepage() {
             className="max-w-2xl mx-auto mt-10"
           >
             <InstallCommand
-              command='pip install "traigent[recommended]" && traigent quickstart'
+              command='uv tool install "traigent[recommended]" && traigent quickstart'
               label="Run the keyless demo on your laptop in under a minute"
-              secondary="No API keys. No LLM provider calls. No spend. Just python."
+              secondary="No API keys. No LLM provider calls. No spend. Just python. (Have pip instead? `pip install` works too.)"
             />
           </motion.div>
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #13. The internal preference is `uv` over `pip` (faster, no venv ceremony for one-shot CLI demos), but the merge of #13 went out before this switch was pushed. This PR is the same single change, rebased on top of `main`.

## What changed

- **Homepage hero** install block: `pip install` → `uv tool install`
- **/get-started SDK card** install block: same swap

In both places the secondary copy mentions that `pip install` is still a valid drop-in for users on the older toolchain.

## Why `uv tool install` (vs `uv pip install` or `uvx`)

- `uv tool install` puts the CLI in uv's managed tool dir and exposes `traigent` on PATH — exactly what the demo needs to do its `traigent quickstart` follow-up. No venv ceremony, no `--system` workaround, no PEP 668 friction on system Pythons.
- `uv pip install` would require the user to be inside a venv first.
- `uvx --from "traigent[recommended]" traigent quickstart` would also work and is even more zero-install, but it's a less familiar shape than `<tool> install <pkg>` and the user would then have to re-install for follow-up code work.

## Test plan

- [x] Local dev server + Playwright screenshots: hero block fits one line with the secondary "(Have pip instead? `pip install` works too.)" caption; `/get-started` SDK card wraps the longer command to two lines without truncation.
- [ ] Once SDK PR #800 merges and a PyPI release ships, run the live one-liner from a clean machine to confirm the `uv tool install` path works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)