### PR TITLE
chore(legal): surface company contact in website footer

### DIFF
--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -565,6 +565,14 @@ constraints:
               <p className="text-slate-400 mb-6 max-w-xs">
                 The agent control layer. Specify. Evaluate. Optimize. Apply.
               </p>
+              <p className="text-xs text-slate-500">
+                Traigent Ltd, Hartglas 16, Tel-Aviv, Israel
+              </p>
+              <p className="mt-2 text-xs text-slate-500">
+                <a href="mailto:support@traigent.ai" className="hover:text-white transition-colors">
+                  support@traigent.ai
+                </a>
+              </p>
             </div>
 
             <div>


### PR DESCRIPTION
## Summary

- Adds Traigent Ltd registered address and support email to the public website footer.
- Keeps `main` website legal routes pointed at the portal as the canonical legal surface.

## Scope

This PR is limited to a small legal/contact footer update on `traigent-web` `main`. It intentionally excludes the research/CAIN/ICSE credibility work so that can be reviewed separately.

## Validation

- `./node_modules/.bin/vite build` — passed

## Notes

- `npm run build` was not used because this repo's prebuild script rewrites `src/version.json`.
- Targeted ESLint could not run on `main` because this checkout has no ESLint config file.
