### PR TITLE
Fix marketing portal links and SDK skill install

### DIFF
--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -4,6 +4,8 @@ import { ChevronDown, Github } from "lucide-react";
 import StartNowModal from "./StartNowModal";
 import { trackEvent } from "../lib/analytics";
 
+const PORTAL_URL = "https://portal.traigent.ai";
+
 const productItems = [
   { label: "Optimization Engine", scrollId: "optimization", desc: "Picks next best config from run history" },
   { label: "Agent Wrapper", scrollId: "product", desc: "Automated execution + KPI capture" },
@@ -101,8 +103,8 @@ export default function TopNav() {
 
   return (
     <>
-      <nav className="sticky top-0 z-50 bg-[#080808]/95 backdrop-blur-md border-b border-slate-800/50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <nav className="sticky top-0 z-50 bg-[#080808]/95 backdrop-blur-md border-b border-slate-800/50 overflow-x-clip">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8" style={{ width: "100vw" }}>
           <div className="flex items-center justify-between h-16">
             {/* Logo — click always returns to the top of the homepage. When already
                 on `/`, React Router skips the navigation, so we scroll manually. */}
@@ -123,6 +125,15 @@ export default function TopNav() {
               />
               Traigent
             </Link>
+            <a
+              href={PORTAL_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => trackEvent("portal_opened", { location: "topnav_mobile" })}
+              className="sm:hidden ml-5 text-sm text-slate-300 hover:text-white transition-colors whitespace-nowrap"
+            >
+              Portal
+            </a>
 
             {/* Tabs */}
             <div className="hidden lg:flex items-center gap-7 text-sm">
@@ -167,7 +178,7 @@ export default function TopNav() {
             </div>
 
             {/* CTAs */}
-            <div className="flex items-center gap-3 sm:gap-4">
+            <div className="hidden sm:flex items-center gap-3 sm:gap-4">
               <a
                 href="https://github.com/Traigent/Traigent"
                 target="_blank"
@@ -180,20 +191,21 @@ export default function TopNav() {
                 <Github className="w-5 h-5" />
               </a>
               <a
-                href="https://portal.traigent.ai"
+                href={PORTAL_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={() => trackEvent("sign_in_clicked", { location: "topnav" })}
-                className="text-sm text-slate-300 hover:text-white transition-colors hidden sm:inline"
+                onClick={() => trackEvent("portal_opened", { location: "topnav" })}
+                className="text-sm text-slate-300 hover:text-white transition-colors whitespace-nowrap"
               >
-                Sign in
+                <span className="sm:hidden">Portal</span>
+                <span className="hidden sm:inline">Open portal</span>
               </a>
               <button
                 onClick={() => {
                   trackEvent("start_now_clicked", { location: "topnav" });
                   setShowStartNow(true);
                 }}
-                className="border border-slate-600 hover:border-slate-400 text-slate-200 hover:text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap"
+                className="hidden sm:inline-flex border border-slate-600 hover:border-slate-400 text-slate-200 hover:text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap"
               >
                 Start Now
               </button>
@@ -202,7 +214,7 @@ export default function TopNav() {
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={() => trackEvent("demo_booking_clicked", { location: "topnav" })}
-                className="bg-[#1A6BF5] hover:bg-[#4D8EF8] text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap"
+                className="hidden sm:inline-flex bg-[#1A6BF5] hover:bg-[#4D8EF8] text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap"
               >
                 Book a demo
               </a>

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -5,6 +5,17 @@ import { Helmet } from "react-helmet-async";
 import InstallCommand from "../components/InstallCommand";
 
 const createPageUrl = (path) => path;
+const SDK_SKILL_INSTALL_COMMAND = [
+  "npx skills add Traigent/agents-skills",
+  "--skill traigent",
+  "--skill traigent-quickstart",
+  "--skill traigent-configuration-space",
+  "--skill traigent-decorator-setup",
+  "--skill traigent-run-optimization",
+  "--skill traigent-analyze-results",
+  "--skill traigent-debugging",
+  "--skill traigent-integrations",
+].join(" ");
 
 export default function GetStarted() {
   return (
@@ -79,8 +90,8 @@ export default function GetStarted() {
             Claude Code, Cursor, Codex, Gemini CLI and 30+ other agents pick up the Traigent skill bundle automatically. They&apos;ll guide you through dry-run-first setup, generate the eval dataset, and apply the best config — without you leaving your editor.
           </p>
           <InstallCommand
-            command="npx skills add Traigent/agents-skills"
-            secondary="Pick the traigent-* skills from the interactive list. The bundle includes a dry-run-first orchestrator that validates the full pipeline at zero cost before any real spend."
+            command={SDK_SKILL_INSTALL_COMMAND}
+            secondary="Installs only the user-facing Traigent SDK skills. Internal review, PR, and security tools stay out of the bundle."
           />
         </div>
 

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -24,6 +24,7 @@ const Button = ({ children, className, onClick, size }) => (
 
 // Placeholder for the createPageUrl function
 const createPageUrl = (path) => path;
+const PORTAL_URL = "https://portal.traigent.ai";
 
 // Reusable animated wrapper to reduce duplication
 const FadeInView = ({ children, className, delay = 0, direction = "y" }) => (
@@ -327,6 +328,32 @@ export default function Homepage() {
                   )}
                 </div>
               </div>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.28 }}
+              className="mb-12 flex flex-wrap justify-center gap-3"
+            >
+              <Link
+                to={createPageUrl("/get-started")}
+                onClick={() => trackEvent("hero_get_started_clicked", { destination: "get-started" })}
+                className="inline-flex items-center justify-center bg-white text-slate-950 hover:bg-slate-100 px-5 py-3 rounded-lg text-sm font-semibold transition-colors whitespace-nowrap"
+              >
+                Get started
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+              <a
+                href={PORTAL_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => trackEvent("portal_opened", { location: "hero" })}
+                className="inline-flex items-center justify-center border border-blue-400/70 text-white hover:bg-blue-500/15 px-5 py-3 rounded-lg text-sm font-semibold transition-colors whitespace-nowrap"
+              >
+                Open portal
+                <ExternalLink className="ml-2 h-4 w-4" />
+              </a>
             </motion.div>
 
             {/* Design Partners & Early Adopters */}
@@ -972,10 +999,15 @@ def answer_question(question: str) -> str:
                 </li>
                 <li>
                   <a
-                    href="https://portal.traigent.ai/pricing"
+                    href={`${PORTAL_URL}/pricing`}
                     className="text-slate-400 hover:text-white transition-colors"
                   >
                     Pricing
+                  </a>
+                </li>
+                <li>
+                  <a href={PORTAL_URL} className="text-slate-400 hover:text-white transition-colors">
+                    Open portal
                   </a>
                 </li>
               </ul>
@@ -986,7 +1018,7 @@ def answer_question(question: str) -> str:
               <ul className="space-y-2">
                 <li>
                   <a
-                    href="https://portal.traigent.ai/privacy"
+                    href={`${PORTAL_URL}/privacy`}
                     className="text-slate-400 hover:text-white transition-colors"
                   >
                     Privacy Policy
@@ -994,7 +1026,7 @@ def answer_question(question: str) -> str:
                 </li>
                 <li>
                   <a
-                    href="https://portal.traigent.ai/terms"
+                    href={`${PORTAL_URL}/terms`}
                     className="text-slate-400 hover:text-white transition-colors"
                   >
                     Terms of Service
@@ -1002,7 +1034,7 @@ def answer_question(question: str) -> str:
                 </li>
                 <li>
                   <a
-                    href="https://portal.traigent.ai/refund"
+                    href={`${PORTAL_URL}/refund`}
                     className="text-slate-400 hover:text-white transition-colors"
                   >
                     Refund Policy

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "v-Traigent/traigent-web-web_changes_Amir-2026-05-14-09:52",
+  "version": "v-Traigent/traigent-web-fix/492-marketing-portal-links-2026-05-20-13:11",
   "repo": "Traigent/traigent-web",
-  "branch": "web_changes_Amir",
-  "buildTime": "2026-05-14-09:52"
+  "branch": "fix/492-marketing-portal-links",
+  "buildTime": "2026-05-20-13:11"
 }


### PR DESCRIPTION
## Summary
- adds a visible portal link to the marketing site header, hero, and footer
- replaces raw all-skills install guidance with an explicit user-facing Traigent skill allowlist
- keeps mobile header controls compact so the portal link remains visible on narrow screens

## Verification
- npm run build
- npm audit --audit-level=moderate
- git diff --check

Note: npm run lint is currently blocked on main because the repo has no ESLint configuration file for the configured lint script.
