### PR TITLE
ship: outreach one-pager + TTM rework + blog link fixes + bundle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,14 +26,14 @@ export default function App() {
   return (
     <Routes>
       <Route path="table-demo" element={<TableDemo />} />
-      {/* Pitch decks — no layout/nav, full-bleed slides */}
+      {/* Pitch decks & outreach one-pager — no layout/nav, full-bleed slides */}
       <Route path="pitch" element={<Pitch />} />
       <Route path="pitch-full" element={<PitchFull />} />
+      <Route path="one-pager" element={<OnePager />} />
 
       <Route path="/" element={<Layout />}>
         <Route index element={<Homepage />} />
         <Route path="get-started" element={<GetStarted />} />
-        <Route path="one-pager" element={<OnePager />} />
         <Route path="value-proposition" element={<ValueProposition />} />
         <Route path="blog" element={<Blog />} />
         <Route path="blog/:slug" element={<BlogPost />} />

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -315,8 +315,11 @@ export default function TopNav() {
           aria-label="Navigation menu"
           className="lg:hidden fixed inset-0 z-[60]"
         >
-          {/* Backdrop */}
-          <div
+          {/* Backdrop — button so keyboard users can dismiss via Enter/Space
+              in addition to the Escape-to-close handler on the dialog */}
+          <button
+            type="button"
+            aria-label="Close navigation menu"
             className="absolute inset-0 bg-black/60 backdrop-blur-sm"
             onClick={closeMobile}
           />

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -1,10 +1,12 @@
-﻿import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
-import { ChevronDown, Github } from "lucide-react";
+import { ChevronDown, Github, Menu, X } from "lucide-react";
 import StartNowModal from "./StartNowModal";
 import { trackEvent } from "../lib/analytics";
 
 const PORTAL_URL = "https://portal.traigent.ai";
+const DEMO_URL = "https://meetings-eu1.hubspot.com/amir8";
+const GITHUB_URL = "https://github.com/Traigent/Traigent";
 
 const productItems = [
   { label: "Optimization Engine", scrollId: "optimization", desc: "Picks next best config from run history" },
@@ -26,6 +28,15 @@ const resourcesItems = [
   { label: "Value Proposition", href: "/value-proposition" },
   { label: "See It In Action", href: "/see-it-in-action", desc: "Watch Traigent converge live" },
   { label: "Optimization in Action", href: "/optimization-in-action", desc: "Live optimization-table demo · sweep & converge" },
+];
+
+// Main top-level tabs (between the Product and Resources dropdowns on desktop;
+// shown as a flat list in the mobile drawer). Centralized so the desktop nav
+// and mobile drawer stay in sync.
+const mainTabs = [
+  { label: "The Problem", href: "/value-proposition" },
+  { label: "Why Traigent", href: "/blog" },
+  { label: "Pricing", href: "/pricing" },
 ];
 
 function MenuItem({ item, onScroll }) {
@@ -81,9 +92,60 @@ function Dropdown({ label, items, isOpen, onOpen, onClose, onScroll }) {
   );
 }
 
+// Mobile-drawer link row. Same handling as MenuItem (external / scrollId /
+// in-app Link) but tap-friendly sized and self-closes the drawer.
+function MobileMenuItem({ item, onClose, onScroll }) {
+  const inner = (
+    <>
+      <div className="text-base text-white font-medium">{item.label}</div>
+      {item.desc && <div className="text-xs text-slate-400 mt-0.5">{item.desc}</div>}
+    </>
+  );
+  const className = "block px-3 py-3 -mx-3 rounded-lg hover:bg-slate-800 active:bg-slate-800 transition-colors";
+
+  if (item.external) {
+    return (
+      <a
+        href={item.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={onClose}
+        className={className}
+      >
+        {inner}
+      </a>
+    );
+  }
+  if (item.scrollId) {
+    return (
+      <a
+        href="#"
+        onClick={(e) => { onClose(); onScroll(item.scrollId)(e); }}
+        className={className}
+      >
+        {inner}
+      </a>
+    );
+  }
+  return (
+    <Link to={item.href} onClick={onClose} className={className}>
+      {inner}
+    </Link>
+  );
+}
+
+function MobileSectionLabel({ children }) {
+  return (
+    <div className="text-[10px] font-mono uppercase tracking-widest text-slate-500 mb-2 mt-6 first:mt-0">
+      {children}
+    </div>
+  );
+}
+
 export default function TopNav() {
   const [openMenu, setOpenMenu] = useState(null);
   const [showStartNow, setShowStartNow] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -94,6 +156,7 @@ export default function TopNav() {
   const scrollOrNavigate = (id) => (e) => {
     e.preventDefault();
     setOpenMenu(null);
+    setMobileOpen(false);
     if (location.pathname === "/") {
       document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "start" });
     } else {
@@ -101,6 +164,29 @@ export default function TopNav() {
       navigate("/");
     }
   };
+
+  // Lock background scroll while the mobile drawer is open, and close on
+  // Escape so it follows standard modal a11y conventions.
+  useEffect(() => {
+    if (!mobileOpen) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const onKey = (e) => { if (e.key === "Escape") setMobileOpen(false); };
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [mobileOpen]);
+
+  // Close the drawer whenever the route changes (e.g. a Link inside the
+  // drawer fires; the drawer's own onClick already toggles it but this
+  // is a safety net for any indirect navigations).
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [location.pathname]);
+
+  const closeMobile = () => setMobileOpen(false);
 
   return (
     <>
@@ -126,17 +212,8 @@ export default function TopNav() {
               />
               Traigent
             </Link>
-            <a
-              href={PORTAL_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => trackEvent("portal_opened", { location: "topnav_mobile" })}
-              className="sm:hidden ml-5 text-sm text-slate-300 hover:text-white transition-colors whitespace-nowrap"
-            >
-              Portal
-            </a>
 
-            {/* Tabs */}
+            {/* Desktop tabs */}
             <div className="hidden lg:flex items-center gap-7 text-sm">
               <Dropdown
                 label="Product"
@@ -146,21 +223,15 @@ export default function TopNav() {
                 onClose={() => setOpenMenu(null)}
                 onScroll={scrollOrNavigate}
               />
-              <Link to="/value-proposition" className="text-slate-300 hover:text-white transition-colors">
-                The Problem
-              </Link>
-              <Link
-                to="/blog"
-                className="text-slate-300 hover:text-white transition-colors"
-              >
-                Why Traigent
-              </Link>
-              <Link
-                to="/pricing"
-                className="text-slate-300 hover:text-white transition-colors"
-              >
-                Pricing
-              </Link>
+              {mainTabs.map((t) => (
+                <Link
+                  key={t.label}
+                  to={t.href}
+                  className="text-slate-300 hover:text-white transition-colors"
+                >
+                  {t.label}
+                </Link>
+              ))}
               <Dropdown
                 label="Resources"
                 items={resourcesItems}
@@ -178,14 +249,14 @@ export default function TopNav() {
               </a>
             </div>
 
-            {/* CTAs */}
-            <div className="hidden sm:flex items-center gap-3 sm:gap-4">
+            {/* Desktop CTAs */}
+            <div className="hidden lg:flex items-center gap-3 sm:gap-4">
               <a
-                href="https://github.com/Traigent/Traigent"
+                href={GITHUB_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={() => trackEvent("github_clicked", { location: "topnav" })}
-                className="text-slate-400 hover:text-white transition-colors hidden sm:flex"
+                className="text-slate-400 hover:text-white transition-colors"
                 title="GitHub"
                 aria-label="GitHub"
               >
@@ -198,31 +269,162 @@ export default function TopNav() {
                 onClick={() => trackEvent("portal_opened", { location: "topnav" })}
                 className="text-sm text-slate-300 hover:text-white transition-colors whitespace-nowrap"
               >
-                <span className="sm:hidden">Portal</span>
-                <span className="hidden sm:inline">Open portal</span>
+                Open portal
               </a>
               <button
                 onClick={() => {
                   trackEvent("start_now_clicked", { location: "topnav" });
                   setShowStartNow(true);
                 }}
-                className="hidden sm:inline-flex border border-slate-600 hover:border-slate-400 text-slate-200 hover:text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap"
+                className="border border-slate-600 hover:border-slate-400 text-slate-200 hover:text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap"
               >
                 Start Now
               </button>
               <a
-                href="https://meetings-eu1.hubspot.com/amir8"
+                href={DEMO_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={() => trackEvent("demo_booking_clicked", { location: "topnav" })}
-                className="hidden sm:inline-flex bg-[#1A6BF5] hover:bg-[#4D8EF8] text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap"
+                className="bg-[#1A6BF5] hover:bg-[#4D8EF8] text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap"
               >
                 Book a demo
               </a>
             </div>
+
+            {/* Mobile: hamburger only. Drawer below carries all the nav. */}
+            <button
+              type="button"
+              onClick={() => setMobileOpen(true)}
+              aria-label="Open navigation menu"
+              aria-expanded={mobileOpen}
+              aria-controls="mobile-nav-drawer"
+              className="lg:hidden inline-flex items-center justify-center p-2 -mr-2 rounded-lg text-slate-300 hover:text-white hover:bg-slate-800 transition-colors"
+            >
+              <Menu className="w-6 h-6" />
+            </button>
           </div>
         </div>
       </nav>
+
+      {/* Mobile drawer */}
+      {mobileOpen && (
+        <div
+          id="mobile-nav-drawer"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Navigation menu"
+          className="lg:hidden fixed inset-0 z-[60]"
+        >
+          {/* Backdrop */}
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={closeMobile}
+          />
+          {/* Panel */}
+          <div className="absolute inset-y-0 right-0 w-full max-w-sm bg-[#080808] border-l border-slate-800 shadow-2xl flex flex-col">
+            {/* Header */}
+            <div className="flex items-center justify-between h-16 px-4 sm:px-6 border-b border-slate-800 flex-shrink-0">
+              <Link
+                to="/"
+                onClick={closeMobile}
+                className="flex items-center text-lg font-bold text-white leading-none"
+              >
+                <img
+                  src="/images/traigent-logo-icon.png"
+                  alt=""
+                  aria-hidden="true"
+                  className="h-5 w-auto mr-2"
+                />
+                Traigent
+              </Link>
+              <button
+                type="button"
+                onClick={closeMobile}
+                aria-label="Close navigation menu"
+                className="p-2 -mr-2 rounded-lg text-slate-300 hover:text-white hover:bg-slate-800 transition-colors"
+              >
+                <X className="w-6 h-6" />
+              </button>
+            </div>
+
+            {/* Scrollable nav body */}
+            <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-6">
+              <MobileSectionLabel>Product</MobileSectionLabel>
+              {productItems.map((item) => (
+                <MobileMenuItem key={item.label} item={item} onClose={closeMobile} onScroll={scrollOrNavigate} />
+              ))}
+
+              <MobileSectionLabel>Main</MobileSectionLabel>
+              {mainTabs.map((t) => (
+                <Link
+                  key={t.label}
+                  to={t.href}
+                  onClick={closeMobile}
+                  className="block px-3 py-3 -mx-3 rounded-lg hover:bg-slate-800 active:bg-slate-800 transition-colors text-base text-white font-medium"
+                >
+                  {t.label}
+                </Link>
+              ))}
+              <a
+                href="#"
+                onClick={scrollOrNavigate("contact")}
+                className="block px-3 py-3 -mx-3 rounded-lg hover:bg-slate-800 active:bg-slate-800 transition-colors text-base text-white font-medium cursor-pointer"
+              >
+                Contact Us
+              </a>
+
+              <MobileSectionLabel>Resources</MobileSectionLabel>
+              {resourcesItems.map((item) => (
+                <MobileMenuItem key={item.label} item={item} onClose={closeMobile} onScroll={scrollOrNavigate} />
+              ))}
+            </div>
+
+            {/* CTAs pinned to the bottom */}
+            <div className="border-t border-slate-800 px-4 sm:px-6 py-4 flex flex-col gap-2 flex-shrink-0">
+              <a
+                href={PORTAL_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => { trackEvent("portal_opened", { location: "topnav_mobile" }); closeMobile(); }}
+                className="text-center text-sm text-slate-300 hover:text-white py-2 transition-colors"
+              >
+                Open portal
+              </a>
+              <button
+                type="button"
+                onClick={() => {
+                  trackEvent("start_now_clicked", { location: "topnav_mobile" });
+                  setShowStartNow(true);
+                  closeMobile();
+                }}
+                className="border border-slate-600 hover:border-slate-400 text-slate-200 hover:text-white py-3 rounded-lg text-sm font-medium transition-colors"
+              >
+                Start Now
+              </button>
+              <a
+                href={DEMO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => { trackEvent("demo_booking_clicked", { location: "topnav_mobile" }); closeMobile(); }}
+                className="bg-[#1A6BF5] hover:bg-[#4D8EF8] text-white py-3 rounded-lg text-sm font-medium text-center transition-colors"
+              >
+                Book a demo
+              </a>
+              <a
+                href={GITHUB_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => { trackEvent("github_clicked", { location: "topnav_mobile" }); closeMobile(); }}
+                className="inline-flex items-center justify-center gap-2 text-xs text-slate-500 hover:text-white pt-2 transition-colors"
+              >
+                <Github className="w-4 h-4" />
+                <span>View on GitHub</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+
       {showStartNow && <StartNowModal onClose={() => setShowStartNow(false)} />}
     </>
   );

--- a/src/content/blog/the-business-case.md
+++ b/src/content/blog/the-business-case.md
@@ -7,7 +7,7 @@ author: "Amir Barnea"
 readingTime: "9 min read"
 tags: "business-case,roi,optimization,cost"
 featured: true
-order: 1
+order: 2
 ---
 
 **See it on your numbers:** [ROI Calculator →](/roi) · [TTM Calculator →](/ttm)

--- a/src/content/blog/the-config-multiverse.md
+++ b/src/content/blog/the-config-multiverse.md
@@ -2,9 +2,9 @@
 title: "The Configuration Multiverse: A Directory of Every Knob in Every Major Model — and Why Skeptics Are Still Wrong"
 slug: "the-config-multiverse"
 date: "2026-05-24"
-summary: "Every chat or reasoning model exposes a dozen knobs, your agent layer adds half a dozen more, and each knob has a handful of reasonable values. The product is millions of valid configurations — and the 'temperature doesn't matter' skeptic isn't wrong about temperature alone. They're wrong about the math."
+summary: "Every agent has two layers of configuration: the knobs you build on top (agent-level) and the knobs the model exposes (model-level). Agent-level dominates. Model-level is more numerous. Together they cross-multiply into millions of combinations — and the 'temperature doesn't matter' skeptic isn't wrong about temperature alone. They're wrong about the math."
 author: "Amir Barnea"
-readingTime: "12 min read"
+readingTime: "13 min read"
 tags: "optimization,configuration,models,benchmarks,reasoning"
 order: 7
 ---
@@ -21,163 +21,192 @@ order: 7
 
 You've heard a version of this in every Slack channel that ships AI agents. It's not a stupid take. Any *one* of the knobs the major providers expose, taken in isolation, on a typical benchmark, will usually move a single metric by a handful of percentage points at most. Sometimes less.
 
-The trap is the word "isolation." You don't ship one knob. You ship *all* of them, at once, against a real workload, and the values you didn't think about get picked by your SDK's defaults — which were chosen by someone who has no idea what your agent does.
+The trap is the word "isolation." You don't ship one knob. You ship *all* of them, at once, against a real workload — and the values you didn't think about get picked by your SDK's defaults, which were chosen by someone who has no idea what your agent does.
 
-This post is two things at once. The first half is a directory: every model knob the major providers expose, the valid range or value set, and a qualitative tag for how much it can move accuracy (**A**), cost (**C**), and latency (**L**). The second half is the math that makes the skeptic's argument collapse — even when each individual claim about each individual knob is correct.
+This post is two things at once. The article makes the qualitative and quantitative argument. The tables — seven of them, sorted by impact — are the reference directory you can come back to when you're tuning a specific stack.
 
-## How to read the tables
+## The two tiers, in order of importance
+
+Every agent has two distinct layers of configuration, and they're not equal.
+
+**Agent-level knobs** are the ones *you* design when you build the agent: system prompt structure, few-shot examples, retrieval `top_k`, embedding model, reranker, memory window, retry policy, tool selection, caching. They live in your code, not in the model's API. They are mostly invisible to the model provider's docs.
+
+**Model-level knobs** are the ones the provider exposes: temperature, top_p, max_tokens, response_format, tool_choice, reasoning_effort, thinking_budget. They live in the request body. The provider's docs enumerate them; their defaults are picked for the median customer, who is not you.
+
+**Agent-level knobs dominate model-level knobs in impact, by a wide margin.**
+
+This sounds counter-intuitive — the model is the expensive part, the model has the cool brand names, the model is where the press releases live. But every working production agent we've seen says the same thing: changing the system prompt structure, the few-shot count, or the retrieval `top_k` reliably swings accuracy 10–30 percentage points on the same eval. Changing temperature on the same agent rarely moves it more than 3–5. The model layer is the engine. The agent layer is the chassis, the transmission, the route, and the driver. The engine matters; everything else matters more, in aggregate.
+
+Why the agent layer dominates:
+
+1. **Agent-level knobs are workload-specific.** Your retrieval index, your tool catalog, your prompt template — these were built for *your* task. The provider's temperature default was built for everyone's task. Workload-specific decisions are where the leverage is.
+2. **Agent-level knobs change the model's *input*.** Model-level knobs change how the model decodes a *given* input. Changing the input is almost always more powerful than re-decoding the same input differently.
+3. **Agent-level knobs interact with the model's strengths and weaknesses.** A good system prompt on a mediocre model often beats a mediocre system prompt on a flagship model — and costs a third as much.
+
+So the article proceeds in order of importance: agent-level first (Table 1), then the model-level tier that's universal across providers (Table 2), then the per-provider model-level knobs (Tables 3–7). The math at the end multiplies everything together.
+
+### How to read the tables
 
 For each knob you'll see three impact tags:
 
-- **L (Low)** — typical effect of changing this one knob, holding everything else fixed, is under ~3 percentage points on the relevant metric for most workloads.
-- **M (Medium)** — typical effect is 3–15 percentage points. Big enough that you'd notice if you A/B-tested it. Small enough that nobody fights about it.
-- **H (High)** — typical effect can exceed 15 percentage points, sometimes substantially. Order-of-magnitude swings on certain workloads.
+- **L (Low)** — typical isolated effect under ~3 percentage points on the relevant metric for most workloads.
+- **M (Medium)** — typical isolated effect 3–15 percentage points. Big enough to notice on an A/B test.
+- **H (High)** — typical isolated effect can exceed 15 percentage points. Order-of-magnitude swings on specific workloads are routine.
 
-A few rules of thumb before you read the tables:
+A few rules before the tables:
 
-1. **No global percentages.** Anyone who tells you "temperature shifts accuracy by 4.2%" without naming a benchmark and a workload is selling you something. Temperature can move accuracy 0% on a deterministic classification task and 25% on a creative-writing eval. The L/M/H tags below are *typical ranges across the kinds of agent workloads we see in production* — not promises for your specific use case.
-2. **The skeptic is right about each knob, individually.** Most knobs are L or M in isolation. The point of this directory is what happens when you multiply.
-3. **A, C, and L impact are independent.** A knob can be L for accuracy but H for cost (e.g., `max_tokens`), and that asymmetry is itself a configuration decision worth optimizing.
-4. **Newer model families introduce new knob classes.** Reasoning models added a whole tier (`reasoning_effort`, `thinking_budget`) that didn't exist three years ago. The dimension count keeps climbing — your config grid doesn't shrink with time, it grows.
-
-Let's start with the universal tier and work outward.
+- **No global percentages.** Anyone who quotes "temperature shifts accuracy by 4.2%" without naming a benchmark and a workload is selling something. The L/M/H tags are *typical ranges across the kinds of agent workloads we see* — not promises for your specific use case.
+- **A, C, and L are independent dimensions.** A knob can be L on accuracy and H on cost (e.g., `max_tokens`), and that asymmetry is itself a configuration decision.
+- **Tables are sorted by impact within each tier.** Knobs at the top affect multiple dimensions (accuracy *and* cost, or accuracy *and* latency). Knobs at the bottom typically affect only one dimension — often accuracy alone, which makes them important when you have the budget to optimize but easy to deprioritize when you don't.
 
 ---
 
-## Tier 1: Knobs nearly every chat model exposes
+## Layer 1 — Agent-level knobs (the dominant tier)
 
-If you've used any chat completion API in the last five years, you've seen most of these. Defaults vary wildly between SDKs.
+This is where most of the variance in your agent's behavior lives. Three concrete examples before the table.
+
+**System prompt structure.** Same model, same task, two different system prompts. We routinely see 20+ point accuracy swings between a 3-line "you are a helpful assistant" template and a structured 200-line system with role definition, examples, hard constraints, and output schema. On Claude specifically, the *format* of the system prompt (XML tags vs prose vs markdown) is itself a knob that can swing accuracy further. This is rarely treated as a hyperparameter, but it should be.
+
+**Few-shot count.** Going from 0 to 4 well-chosen examples typically delivers more accuracy than swapping `gpt-4o-mini` for `gpt-4o` on the same task — at a fraction of the per-call cost increase. The optimum is workload-specific (too many examples and you blow context budget or trigger "lost in the middle" effects) and almost nobody finds it by intuition. **Table 1** shows the rest of the agent-level tier.
+
+**Retrieval `top_k` and chunk size.** In any agent with a RAG component, the retrieval parameters dominate the downstream model parameters. Doubling `top_k` from 5 to 10 commonly shifts accuracy 5–15 points on QA tasks — comparable to a model-tier upgrade, at a marginal cost. Halving chunk size from 800 to 400 tokens often improves retrieval precision but doubles index size and latency. These are the knobs nobody at the LLM provider can tune for you.
+
+What follows is the full agent-level table. Note that the last three rows (embedding model, few-shot selection method, few-shot ordering) are listed last *not because they're unimportant* — they all can swing accuracy heavily — but because their effect is concentrated on the accuracy axis with no direct cost or latency impact. They're the items easiest to overlook in a quarterly review focused on the bill.
+
+### Table 1 — Agent-level knobs
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
-| `temperature` | 0 to 2 (most sane in 0–1) | M | none | none | Controls sampling determinism. Bigger effect on free-form generation than on classification. Reasoning models tolerate it less. |
-| `top_p` (nucleus sampling) | 0 to 1 | L–M | none | none | Often substitutes for temperature; varying both at once is usually redundant. |
-| `top_k` | 1 to vocab size | L | none | none | Hard cap on candidate tokens. Most providers default it sensibly; rarely worth tuning. |
-| `max_tokens` / `max_output_tokens` | 1 to model max | L (truncation only) | **H** | **H** | The single biggest cost knob. Halving the cap can halve the bill — and sometimes the answer along with it. |
-| `stop` / `stop_sequences` | array of strings | L–M | L | L | Can dramatically change streaming behavior and parsing reliability. Often the difference between "JSON parses" and "doesn't." |
-| `seed` (where supported) | integer | 0 *on average* | none | none | Determinism, not quality. Critical for reproducible evals — irrelevant for users. |
+| Few-shot example count | 0 to N | **H** | **M–H** | **M–H** | More examples raise accuracy until they overflow attention. The optimum is workload-specific. Token cost compounds quickly. |
+| Caching layer (semantic / exact) | TTL settings | M (consistency) | **H** (savings) | **H** | Same-cache-key hits are essentially free. The single biggest cost optimization on a high-traffic agent. |
+| RAG `top_k` (retrieved chunks) | 1 to ~100 | **H** | **M–H** | M | More chunks → more context → more accuracy, until precision collapses and cost balloons. |
+| Memory window | turns or tokens | **H** | **M–H** | M | Trade context cost for conversational accuracy. Critical for multi-turn agents. |
+| System prompt template | variants | **H** | M (token count) | M | The single most under-optimized dimension in production agents. |
+| RAG chunk size | 100 to 2000 tokens | **H** | M | M | The biggest knob inside your retrieval pipeline. |
+| Fallback model | other model | **H** (failure mode) | M | M | What you fall back to when the primary refuses, errors, or times out. |
+| Reranker | none / cross-encoder / LLM-as-ranker | M–H | M | M | Cheap accuracy bump, especially when `top_k` is generous. |
+| Confidence threshold | 0 to 1 | M–H | M | M | When to ask a human, when to retry, when to fall back. |
+| Tool selection strategy | greedy / heuristic / learned | M–H | M | M | How the agent decides *which* tool to consider when many are exposed. |
+| Retry policy | none / fixed / exponential / on-schema-failure | M | L–M | M | Big effect on robustness; sneaks into your cost surface. |
+| RAG chunk overlap | 0 to chunk size | M | M | L | Mitigates boundary loss between chunks. |
+| Embedding model | various | **H** (retrieval) | L | L | Different embeddings → different retrieval results → different downstream accuracy. Pure-accuracy knob. |
+| Few-shot selection method | random / semantic-similar / hard-coded / diverse | **H** | none | none | Free upgrade for retrieval-augmented few-shotting. Pure-accuracy knob. |
+| Few-shot ordering | first, last, random | M | none | none | "Lost in the middle" is real: position matters. Pure-accuracy knob. |
+
+Fifteen knobs, ~4 reasonable values each. That alone is on the order of 10⁹ combinations *before* you touch the model layer.
+
+---
+
+## Layer 2 — Model-level knobs (the long tail)
+
+Smaller per-knob, but more numerous, and they compound. Five tables: one for the knobs nearly every model exposes (the universal tier), then one per major provider family.
+
+### The universal tier
+
+Every chat model exposes most of these. Defaults vary wildly between SDKs and you've probably never thought about most of them.
+
+The two top entries — `n` / `candidate_count` (best-of-n) and `max_tokens` — are special: both are H on cost and latency. They're the model-level knobs most directly tied to your bill and your p99 latency. Everything below the line is mostly an accuracy/determinism trade. **Table 2.**
+
+### Table 2 — Universal tier (chat models, all providers)
+
+| Knob | Range / values | A | C | L | Why it matters |
+|---|---|---|---|---|---|
 | `n` / `candidate_count` | integer ≥ 1 | M | **H** | **H** | Best-of-n sampling. Real accuracy gains, brutal cost multiplier. |
+| `max_tokens` / `max_output_tokens` | 1 to model max | L (truncation only) | **H** | **H** | The single biggest cost knob. Halving the cap can halve the bill — sometimes the answer along with it. |
+| `stop` / `stop_sequences` | array of strings | L–M | L | L | Can dramatically change streaming behavior and parsing reliability. |
+| `temperature` | 0 to 2 (most sane in 0–1) | M | none | none | Controls sampling determinism. Pure-accuracy knob in isolation. |
+| `top_p` (nucleus sampling) | 0 to 1 | L–M | none | none | Often substitutes for temperature; varying both at once is usually redundant. |
+| `top_k` | 1 to vocab size | L | none | none | Hard cap on candidate tokens. Most providers default it sensibly. |
+| `seed` (where supported) | integer | 0 *on average* | none | none | Determinism, not quality. Critical for reproducible evals — irrelevant for users. |
 
-Already, before any provider-specific knobs, you have 7 dimensions × maybe 5 reasonable values each = **~78,000 configurations**. And we've barely started.
+### OpenAI
 
----
+OpenAI now ships two distinct families with different knob surfaces. Worth treating them separately because the *reasoning* family has knobs that frequently dwarf everything else in this entire directory.
 
-## OpenAI
+For the **chat family** (GPT-4o, GPT-4o-mini, GPT-3.5-turbo), the qualitative point is: `tool_choice` and `parallel_tool_calls` are the action-shaping knobs that change the agent's *behavior class*, not just its decoding. Forcing `tool_choice: required` versus `auto` is the difference between a deterministic pipeline and an open-ended agent. Disabling `parallel_tool_calls` serializes a plan that would otherwise run concurrently, which can double end-to-end latency on multi-tool agents. **Table 3.**
 
-OpenAI now ships two distinct families, with different knob surfaces. Worth treating them separately.
+For the **reasoning family** (o1, o3, o3-mini, o3-pro, o4-mini, GPT-5, GPT-5-mini, GPT-5-nano), one knob — `reasoning_effort` — typically swamps every other model-level knob. Moving from `low` to `high` on a hard math or code benchmark can double accuracy and 10× the bill. There is no other model-level decision in this whole post with that kind of leverage. **Table 4.**
 
-### Chat / completion models (GPT-4o, GPT-4o-mini, GPT-4-turbo, GPT-3.5-turbo)
+### Table 3 — OpenAI chat models
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
-| `presence_penalty` | -2 to 2 | L | none | none | Pushes the model toward (or away from) novel tokens. Subtle effect on most chat tasks. |
-| `frequency_penalty` | -2 to 2 | L | none | none | Suppresses repetition. Bigger effect on long outputs. |
-| `response_format` | `{type: "text" \| "json_object" \| "json_schema"}` | **M–H** (on JSON tasks) | L | L | Schema-enforced JSON dramatically reduces parsing-failure cost on extraction agents. |
 | `tool_choice` | `"auto"`, `"none"`, `"required"`, `{specific}` | **H** | M | M | Forcing a specific tool changes the agent's behavior class — not just a tweak. |
 | `parallel_tool_calls` | bool | M | M | **M–H** (sequential blocks) | Off forces serial reasoning; can double latency on multi-tool plans. |
-| `logprobs` / `top_logprobs` | bool, integer | none | L | L (overhead) | Critical for self-consistency / confidence routing; otherwise noise. |
 | `service_tier` (where available) | `"auto"` / `"default"` / `"flex"` | L (if any) | M | M | Trades cost for predictable latency. |
+| `response_format` | `{type: "text" \| "json_object" \| "json_schema"}` | **M–H** (on JSON tasks) | L | L | Schema-enforced JSON dramatically reduces parsing-failure cost on extraction agents. |
+| `logprobs` / `top_logprobs` | bool, integer | none | L | L (overhead) | Critical for self-consistency / confidence routing; otherwise noise. |
+| `presence_penalty` | -2 to 2 | L | none | none | Pushes the model toward (or away from) novel tokens. Subtle on most chat tasks. Pure-accuracy knob. |
+| `frequency_penalty` | -2 to 2 | L | none | none | Suppresses repetition. Bigger effect on long outputs. Pure-accuracy knob. |
 
-### Reasoning models (o1, o3, o3-mini, o3-pro, o4-mini, GPT-5, GPT-5-mini, GPT-5-nano)
-
-A new tier of knobs that don't exist on chat models. These often *dominate* everything else.
+### Table 4 — OpenAI reasoning models (o-series, GPT-5)
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
-| `reasoning_effort` | `"minimal"`, `"low"`, `"medium"`, `"high"` | **H** | **H** | **H** | The biggest knob in the OpenAI catalog right now. `high` can double an o-series model's accuracy on hard tasks — and 10× its bill. |
-| `verbosity` (GPT-5 family) | `"low"`, `"medium"`, `"high"` | M | M | M | Affects how much the model says, independent of how much it thinks. |
+| `reasoning_effort` | `"minimal"`, `"low"`, `"medium"`, `"high"` | **H** | **H** | **H** | The biggest knob in the OpenAI catalog. `high` can double accuracy on hard tasks — and 10× the bill. |
 | `max_completion_tokens` (replaces `max_tokens`) | 1 to model max | L | **H** | **H** | Reasoning tokens count against this budget. Underestimating clips the answer. |
-| `reasoning.summary` (where available) | `"auto"`, `"detailed"`, `null` | L | L | M | Whether to expose a reasoning summary. Affects payload size and parsing. |
-| `store` | bool | none | L (long term) | none | Whether responses persist for evals. No runtime impact, but matters for your eval pipeline. |
+| `verbosity` (GPT-5 family) | `"low"`, `"medium"`, `"high"` | M | M | M | Affects how much the model says, independent of how much it thinks. |
+| `reasoning.summary` | `"auto"`, `"detailed"`, `null` | L | L | M | Whether to expose a reasoning summary. Affects payload size and parsing. |
+| `store` | bool | none | L (long term) | none | Whether responses persist for evals. Indirect knob. |
 
-OpenAI alone: **~12 reasonable knobs × ~4–5 values each** ≈ 4M+ combinations before agent-level configuration.
+### Anthropic
 
----
+The Claude family (3.5, 3.7, 4, 4.5 — Haiku, Sonnet, Opus) is unique in two ways. First, the `system` field is far more load-bearing than on most providers — its structure and length consistently swing accuracy more than temperature does. Second, the extended-thinking knob on 3.7+ and Sonnet 4.5 has the same kind of dominance as OpenAI's `reasoning_effort`: large accuracy gains for proportionally larger cost. **Table 5.**
 
-## Anthropic (Claude 3.5 / 3.7 / 4 / 4.5 — Haiku, Sonnet, Opus)
+### Table 5 — Anthropic (Claude family)
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
-| `temperature` | 0 to 1 | M | none | none | Same role as OpenAI's. Reasoning Claude tolerates it less. |
-| `top_p` | 0 to 1 | L–M | none | none | |
-| `top_k` | integer ≥ 1 | L | none | none | |
-| `max_tokens` | 1 to model max | L | **H** | **H** | Required parameter on Claude — there is no "model default." |
-| `system` | string | **H** | M | M | The system prompt is far more load-bearing on Claude than on most providers; longer, more structured systems consistently outperform terse ones on agent tasks. |
-| `stop_sequences` | array | L–M | L | L | |
+| `thinking` (extended thinking — 3.7, 4, 4.5) | `{type: "enabled", budget_tokens: 1024+}` | **H** | **H** | **H** | Budget can range from 1K to many tens of thousands of tokens. Same family as OpenAI's reasoning_effort. |
+| `system` | string | **H** | M | M | The system prompt is far more load-bearing on Claude than on most providers. |
 | `tools` | array of definitions | **H** | M | M | Tool count + descriptions strongly bias which path the model takes. |
 | `tool_choice` | `"auto"`, `"any"`, `"tool"`, `"none"` | **H** | M | M | |
+| `max_tokens` | 1 to model max | L | **H** | **H** | Required parameter on Claude — there is no "model default." |
 | `disable_parallel_tool_use` | bool | M | M | **M–H** | Same shape as OpenAI's `parallel_tool_calls=false`. |
-| `thinking` (extended thinking — 3.7, 4, 4.5) | `{type: "enabled", budget_tokens: 1024+}` | **H** | **H** | **H** | Same family as OpenAI's reasoning_effort. Budget can range from 1K to many tens of thousands of tokens. |
+| `stop_sequences` | array | L–M | L | L | |
+| `temperature` | 0 to 1 | M | none | none | Same role as OpenAI's. Reasoning Claude tolerates it less. Pure-accuracy knob. |
+| `top_p` | 0 to 1 | L–M | none | none | Pure-accuracy knob. |
+| `top_k` | integer ≥ 1 | L | none | none | Pure-accuracy knob. |
 | `metadata.user_id` | string | none | none | none | Compliance/abuse routing. Not a quality knob. |
 
-Anthropic adds the system-prompt knob category, which is interesting: on Claude, the *structure* of the system prompt (XML tags, ordered sections, explicit role definition) reliably swings accuracy more than temperature does. There is no single value to put in a table — but if you treat "system prompt template" as a knob with, say, 5 candidate variants, you've added another 5× to your search space.
+### Google Gemini
 
----
+Gemini (1.5 / 2.0 / 2.5 — Pro / Flash / Flash-Lite) deserves a callout for two specific knobs that are easy to miss: `cached_content` and `thinking_config`. Context caching is a real cost knob — if your agent ships a long, mostly-static system prompt and/or tool catalog, *not* caching can leave 30–50% savings on the table. `thinking_config` is the 2.5 family's reasoning toggle, same dominance pattern as OpenAI's and Anthropic's. **Table 6.**
 
-## Google (Gemini 1.5 / 2.0 / 2.5 — Pro / Flash / Flash-Lite)
+### Table 6 — Google Gemini
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
-| `temperature` | 0 to 2 | M | none | none | |
-| `top_p` | 0 to 1 | L–M | none | none | |
-| `top_k` | integer | L | none | none | |
-| `max_output_tokens` | 1 to model max | L | **H** | **H** | |
+| `thinking_config` / `thinking_budget` (2.5) | integer tokens (0 disables) | **H** | **H** | **H** | Same family as reasoning_effort / thinking on the other providers. |
 | `candidate_count` | integer ≥ 1 | M | **H** | **H** | Best-of-n. |
+| `max_output_tokens` | 1 to model max | L | **H** | **H** | |
+| `cached_content` | string handle | M (consistency) | **H** (savings) | M | Context caching can dramatically cut cost for long-context agents. |
 | `response_mime_type` | `"text/plain"`, `"application/json"` | **M–H** (JSON tasks) | L | L | |
 | `response_schema` | OpenAPI-flavor JSON schema | M | L | L | Structured output enforcement. Massively reduces parsing failure on extraction tasks. |
-| `thinking_config` / `thinking_budget` (2.5) | integer tokens (0 disables) | **H** | **H** | **H** | Same family as reasoning_effort / thinking on the other providers. |
+| `temperature` | 0 to 2 | M | none | none | Pure-accuracy knob. |
+| `top_p` | 0 to 1 | L–M | none | none | Pure-accuracy knob. |
+| `top_k` | integer | L | none | none | Pure-accuracy knob. |
 | `safety_settings` | array of {category, threshold} | L (rejection rate) | none | none | Affects how often the model refuses, not how well it answers. |
-| `cached_content` | string handle | M (consistency) | **H** (savings) | M | Context caching can dramatically cut cost for long-context agents. A real knob, not just an optimization. |
 
-Gemini's `cached_content` deserves its own callout. If your agent ships a long, mostly-static system prompt and/or tool catalog, *not* caching is leaving real money on the table — sometimes 50%+ savings on inference, with measurable latency improvement on cache hits.
+### Open-source (Llama / Mistral / Qwen / DeepSeek via vLLM / TGI / llama.cpp / Ollama)
 
----
+Open-source servers expose a *much* larger surface than the closed providers — because nothing is hidden behind a SaaS façade. The headline knob now is the explicit reasoning toggle on newer families (Qwen 3, DeepSeek R1). Quantization and speculative decoding aren't runtime knobs in the strict sense — they're deploy-time configuration — but they dominate cost and latency to a degree that's worth listing alongside the sampling knobs. The biggest *silent* accuracy killer on this list is `prompt_format`: using the wrong chat template for a model (Llama instruct vs Mistral instruct vs ChatML) commonly costs 10–30 points on benchmarks before you realize what's wrong. **Table 7.**
 
-## Open-source models served via vLLM / TGI / llama.cpp / Ollama (Llama / Mistral / Qwen / DeepSeek / Yi)
-
-You inherit all the Tier 1 knobs, plus a set the closed providers don't expose:
+### Table 7 — Open-source model serving stacks
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
-| `min_p` | 0 to 1 | L–M | none | none | Newer sampling method; some teams prefer over top_p/top_k. |
-| `repetition_penalty` | ~0.5 to 2 | L–M | none | none | Independent of presence/frequency penalty. |
-| `typical_p` | 0 to 1 | L | none | none | Locally typical sampling. Rarely worth tuning. |
-| `mirostat_mode` / `mirostat_eta` / `mirostat_tau` | mode 0/1/2, floats | M | none | none | Adaptive sampling. llama.cpp / text-generation-webui only. |
-| `repeat_last_n` | integer | L | none | none | How far back the repetition penalty looks. |
-| `enable_thinking` (Qwen 3, DeepSeek R1, others) | bool | **H** | **H** | **H** | Newer open models have a reasoning toggle similar to OpenAI/Anthropic. |
-| Quantization (server-side) | fp16, fp8, int8, int4, awq, gptq, etc. | L–M | **H** (compute) | M | Not a runtime knob, but a deploy-time configuration that dominates cost. |
-| Speculative decoding draft model | model name | none | L | **M–H** | Speed without accuracy loss, *if* the draft model agrees often enough. |
+| `enable_thinking` (Qwen 3, DeepSeek R1, others) | bool | **H** | **H** | **H** | Reasoning toggle on newer open models. |
+| Quantization (server-side) | fp16, fp8, int8, int4, awq, gptq, etc. | L–M | **H** (compute) | M | Deploy-time configuration that dominates cost. |
 | `n_ctx` allocation | tokens | L (if you have enough) | M (VRAM) | M | Bigger context allocation costs memory and can slow attention. |
-| Sampler order | list (e.g. `["top_k", "tfs", "typical_p", "top_p", "min_p", "temp"]`) | L–M | none | none | llama.cpp-style fine control. |
-| `prompt_format` template | provider-specific | **H** | none | none | Using the wrong chat template (Llama instruct vs Mistral instruct vs ChatML) is a silent accuracy killer. |
-
-The open-source surface area is *much* larger than the closed providers — because nothing is hidden behind a SaaS facade. That's a strength and a liability.
-
----
-
-## Agent-level knobs (these often dwarf the model-level ones)
-
-Everything above is what the model exposes. But the agent layer you build on top of it adds its own dimensions, and in our experience these are often where *most* of the accuracy and cost variance hides.
-
-| Knob | Range / values | A | C | L | Why it matters |
-|---|---|---|---|---|---|
-| System prompt template | variants | **H** | M (token count) | M | The single most under-optimized dimension in production agents. Same model, different system prompt, 20+ point swings on the same eval. |
-| Few-shot example count | 0 to N | **H** | **M–H** (token cost) | **M–H** | More examples raise accuracy until they overflow attention. The optimum is workload-specific. |
-| Few-shot selection method | random / semantic-similar / hard-coded / diverse | **H** | none | none | Free upgrade for retrieval-augmented few-shotting. |
-| Few-shot ordering | first, last, random | M | none | none | "Lost in the middle" is real: position matters. |
-| RAG `top_k` (retrieved chunks) | 1 to ~100 | **H** | **M–H** | M | More chunks → more context → more accuracy, until precision collapses. |
-| RAG chunk size | 100 to 2000 tokens | **H** | M | M | The biggest knob in your retrieval pipeline. |
-| RAG chunk overlap | 0 to chunk size | M | M | L | Mitigates boundary loss. |
-| Embedding model | various | **H** (retrieval) | L | L | Different embeddings = different retrieval results = different downstream accuracy. |
-| Reranker | none / cross-encoder / LLM-as-ranker | M–H | M | M | Cheap accuracy bump, especially when `top_k` is generous. |
-| Memory window | turns or tokens | **H** | M–H | M | Trade context cost for conversational accuracy. |
-| Retry policy | none / fixed / exponential / on-schema-failure | M | L–M | M | Big effect on robustness, sneaks into your cost surface. |
-| Fallback model | other model | **H** (failure mode) | M | M | What you fall back to when the primary refuses, errors, or times out. |
-| Confidence threshold | 0 to 1 | M–H | M | M | When to ask a human, when to retry, when to fall back. |
-| Caching layer (semantic / exact) | TTL settings | M (consistency) | **H** (savings) | **H** | Same-cache-key hits are essentially free. |
-| Tool selection strategy | greedy / heuristic / learned | M–H | M | M | How the agent decides *which* tool to consider when many are exposed. |
-
-It's not unusual for a real agent to expose 10–15 of these dimensions, on top of the 10–15 model-level knobs. The product of two double-digit dimension counts is a five-or-six-digit dimension count. We haven't even multiplied yet.
+| Speculative decoding draft model | model name | none | L | **M–H** | Speed without accuracy loss, *if* the draft model agrees often enough. |
+| `prompt_format` template | provider-specific | **H** | none | none | Wrong chat template = silent accuracy killer. Pure-accuracy knob with huge leverage. |
+| `mirostat_mode` / `mirostat_eta` / `mirostat_tau` | mode 0/1/2, floats | M | none | none | Adaptive sampling. llama.cpp / text-generation-webui only. Pure-accuracy. |
+| `min_p` | 0 to 1 | L–M | none | none | Newer sampling method; some teams prefer over top_p/top_k. Pure-accuracy. |
+| `repetition_penalty` | ~0.5 to 2 | L–M | none | none | Independent of presence/frequency penalty. Pure-accuracy. |
+| Sampler order | list (e.g. `["top_k", "tfs", "typical_p", "top_p", "min_p", "temp"]`) | L–M | none | none | llama.cpp-style fine control. Pure-accuracy. |
+| `typical_p` | 0 to 1 | L | none | none | Locally typical sampling. Rarely worth tuning. Pure-accuracy. |
+| `repeat_last_n` | integer | L | none | none | How far back the repetition penalty looks. Pure-accuracy. |
 
 ---
 
@@ -185,7 +214,7 @@ It's not unusual for a real agent to expose 10–15 of these dimensions, on top 
 
 Take a *modest* production agent: GPT-4o with chat-completion knobs only (no reasoning model, no fancy tool routing), plus a basic RAG pipeline.
 
-**Model side (7 knobs × ~5 reasonable values each):**
+**Model side (7 reasonable knobs × ~5 reasonable values each):**
 
 - `temperature` ∈ {0, 0.2, 0.4, 0.7, 1.0}
 - `top_p` ∈ {0.5, 0.8, 0.95, 1.0, "off"}
@@ -207,13 +236,13 @@ Take a *modest* production agent: GPT-4o with chat-completion knobs only (no rea
 
 4 × 4 × 4 × 4 × 3 = **768** combinations.
 
-**Total combined configuration space: ~11.5 million configurations.**
+**Combined: ~11.5 million configurations.**
 
-This is the conservative version. Drop in a reasoning model with `reasoning_effort` (×4) and a confidence threshold (×4) and you're at ~180 million. None of this counts seeds, retries, fallback policies, or any kind of caching. None of this counts running the search against multiple evaluation datasets.
+This is the *conservative* version — five agent knobs out of the fifteen in Table 1. Drop in a reasoning model with `reasoning_effort` (×4) and a confidence threshold (×4), use all fifteen agent-level knobs, and you're well into the billions. None of this counts seeds, retries, fallback policies, or any kind of caching. None of this counts running the search against multiple evaluation datasets.
 
 A single LLM eval pass on a serious benchmark takes seconds to minutes. Eleven million seconds is four months. *Per model.* Per benchmark.
 
-You can't grid-search this. You can't even random-search it meaningfully — sparse random sampling in a 14-dimensional space hits sub-1% coverage almost immediately. The only sane response is empirical optimization that converges — picks the next configuration based on what previous configurations revealed, instead of sampling blindly.
+You can't grid-search this. You can't even random-search it meaningfully — sparse random sampling in a 12-dimensional space hits sub-1% coverage almost immediately. The only sane response is empirical optimization that converges — picks the next configuration based on what previous configurations revealed, instead of sampling blindly.
 
 That's the actual rebuttal to the skeptic. Not "temperature matters more than you think." It's "you don't have time to *check* whether temperature matters more than you think."
 
@@ -225,13 +254,15 @@ The skeptic's argument, in its strongest form:
 
 > "Each individual knob, on a typical workload, shifts accuracy by a few percentage points at most. Engineering time spent tuning is engineering time not spent shipping. Pick reasonable defaults and move on."
 
-The first sentence is mostly true. The second is the load-bearing one — and the math doesn't support it.
+The first sentence is mostly true for model-level knobs taken in isolation. The second — the load-bearing one — falls apart on two counts.
 
-A few percent here, a few percent there, compound. Stack a handful of independent 5–10% knobs across model + agent layers and the compounded difference between a *bad* configuration and an *optimized* configuration is routinely 2–5× on cost and 10–30 percentage points on accuracy. That's not an exotic claim — it's the gap between the production agent that survives a review and the one that gets quietly killed three months in.
+First, the agent-level tier breaks it on its own. As Table 1 lays out, the typical agent has roughly fifteen knobs *above* the model layer, and most of them are individually in the H column for accuracy. The agent layer doesn't need compounding for its effect to be large; one knob (system prompt, few-shot count, RAG `top_k`) often delivers an H-magnitude swing by itself.
 
-There's also a second-order effect that the skeptic underestimates: **the knobs aren't independent.** Raising `reasoning_effort` changes which `temperature` is optimal. Increasing RAG `top_k` changes which `top_p` is optimal. These interactions are exactly what makes the configuration space too big to navigate by intuition — and exactly what an optimizer with memory of prior runs can exploit.
+Second, the model-level tier doesn't survive compounding either. A few percent here, a few percent there, stacked across the model knobs in Tables 2–7, routinely compounds to 2–5× on cost and 10–30 percentage points on accuracy — well-known territory in the gap between a *bad* model-tier config and an *optimized* one.
 
-The skeptic's mistake isn't believing temperature is minor. It's believing the *consequences* are minor. They aren't.
+There's also a second-order effect that the skeptic underestimates: **the knobs aren't independent.** Raising `reasoning_effort` changes which `temperature` is optimal. Increasing RAG `top_k` changes which `top_p` is optimal. Swapping the embedding model changes which system prompt variant works best. These interactions are exactly what makes the configuration space too big to navigate by intuition — and exactly what an optimizer with memory of prior runs can exploit.
+
+The skeptic's mistake isn't believing individual knobs are minor. It's believing the *consequences* are minor. They aren't.
 
 ---
 
@@ -239,8 +270,8 @@ The skeptic's mistake isn't believing temperature is minor. It's believing the *
 
 Three options, in increasing order of seriousness:
 
-1. **Acknowledge the space.** Stop shipping "we set temperature to 0 and called it a day." Treat configuration as a real engineering surface and write it down — which knobs, which values, which trade-offs. The directory above is a starting template.
-2. **Sweep a small subset by hand.** Pick the 3–4 highest-leverage knobs for your specific workload (almost always: model selection, system prompt, few-shot count, RAG top_k). Run a manual A/B/C/D. Document what you found and why.
+1. **Acknowledge the space.** Stop shipping "we set temperature to 0 and called it a day." Treat configuration as a real engineering surface and write it down — which knobs, which values, which trade-offs. Tables 1–7 above are a starting template.
+2. **Sweep a small subset by hand.** Pick the 3–4 highest-leverage agent-level knobs for your specific workload (almost always: system prompt, few-shot count, RAG `top_k`, model choice). Run a manual A/B/C/D. Document what you found and why. This will get you most of the way there for the cost of a sprint.
 3. **Use an optimizer.** Outsource the search to a system that picks the next configuration intelligently, converges on the cost-performance frontier, and re-optimizes when the world changes. That's exactly what Traigent does — and it's why we exist.
 
 There is no fourth option where you pick a config by gut and the math works out.

--- a/src/content/blog/the-config-multiverse.md
+++ b/src/content/blog/the-config-multiverse.md
@@ -1,5 +1,6 @@
 ---
 title: "The Magnitude of the AI Agent Optimization Problem"
+subtitle: "The Configuration Multiverse explained in detail."
 slug: "the-config-multiverse"
 date: "2026-05-24"
 summary: "Every AI agent in production is the product of ~25 configuration decisions across two layers — agent-level decisions you designed yourself, and model-level knobs your provider exposes. Each has a handful of reasonable values. Multiplied out, the space is in the millions per model per workload. This post explains the math, then catalogs every knob in seven sorted tables."
@@ -8,8 +9,6 @@ readingTime: "13 min read"
 tags: "optimization,configuration,models,benchmarks,reasoning"
 order: 7
 ---
-
-*The Configuration Multiverse explained in detail.*
 
 **See it on your numbers:** [ROI Calculator →](/roi) · [TTM Calculator →](/ttm)
 

--- a/src/content/blog/the-config-multiverse.md
+++ b/src/content/blog/the-config-multiverse.md
@@ -1,5 +1,5 @@
 ---
-title: "The Configuration Multiverse: A Directory of Every Knob in Every Major Model — and Why Skeptics Are Still Wrong"
+title: "The Magnitude of the AI Agent Optimization Problem"
 slug: "the-config-multiverse"
 date: "2026-05-24"
 summary: "Every AI agent in production is the product of ~25 configuration decisions across two layers — agent-level decisions you designed yourself, and model-level knobs your provider exposes. Each has a handful of reasonable values. Multiplied out, the space is in the millions per model per workload. This post explains the math, then catalogs every knob in seven sorted tables."
@@ -8,6 +8,8 @@ readingTime: "13 min read"
 tags: "optimization,configuration,models,benchmarks,reasoning"
 order: 7
 ---
+
+*The Configuration Multiverse explained in detail.*
 
 **See it on your numbers:** [ROI Calculator →](/roi) · [TTM Calculator →](/ttm)
 

--- a/src/content/blog/the-config-multiverse.md
+++ b/src/content/blog/the-config-multiverse.md
@@ -1,0 +1,252 @@
+---
+title: "The Configuration Multiverse: A Directory of Every Knob in Every Major Model — and Why Skeptics Are Still Wrong"
+slug: "the-config-multiverse"
+date: "2026-05-24"
+summary: "Every chat or reasoning model exposes a dozen knobs, your agent layer adds half a dozen more, and each knob has a handful of reasonable values. The product is millions of valid configurations — and the 'temperature doesn't matter' skeptic isn't wrong about temperature alone. They're wrong about the math."
+author: "Amir Barnea"
+readingTime: "12 min read"
+tags: "optimization,configuration,models,benchmarks,reasoning"
+order: 7
+---
+
+**See it on your numbers:** [ROI Calculator →](/roi) · [TTM Calculator →](/ttm)
+
+---
+
+> *"Temperature doesn't matter much."*
+>
+> *"top_p? Same thing as temperature. Skip it."*
+>
+> *"I just pick `gpt-4o` at temperature 0 and ship. Done."*
+
+You've heard a version of this in every Slack channel that ships AI agents. It's not a stupid take. Any *one* of the knobs the major providers expose, taken in isolation, on a typical benchmark, will usually move a single metric by a handful of percentage points at most. Sometimes less.
+
+The trap is the word "isolation." You don't ship one knob. You ship *all* of them, at once, against a real workload, and the values you didn't think about get picked by your SDK's defaults — which were chosen by someone who has no idea what your agent does.
+
+This post is two things at once. The first half is a directory: every model knob the major providers expose, the valid range or value set, and a qualitative tag for how much it can move accuracy (**A**), cost (**C**), and latency (**L**). The second half is the math that makes the skeptic's argument collapse — even when each individual claim about each individual knob is correct.
+
+## How to read the tables
+
+For each knob you'll see three impact tags:
+
+- **L (Low)** — typical effect of changing this one knob, holding everything else fixed, is under ~3 percentage points on the relevant metric for most workloads.
+- **M (Medium)** — typical effect is 3–15 percentage points. Big enough that you'd notice if you A/B-tested it. Small enough that nobody fights about it.
+- **H (High)** — typical effect can exceed 15 percentage points, sometimes substantially. Order-of-magnitude swings on certain workloads.
+
+A few rules of thumb before you read the tables:
+
+1. **No global percentages.** Anyone who tells you "temperature shifts accuracy by 4.2%" without naming a benchmark and a workload is selling you something. Temperature can move accuracy 0% on a deterministic classification task and 25% on a creative-writing eval. The L/M/H tags below are *typical ranges across the kinds of agent workloads we see in production* — not promises for your specific use case.
+2. **The skeptic is right about each knob, individually.** Most knobs are L or M in isolation. The point of this directory is what happens when you multiply.
+3. **A, C, and L impact are independent.** A knob can be L for accuracy but H for cost (e.g., `max_tokens`), and that asymmetry is itself a configuration decision worth optimizing.
+4. **Newer model families introduce new knob classes.** Reasoning models added a whole tier (`reasoning_effort`, `thinking_budget`) that didn't exist three years ago. The dimension count keeps climbing — your config grid doesn't shrink with time, it grows.
+
+Let's start with the universal tier and work outward.
+
+---
+
+## Tier 1: Knobs nearly every chat model exposes
+
+If you've used any chat completion API in the last five years, you've seen most of these. Defaults vary wildly between SDKs.
+
+| Knob | Range / values | A | C | L | Why it matters |
+|---|---|---|---|---|---|
+| `temperature` | 0 to 2 (most sane in 0–1) | M | none | none | Controls sampling determinism. Bigger effect on free-form generation than on classification. Reasoning models tolerate it less. |
+| `top_p` (nucleus sampling) | 0 to 1 | L–M | none | none | Often substitutes for temperature; varying both at once is usually redundant. |
+| `top_k` | 1 to vocab size | L | none | none | Hard cap on candidate tokens. Most providers default it sensibly; rarely worth tuning. |
+| `max_tokens` / `max_output_tokens` | 1 to model max | L (truncation only) | **H** | **H** | The single biggest cost knob. Halving the cap can halve the bill — and sometimes the answer along with it. |
+| `stop` / `stop_sequences` | array of strings | L–M | L | L | Can dramatically change streaming behavior and parsing reliability. Often the difference between "JSON parses" and "doesn't." |
+| `seed` (where supported) | integer | 0 *on average* | none | none | Determinism, not quality. Critical for reproducible evals — irrelevant for users. |
+| `n` / `candidate_count` | integer ≥ 1 | M | **H** | **H** | Best-of-n sampling. Real accuracy gains, brutal cost multiplier. |
+
+Already, before any provider-specific knobs, you have 7 dimensions × maybe 5 reasonable values each = **~78,000 configurations**. And we've barely started.
+
+---
+
+## OpenAI
+
+OpenAI now ships two distinct families, with different knob surfaces. Worth treating them separately.
+
+### Chat / completion models (GPT-4o, GPT-4o-mini, GPT-4-turbo, GPT-3.5-turbo)
+
+| Knob | Range / values | A | C | L | Why it matters |
+|---|---|---|---|---|---|
+| `presence_penalty` | -2 to 2 | L | none | none | Pushes the model toward (or away from) novel tokens. Subtle effect on most chat tasks. |
+| `frequency_penalty` | -2 to 2 | L | none | none | Suppresses repetition. Bigger effect on long outputs. |
+| `response_format` | `{type: "text" \| "json_object" \| "json_schema"}` | **M–H** (on JSON tasks) | L | L | Schema-enforced JSON dramatically reduces parsing-failure cost on extraction agents. |
+| `tool_choice` | `"auto"`, `"none"`, `"required"`, `{specific}` | **H** | M | M | Forcing a specific tool changes the agent's behavior class — not just a tweak. |
+| `parallel_tool_calls` | bool | M | M | **M–H** (sequential blocks) | Off forces serial reasoning; can double latency on multi-tool plans. |
+| `logprobs` / `top_logprobs` | bool, integer | none | L | L (overhead) | Critical for self-consistency / confidence routing; otherwise noise. |
+| `service_tier` (where available) | `"auto"` / `"default"` / `"flex"` | L (if any) | M | M | Trades cost for predictable latency. |
+
+### Reasoning models (o1, o3, o3-mini, o3-pro, o4-mini, GPT-5, GPT-5-mini, GPT-5-nano)
+
+A new tier of knobs that don't exist on chat models. These often *dominate* everything else.
+
+| Knob | Range / values | A | C | L | Why it matters |
+|---|---|---|---|---|---|
+| `reasoning_effort` | `"minimal"`, `"low"`, `"medium"`, `"high"` | **H** | **H** | **H** | The biggest knob in the OpenAI catalog right now. `high` can double an o-series model's accuracy on hard tasks — and 10× its bill. |
+| `verbosity` (GPT-5 family) | `"low"`, `"medium"`, `"high"` | M | M | M | Affects how much the model says, independent of how much it thinks. |
+| `max_completion_tokens` (replaces `max_tokens`) | 1 to model max | L | **H** | **H** | Reasoning tokens count against this budget. Underestimating clips the answer. |
+| `reasoning.summary` (where available) | `"auto"`, `"detailed"`, `null` | L | L | M | Whether to expose a reasoning summary. Affects payload size and parsing. |
+| `store` | bool | none | L (long term) | none | Whether responses persist for evals. No runtime impact, but matters for your eval pipeline. |
+
+OpenAI alone: **~12 reasonable knobs × ~4–5 values each** ≈ 4M+ combinations before agent-level configuration.
+
+---
+
+## Anthropic (Claude 3.5 / 3.7 / 4 / 4.5 — Haiku, Sonnet, Opus)
+
+| Knob | Range / values | A | C | L | Why it matters |
+|---|---|---|---|---|---|
+| `temperature` | 0 to 1 | M | none | none | Same role as OpenAI's. Reasoning Claude tolerates it less. |
+| `top_p` | 0 to 1 | L–M | none | none | |
+| `top_k` | integer ≥ 1 | L | none | none | |
+| `max_tokens` | 1 to model max | L | **H** | **H** | Required parameter on Claude — there is no "model default." |
+| `system` | string | **H** | M | M | The system prompt is far more load-bearing on Claude than on most providers; longer, more structured systems consistently outperform terse ones on agent tasks. |
+| `stop_sequences` | array | L–M | L | L | |
+| `tools` | array of definitions | **H** | M | M | Tool count + descriptions strongly bias which path the model takes. |
+| `tool_choice` | `"auto"`, `"any"`, `"tool"`, `"none"` | **H** | M | M | |
+| `disable_parallel_tool_use` | bool | M | M | **M–H** | Same shape as OpenAI's `parallel_tool_calls=false`. |
+| `thinking` (extended thinking — 3.7, 4, 4.5) | `{type: "enabled", budget_tokens: 1024+}` | **H** | **H** | **H** | Same family as OpenAI's reasoning_effort. Budget can range from 1K to many tens of thousands of tokens. |
+| `metadata.user_id` | string | none | none | none | Compliance/abuse routing. Not a quality knob. |
+
+Anthropic adds the system-prompt knob category, which is interesting: on Claude, the *structure* of the system prompt (XML tags, ordered sections, explicit role definition) reliably swings accuracy more than temperature does. There is no single value to put in a table — but if you treat "system prompt template" as a knob with, say, 5 candidate variants, you've added another 5× to your search space.
+
+---
+
+## Google (Gemini 1.5 / 2.0 / 2.5 — Pro / Flash / Flash-Lite)
+
+| Knob | Range / values | A | C | L | Why it matters |
+|---|---|---|---|---|---|
+| `temperature` | 0 to 2 | M | none | none | |
+| `top_p` | 0 to 1 | L–M | none | none | |
+| `top_k` | integer | L | none | none | |
+| `max_output_tokens` | 1 to model max | L | **H** | **H** | |
+| `candidate_count` | integer ≥ 1 | M | **H** | **H** | Best-of-n. |
+| `response_mime_type` | `"text/plain"`, `"application/json"` | **M–H** (JSON tasks) | L | L | |
+| `response_schema` | OpenAPI-flavor JSON schema | M | L | L | Structured output enforcement. Massively reduces parsing failure on extraction tasks. |
+| `thinking_config` / `thinking_budget` (2.5) | integer tokens (0 disables) | **H** | **H** | **H** | Same family as reasoning_effort / thinking on the other providers. |
+| `safety_settings` | array of {category, threshold} | L (rejection rate) | none | none | Affects how often the model refuses, not how well it answers. |
+| `cached_content` | string handle | M (consistency) | **H** (savings) | M | Context caching can dramatically cut cost for long-context agents. A real knob, not just an optimization. |
+
+Gemini's `cached_content` deserves its own callout. If your agent ships a long, mostly-static system prompt and/or tool catalog, *not* caching is leaving real money on the table — sometimes 50%+ savings on inference, with measurable latency improvement on cache hits.
+
+---
+
+## Open-source models served via vLLM / TGI / llama.cpp / Ollama (Llama / Mistral / Qwen / DeepSeek / Yi)
+
+You inherit all the Tier 1 knobs, plus a set the closed providers don't expose:
+
+| Knob | Range / values | A | C | L | Why it matters |
+|---|---|---|---|---|---|
+| `min_p` | 0 to 1 | L–M | none | none | Newer sampling method; some teams prefer over top_p/top_k. |
+| `repetition_penalty` | ~0.5 to 2 | L–M | none | none | Independent of presence/frequency penalty. |
+| `typical_p` | 0 to 1 | L | none | none | Locally typical sampling. Rarely worth tuning. |
+| `mirostat_mode` / `mirostat_eta` / `mirostat_tau` | mode 0/1/2, floats | M | none | none | Adaptive sampling. llama.cpp / text-generation-webui only. |
+| `repeat_last_n` | integer | L | none | none | How far back the repetition penalty looks. |
+| `enable_thinking` (Qwen 3, DeepSeek R1, others) | bool | **H** | **H** | **H** | Newer open models have a reasoning toggle similar to OpenAI/Anthropic. |
+| Quantization (server-side) | fp16, fp8, int8, int4, awq, gptq, etc. | L–M | **H** (compute) | M | Not a runtime knob, but a deploy-time configuration that dominates cost. |
+| Speculative decoding draft model | model name | none | L | **M–H** | Speed without accuracy loss, *if* the draft model agrees often enough. |
+| `n_ctx` allocation | tokens | L (if you have enough) | M (VRAM) | M | Bigger context allocation costs memory and can slow attention. |
+| Sampler order | list (e.g. `["top_k", "tfs", "typical_p", "top_p", "min_p", "temp"]`) | L–M | none | none | llama.cpp-style fine control. |
+| `prompt_format` template | provider-specific | **H** | none | none | Using the wrong chat template (Llama instruct vs Mistral instruct vs ChatML) is a silent accuracy killer. |
+
+The open-source surface area is *much* larger than the closed providers — because nothing is hidden behind a SaaS facade. That's a strength and a liability.
+
+---
+
+## Agent-level knobs (these often dwarf the model-level ones)
+
+Everything above is what the model exposes. But the agent layer you build on top of it adds its own dimensions, and in our experience these are often where *most* of the accuracy and cost variance hides.
+
+| Knob | Range / values | A | C | L | Why it matters |
+|---|---|---|---|---|---|
+| System prompt template | variants | **H** | M (token count) | M | The single most under-optimized dimension in production agents. Same model, different system prompt, 20+ point swings on the same eval. |
+| Few-shot example count | 0 to N | **H** | **M–H** (token cost) | **M–H** | More examples raise accuracy until they overflow attention. The optimum is workload-specific. |
+| Few-shot selection method | random / semantic-similar / hard-coded / diverse | **H** | none | none | Free upgrade for retrieval-augmented few-shotting. |
+| Few-shot ordering | first, last, random | M | none | none | "Lost in the middle" is real: position matters. |
+| RAG `top_k` (retrieved chunks) | 1 to ~100 | **H** | **M–H** | M | More chunks → more context → more accuracy, until precision collapses. |
+| RAG chunk size | 100 to 2000 tokens | **H** | M | M | The biggest knob in your retrieval pipeline. |
+| RAG chunk overlap | 0 to chunk size | M | M | L | Mitigates boundary loss. |
+| Embedding model | various | **H** (retrieval) | L | L | Different embeddings = different retrieval results = different downstream accuracy. |
+| Reranker | none / cross-encoder / LLM-as-ranker | M–H | M | M | Cheap accuracy bump, especially when `top_k` is generous. |
+| Memory window | turns or tokens | **H** | M–H | M | Trade context cost for conversational accuracy. |
+| Retry policy | none / fixed / exponential / on-schema-failure | M | L–M | M | Big effect on robustness, sneaks into your cost surface. |
+| Fallback model | other model | **H** (failure mode) | M | M | What you fall back to when the primary refuses, errors, or times out. |
+| Confidence threshold | 0 to 1 | M–H | M | M | When to ask a human, when to retry, when to fall back. |
+| Caching layer (semantic / exact) | TTL settings | M (consistency) | **H** (savings) | **H** | Same-cache-key hits are essentially free. |
+| Tool selection strategy | greedy / heuristic / learned | M–H | M | M | How the agent decides *which* tool to consider when many are exposed. |
+
+It's not unusual for a real agent to expose 10–15 of these dimensions, on top of the 10–15 model-level knobs. The product of two double-digit dimension counts is a five-or-six-digit dimension count. We haven't even multiplied yet.
+
+---
+
+## The cardinality, with the math actually written out
+
+Take a *modest* production agent: GPT-4o with chat-completion knobs only (no reasoning model, no fancy tool routing), plus a basic RAG pipeline.
+
+**Model side (7 knobs × ~5 reasonable values each):**
+
+- `temperature` ∈ {0, 0.2, 0.4, 0.7, 1.0}
+- `top_p` ∈ {0.5, 0.8, 0.95, 1.0, "off"}
+- `max_tokens` ∈ {256, 512, 1024, 2048, 4096}
+- `presence_penalty` ∈ {-0.5, 0, 0.5, 1, 1.5}
+- `response_format` ∈ {text, json_object, json_schema}
+- `parallel_tool_calls` ∈ {true, false}
+- `tool_choice` ∈ {auto, required}
+
+5 × 5 × 5 × 5 × 3 × 2 × 2 = **15,000** combinations.
+
+**Agent side (5 knobs × ~4 values each):**
+
+- System prompt template ∈ {v1, v2, v3, v4}
+- Few-shot count ∈ {0, 2, 4, 8}
+- RAG `top_k` ∈ {3, 5, 10, 20}
+- Embedding model ∈ {ada-3-small, ada-3-large, voyage-3, cohere-v3}
+- Reranker ∈ {none, cross-encoder, LLM}
+
+4 × 4 × 4 × 4 × 3 = **768** combinations.
+
+**Total combined configuration space: ~11.5 million configurations.**
+
+This is the conservative version. Drop in a reasoning model with `reasoning_effort` (×4) and a confidence threshold (×4) and you're at ~180 million. None of this counts seeds, retries, fallback policies, or any kind of caching. None of this counts running the search against multiple evaluation datasets.
+
+A single LLM eval pass on a serious benchmark takes seconds to minutes. Eleven million seconds is four months. *Per model.* Per benchmark.
+
+You can't grid-search this. You can't even random-search it meaningfully — sparse random sampling in a 14-dimensional space hits sub-1% coverage almost immediately. The only sane response is empirical optimization that converges — picks the next configuration based on what previous configurations revealed, instead of sampling blindly.
+
+That's the actual rebuttal to the skeptic. Not "temperature matters more than you think." It's "you don't have time to *check* whether temperature matters more than you think."
+
+---
+
+## The skeptic, addressed directly
+
+The skeptic's argument, in its strongest form:
+
+> "Each individual knob, on a typical workload, shifts accuracy by a few percentage points at most. Engineering time spent tuning is engineering time not spent shipping. Pick reasonable defaults and move on."
+
+The first sentence is mostly true. The second is the load-bearing one — and the math doesn't support it.
+
+A few percent here, a few percent there, compound. Stack a handful of independent 5–10% knobs across model + agent layers and the compounded difference between a *bad* configuration and an *optimized* configuration is routinely 2–5× on cost and 10–30 percentage points on accuracy. That's not an exotic claim — it's the gap between the production agent that survives a review and the one that gets quietly killed three months in.
+
+There's also a second-order effect that the skeptic underestimates: **the knobs aren't independent.** Raising `reasoning_effort` changes which `temperature` is optimal. Increasing RAG `top_k` changes which `top_p` is optimal. These interactions are exactly what makes the configuration space too big to navigate by intuition — and exactly what an optimizer with memory of prior runs can exploit.
+
+The skeptic's mistake isn't believing temperature is minor. It's believing the *consequences* are minor. They aren't.
+
+---
+
+## What to do about it
+
+Three options, in increasing order of seriousness:
+
+1. **Acknowledge the space.** Stop shipping "we set temperature to 0 and called it a day." Treat configuration as a real engineering surface and write it down — which knobs, which values, which trade-offs. The directory above is a starting template.
+2. **Sweep a small subset by hand.** Pick the 3–4 highest-leverage knobs for your specific workload (almost always: model selection, system prompt, few-shot count, RAG top_k). Run a manual A/B/C/D. Document what you found and why.
+3. **Use an optimizer.** Outsource the search to a system that picks the next configuration intelligently, converges on the cost-performance frontier, and re-optimizes when the world changes. That's exactly what Traigent does — and it's why we exist.
+
+There is no fourth option where you pick a config by gut and the math works out.
+
+---
+
+**See what your math looks like:** [ROI Calculator →](/roi) · [TTM Calculator →](/ttm)
+
+**Or read more on the same theme:** [The Model Myth →](/blog/the-model-myth) · [The Eval Trap →](/blog/the-eval-trap) · [The Business Case →](/blog/the-business-case)

--- a/src/content/blog/the-config-multiverse.md
+++ b/src/content/blog/the-config-multiverse.md
@@ -7,16 +7,19 @@ summary: "Every AI agent in production is the product of ~25 configuration decis
 author: "Amir Barnea"
 readingTime: "13 min read"
 tags: "optimization,configuration,models,benchmarks,reasoning"
-order: 7
+featured: true
+order: 1
 ---
 
 **See it on your numbers:** [ROI Calculator →](/roi) · [TTM Calculator →](/ttm)
 
 ---
 
-## The problem in one paragraph
+## The magnitude of the problem
 
-Every AI agent in production is the product of roughly twenty-five configuration decisions — about fifteen at the agent layer you designed yourself, about ten at the model layer your provider exposes. Each decision has a small handful of reasonable values. Multiplied out, this gives a configuration space in the millions, per model, per workload. Most teams pick one point in that space by gut and ship; many of them ship the wrong one and never find out.
+Every AI agent in production is the product of roughly twenty-five configuration decisions in addition to the model selection itself — about fifteen at the agent layer you designed yourself, about ten at the model layer your provider exposes. Each decision has a small handful of reasonable values. Multiplied out, this gives a configuration space in the millions, per model, per workload. Most teams pick one point in that space by gut and ship; many of them ship the wrong one and never find out.
+
+Your model and configuration choices have significant impact on Accuracy (**A**), Cost (**C**), and Latency (**L**). The following discussion maps all the options and their potential impact on **A**, **C**, and **L** — and therefore on the ROI of the agent or its cost-effectiveness. Since it's impossible (or at best impractical) to manually evaluate millions of configurations, you need an automated agent optimizer such as Traigent.
 
 The rest of this post does three things. **First**, it shows the math of *why* the configuration space is that big — the two-tier structure, the multiplication, the way small effects compound. **Second**, it provides a directory — seven tables, sorted by impact — covering the agent-layer knobs you build on top plus every model-layer knob the major providers expose. **Third**, it explains what to do about all this without spending a quarter on grid search.
 

--- a/src/content/blog/the-config-multiverse.md
+++ b/src/content/blog/the-config-multiverse.md
@@ -29,13 +29,13 @@ This post is two things at once. The article makes the qualitative and quantitat
 
 Every agent has two distinct layers of configuration, and they're not equal.
 
-**Agent-level knobs** are the ones *you* design when you build the agent: system prompt structure, few-shot examples, retrieval `top_k`, embedding model, reranker, memory window, retry policy, tool selection, caching. They live in your code, not in the model's API. They are mostly invisible to the model provider's docs.
+**Agent-level knobs** are the ones *you* design when you build the agent: system prompt structure, few-shot examples, retrieval top_k, embedding model, reranker, memory window, retry policy, tool selection, caching. They live in your code, not in the model's API. They are mostly invisible to the model provider's docs.
 
 **Model-level knobs** are the ones the provider exposes: temperature, top_p, max_tokens, response_format, tool_choice, reasoning_effort, thinking_budget. They live in the request body. The provider's docs enumerate them; their defaults are picked for the median customer, who is not you.
 
 **Agent-level knobs dominate model-level knobs in impact, by a wide margin.**
 
-This sounds counter-intuitive — the model is the expensive part, the model has the cool brand names, the model is where the press releases live. But every working production agent we've seen says the same thing: changing the system prompt structure, the few-shot count, or the retrieval `top_k` reliably swings accuracy 10–30 percentage points on the same eval. Changing temperature on the same agent rarely moves it more than 3–5. The model layer is the engine. The agent layer is the chassis, the transmission, the route, and the driver. The engine matters; everything else matters more, in aggregate.
+This sounds counter-intuitive — the model is the expensive part, the model has the cool brand names, the model is where the press releases live. But every working production agent we've seen says the same thing: changing the system prompt structure, the few-shot count, or the retrieval top_k reliably swings accuracy 10–30 percentage points on the same eval. Changing temperature on the same agent rarely moves it more than 3–5. The model layer is the engine. The agent layer is the chassis, the transmission, the route, and the driver. The engine matters; everything else matters more, in aggregate.
 
 Why the agent layer dominates:
 
@@ -56,7 +56,7 @@ For each knob you'll see three impact tags:
 A few rules before the tables:
 
 - **No global percentages.** Anyone who quotes "temperature shifts accuracy by 4.2%" without naming a benchmark and a workload is selling something. The L/M/H tags are *typical ranges across the kinds of agent workloads we see* — not promises for your specific use case.
-- **A, C, and L are independent dimensions.** A knob can be L on accuracy and H on cost (e.g., `max_tokens`), and that asymmetry is itself a configuration decision.
+- **A, C, and L are independent dimensions.** A knob can be L on accuracy and H on cost (e.g., max_tokens), and that asymmetry is itself a configuration decision.
 - **Tables are sorted by impact within each tier.** Knobs at the top affect multiple dimensions (accuracy *and* cost, or accuracy *and* latency). Knobs at the bottom typically affect only one dimension — often accuracy alone, which makes them important when you have the budget to optimize but easy to deprioritize when you don't.
 
 ---
@@ -69,7 +69,7 @@ This is where most of the variance in your agent's behavior lives. Three concret
 
 **Few-shot count.** Going from 0 to 4 well-chosen examples typically delivers more accuracy than swapping `gpt-4o-mini` for `gpt-4o` on the same task — at a fraction of the per-call cost increase. The optimum is workload-specific (too many examples and you blow context budget or trigger "lost in the middle" effects) and almost nobody finds it by intuition. **Table 1** shows the rest of the agent-level tier.
 
-**Retrieval `top_k` and chunk size.** In any agent with a RAG component, the retrieval parameters dominate the downstream model parameters. Doubling `top_k` from 5 to 10 commonly shifts accuracy 5–15 points on QA tasks — comparable to a model-tier upgrade, at a marginal cost. Halving chunk size from 800 to 400 tokens often improves retrieval precision but doubles index size and latency. These are the knobs nobody at the LLM provider can tune for you.
+**Retrieval top_k and chunk size.** In any agent with a RAG component, the retrieval parameters dominate the downstream model parameters. Doubling top_k from 5 to 10 commonly shifts accuracy 5–15 points on QA tasks — comparable to a model-tier upgrade, at a marginal cost. Halving chunk size from 800 to 400 tokens often improves retrieval precision but doubles index size and latency. These are the knobs nobody at the LLM provider can tune for you.
 
 What follows is the full agent-level table. Note that the last three rows (embedding model, few-shot selection method, few-shot ordering) are listed last *not because they're unimportant* — they all can swing accuracy heavily — but because their effect is concentrated on the accuracy axis with no direct cost or latency impact. They're the items easiest to overlook in a quarterly review focused on the bill.
 
@@ -79,12 +79,12 @@ What follows is the full agent-level table. Note that the last three rows (embed
 |---|---|---|---|---|---|
 | Few-shot example count | 0 to N | **H** | **M–H** | **M–H** | More examples raise accuracy until they overflow attention. The optimum is workload-specific. Token cost compounds quickly. |
 | Caching layer (semantic / exact) | TTL settings | M (consistency) | **H** (savings) | **H** | Same-cache-key hits are essentially free. The single biggest cost optimization on a high-traffic agent. |
-| RAG `top_k` (retrieved chunks) | 1 to ~100 | **H** | **M–H** | M | More chunks → more context → more accuracy, until precision collapses and cost balloons. |
+| RAG top_k (retrieved chunks) | 1 to ~100 | **H** | **M–H** | M | More chunks → more context → more accuracy, until precision collapses and cost balloons. |
 | Memory window | turns or tokens | **H** | **M–H** | M | Trade context cost for conversational accuracy. Critical for multi-turn agents. |
 | System prompt template | variants | **H** | M (token count) | M | The single most under-optimized dimension in production agents. |
 | RAG chunk size | 100 to 2000 tokens | **H** | M | M | The biggest knob inside your retrieval pipeline. |
 | Fallback model | other model | **H** (failure mode) | M | M | What you fall back to when the primary refuses, errors, or times out. |
-| Reranker | none / cross-encoder / LLM-as-ranker | M–H | M | M | Cheap accuracy bump, especially when `top_k` is generous. |
+| Reranker | none / cross-encoder / LLM-as-ranker | M–H | M | M | Cheap accuracy bump, especially when top_k is generous. |
 | Confidence threshold | 0 to 1 | M–H | M | M | When to ask a human, when to retry, when to fall back. |
 | Tool selection strategy | greedy / heuristic / learned | M–H | M | M | How the agent decides *which* tool to consider when many are exposed. |
 | Retry policy | none / fixed / exponential / on-schema-failure | M | L–M | M | Big effect on robustness; sneaks into your cost surface. |
@@ -105,108 +105,108 @@ Smaller per-knob, but more numerous, and they compound. Five tables: one for the
 
 Every chat model exposes most of these. Defaults vary wildly between SDKs and you've probably never thought about most of them.
 
-The two top entries — `n` / `candidate_count` (best-of-n) and `max_tokens` — are special: both are H on cost and latency. They're the model-level knobs most directly tied to your bill and your p99 latency. Everything below the line is mostly an accuracy/determinism trade. **Table 2.**
+The two top entries — n / candidate_count (best-of-n) and max_tokens — are special: both are H on cost and latency. They're the model-level knobs most directly tied to your bill and your p99 latency. Everything below the line is mostly an accuracy/determinism trade. **Table 2.**
 
 ### Table 2 — Universal tier (chat models, all providers)
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
-| `n` / `candidate_count` | integer ≥ 1 | M | **H** | **H** | Best-of-n sampling. Real accuracy gains, brutal cost multiplier. |
-| `max_tokens` / `max_output_tokens` | 1 to model max | L (truncation only) | **H** | **H** | The single biggest cost knob. Halving the cap can halve the bill — sometimes the answer along with it. |
-| `stop` / `stop_sequences` | array of strings | L–M | L | L | Can dramatically change streaming behavior and parsing reliability. |
-| `temperature` | 0 to 2 (most sane in 0–1) | M | none | none | Controls sampling determinism. Pure-accuracy knob in isolation. |
-| `top_p` (nucleus sampling) | 0 to 1 | L–M | none | none | Often substitutes for temperature; varying both at once is usually redundant. |
-| `top_k` | 1 to vocab size | L | none | none | Hard cap on candidate tokens. Most providers default it sensibly. |
-| `seed` (where supported) | integer | 0 *on average* | none | none | Determinism, not quality. Critical for reproducible evals — irrelevant for users. |
+| n / candidate_count | integer ≥ 1 | M | **H** | **H** | Best-of-n sampling. Real accuracy gains, brutal cost multiplier. |
+| max_tokens / max_output_tokens | 1 to model max | L (truncation only) | **H** | **H** | The single biggest cost knob. Halving the cap can halve the bill — sometimes the answer along with it. |
+| stop / stop_sequences | array of strings | L–M | L | L | Can dramatically change streaming behavior and parsing reliability. |
+| temperature | 0 to 2 (most sane in 0–1) | M | none | none | Controls sampling determinism. Pure-accuracy knob in isolation. |
+| top_p (nucleus sampling) | 0 to 1 | L–M | none | none | Often substitutes for temperature; varying both at once is usually redundant. |
+| top_k | 1 to vocab size | L | none | none | Hard cap on candidate tokens. Most providers default it sensibly. |
+| seed (where supported) | integer | 0 *on average* | none | none | Determinism, not quality. Critical for reproducible evals — irrelevant for users. |
 
 ### OpenAI
 
 OpenAI now ships two distinct families with different knob surfaces. Worth treating them separately because the *reasoning* family has knobs that frequently dwarf everything else in this entire directory.
 
-For the **chat family** (GPT-4o, GPT-4o-mini, GPT-3.5-turbo), the qualitative point is: `tool_choice` and `parallel_tool_calls` are the action-shaping knobs that change the agent's *behavior class*, not just its decoding. Forcing `tool_choice: required` versus `auto` is the difference between a deterministic pipeline and an open-ended agent. Disabling `parallel_tool_calls` serializes a plan that would otherwise run concurrently, which can double end-to-end latency on multi-tool agents. **Table 3.**
+For the **chat family** (GPT-4o, GPT-4o-mini, GPT-3.5-turbo), the qualitative point is: tool_choice and parallel_tool_calls are the action-shaping knobs that change the agent's *behavior class*, not just its decoding. Forcing `tool_choice: required` versus `auto` is the difference between a deterministic pipeline and an open-ended agent. Disabling parallel_tool_calls serializes a plan that would otherwise run concurrently, which can double end-to-end latency on multi-tool agents. **Table 3.**
 
-For the **reasoning family** (o1, o3, o3-mini, o3-pro, o4-mini, GPT-5, GPT-5-mini, GPT-5-nano), one knob — `reasoning_effort` — typically swamps every other model-level knob. Moving from `low` to `high` on a hard math or code benchmark can double accuracy and 10× the bill. There is no other model-level decision in this whole post with that kind of leverage. **Table 4.**
+For the **reasoning family** (o1, o3, o3-mini, o3-pro, o4-mini, GPT-5, GPT-5-mini, GPT-5-nano), one knob — reasoning_effort — typically swamps every other model-level knob. Moving from `low` to `high` on a hard math or code benchmark can double accuracy and 10× the bill. There is no other model-level decision in this whole post with that kind of leverage. **Table 4.**
 
 ### Table 3 — OpenAI chat models
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
-| `tool_choice` | `"auto"`, `"none"`, `"required"`, `{specific}` | **H** | M | M | Forcing a specific tool changes the agent's behavior class — not just a tweak. |
-| `parallel_tool_calls` | bool | M | M | **M–H** (sequential blocks) | Off forces serial reasoning; can double latency on multi-tool plans. |
-| `service_tier` (where available) | `"auto"` / `"default"` / `"flex"` | L (if any) | M | M | Trades cost for predictable latency. |
-| `response_format` | `{type: "text" \| "json_object" \| "json_schema"}` | **M–H** (on JSON tasks) | L | L | Schema-enforced JSON dramatically reduces parsing-failure cost on extraction agents. |
-| `logprobs` / `top_logprobs` | bool, integer | none | L | L (overhead) | Critical for self-consistency / confidence routing; otherwise noise. |
-| `presence_penalty` | -2 to 2 | L | none | none | Pushes the model toward (or away from) novel tokens. Subtle on most chat tasks. Pure-accuracy knob. |
-| `frequency_penalty` | -2 to 2 | L | none | none | Suppresses repetition. Bigger effect on long outputs. Pure-accuracy knob. |
+| tool_choice | `"auto"`, `"none"`, `"required"`, `{specific}` | **H** | M | M | Forcing a specific tool changes the agent's behavior class — not just a tweak. |
+| parallel_tool_calls | bool | M | M | **M–H** (sequential blocks) | Off forces serial reasoning; can double latency on multi-tool plans. |
+| service_tier (where available) | `"auto"` / `"default"` / `"flex"` | L (if any) | M | M | Trades cost for predictable latency. |
+| response_format | `{type: "text" \| "json_object" \| "json_schema"}` | **M–H** (on JSON tasks) | L | L | Schema-enforced JSON dramatically reduces parsing-failure cost on extraction agents. |
+| logprobs / top_logprobs | bool, integer | none | L | L (overhead) | Critical for self-consistency / confidence routing; otherwise noise. |
+| presence_penalty | -2 to 2 | L | none | none | Pushes the model toward (or away from) novel tokens. Subtle on most chat tasks. Pure-accuracy knob. |
+| frequency_penalty | -2 to 2 | L | none | none | Suppresses repetition. Bigger effect on long outputs. Pure-accuracy knob. |
 
 ### Table 4 — OpenAI reasoning models (o-series, GPT-5)
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
-| `reasoning_effort` | `"minimal"`, `"low"`, `"medium"`, `"high"` | **H** | **H** | **H** | The biggest knob in the OpenAI catalog. `high` can double accuracy on hard tasks — and 10× the bill. |
-| `max_completion_tokens` (replaces `max_tokens`) | 1 to model max | L | **H** | **H** | Reasoning tokens count against this budget. Underestimating clips the answer. |
-| `verbosity` (GPT-5 family) | `"low"`, `"medium"`, `"high"` | M | M | M | Affects how much the model says, independent of how much it thinks. |
-| `reasoning.summary` | `"auto"`, `"detailed"`, `null` | L | L | M | Whether to expose a reasoning summary. Affects payload size and parsing. |
-| `store` | bool | none | L (long term) | none | Whether responses persist for evals. Indirect knob. |
+| reasoning_effort | `"minimal"`, `"low"`, `"medium"`, `"high"` | **H** | **H** | **H** | The biggest knob in the OpenAI catalog. `high` can double accuracy on hard tasks — and 10× the bill. |
+| max_completion_tokens (replaces max_tokens) | 1 to model max | L | **H** | **H** | Reasoning tokens count against this budget. Underestimating clips the answer. |
+| verbosity (GPT-5 family) | `"low"`, `"medium"`, `"high"` | M | M | M | Affects how much the model says, independent of how much it thinks. |
+| reasoning.summary | `"auto"`, `"detailed"`, `null` | L | L | M | Whether to expose a reasoning summary. Affects payload size and parsing. |
+| store | bool | none | L (long term) | none | Whether responses persist for evals. Indirect knob. |
 
 ### Anthropic
 
-The Claude family (3.5, 3.7, 4, 4.5 — Haiku, Sonnet, Opus) is unique in two ways. First, the `system` field is far more load-bearing than on most providers — its structure and length consistently swing accuracy more than temperature does. Second, the extended-thinking knob on 3.7+ and Sonnet 4.5 has the same kind of dominance as OpenAI's `reasoning_effort`: large accuracy gains for proportionally larger cost. **Table 5.**
+The Claude family (3.5, 3.7, 4, 4.5 — Haiku, Sonnet, Opus) is unique in two ways. First, the system field is far more load-bearing than on most providers — its structure and length consistently swing accuracy more than temperature does. Second, the extended-thinking knob on 3.7+ and Sonnet 4.5 has the same kind of dominance as OpenAI's reasoning_effort: large accuracy gains for proportionally larger cost. **Table 5.**
 
 ### Table 5 — Anthropic (Claude family)
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
-| `thinking` (extended thinking — 3.7, 4, 4.5) | `{type: "enabled", budget_tokens: 1024+}` | **H** | **H** | **H** | Budget can range from 1K to many tens of thousands of tokens. Same family as OpenAI's reasoning_effort. |
-| `system` | string | **H** | M | M | The system prompt is far more load-bearing on Claude than on most providers. |
-| `tools` | array of definitions | **H** | M | M | Tool count + descriptions strongly bias which path the model takes. |
-| `tool_choice` | `"auto"`, `"any"`, `"tool"`, `"none"` | **H** | M | M | |
-| `max_tokens` | 1 to model max | L | **H** | **H** | Required parameter on Claude — there is no "model default." |
-| `disable_parallel_tool_use` | bool | M | M | **M–H** | Same shape as OpenAI's `parallel_tool_calls=false`. |
-| `stop_sequences` | array | L–M | L | L | |
-| `temperature` | 0 to 1 | M | none | none | Same role as OpenAI's. Reasoning Claude tolerates it less. Pure-accuracy knob. |
-| `top_p` | 0 to 1 | L–M | none | none | Pure-accuracy knob. |
-| `top_k` | integer ≥ 1 | L | none | none | Pure-accuracy knob. |
-| `metadata.user_id` | string | none | none | none | Compliance/abuse routing. Not a quality knob. |
+| thinking (extended thinking — 3.7, 4, 4.5) | `{type: "enabled", budget_tokens: 1024+}` | **H** | **H** | **H** | Budget can range from 1K to many tens of thousands of tokens. Same family as OpenAI's reasoning_effort. |
+| system | string | **H** | M | M | The system prompt is far more load-bearing on Claude than on most providers. |
+| tools | array of definitions | **H** | M | M | Tool count + descriptions strongly bias which path the model takes. |
+| tool_choice | `"auto"`, `"any"`, `"tool"`, `"none"` | **H** | M | M | |
+| max_tokens | 1 to model max | L | **H** | **H** | Required parameter on Claude — there is no "model default." |
+| disable_parallel_tool_use | bool | M | M | **M–H** | Same shape as OpenAI's `parallel_tool_calls=false`. |
+| stop_sequences | array | L–M | L | L | |
+| temperature | 0 to 1 | M | none | none | Same role as OpenAI's. Reasoning Claude tolerates it less. Pure-accuracy knob. |
+| top_p | 0 to 1 | L–M | none | none | Pure-accuracy knob. |
+| top_k | integer ≥ 1 | L | none | none | Pure-accuracy knob. |
+| metadata.user_id | string | none | none | none | Compliance/abuse routing. Not a quality knob. |
 
 ### Google Gemini
 
-Gemini (1.5 / 2.0 / 2.5 — Pro / Flash / Flash-Lite) deserves a callout for two specific knobs that are easy to miss: `cached_content` and `thinking_config`. Context caching is a real cost knob — if your agent ships a long, mostly-static system prompt and/or tool catalog, *not* caching can leave 30–50% savings on the table. `thinking_config` is the 2.5 family's reasoning toggle, same dominance pattern as OpenAI's and Anthropic's. **Table 6.**
+Gemini (1.5 / 2.0 / 2.5 — Pro / Flash / Flash-Lite) deserves a callout for two specific knobs that are easy to miss: cached_content and thinking_config. Context caching is a real cost knob — if your agent ships a long, mostly-static system prompt and/or tool catalog, *not* caching can leave 30–50% savings on the table. thinking_config is the 2.5 family's reasoning toggle, same dominance pattern as OpenAI's and Anthropic's. **Table 6.**
 
 ### Table 6 — Google Gemini
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
-| `thinking_config` / `thinking_budget` (2.5) | integer tokens (0 disables) | **H** | **H** | **H** | Same family as reasoning_effort / thinking on the other providers. |
-| `candidate_count` | integer ≥ 1 | M | **H** | **H** | Best-of-n. |
-| `max_output_tokens` | 1 to model max | L | **H** | **H** | |
-| `cached_content` | string handle | M (consistency) | **H** (savings) | M | Context caching can dramatically cut cost for long-context agents. |
-| `response_mime_type` | `"text/plain"`, `"application/json"` | **M–H** (JSON tasks) | L | L | |
-| `response_schema` | OpenAPI-flavor JSON schema | M | L | L | Structured output enforcement. Massively reduces parsing failure on extraction tasks. |
-| `temperature` | 0 to 2 | M | none | none | Pure-accuracy knob. |
-| `top_p` | 0 to 1 | L–M | none | none | Pure-accuracy knob. |
-| `top_k` | integer | L | none | none | Pure-accuracy knob. |
-| `safety_settings` | array of {category, threshold} | L (rejection rate) | none | none | Affects how often the model refuses, not how well it answers. |
+| thinking_config / thinking_budget (2.5) | integer tokens (0 disables) | **H** | **H** | **H** | Same family as reasoning_effort / thinking on the other providers. |
+| candidate_count | integer ≥ 1 | M | **H** | **H** | Best-of-n. |
+| max_output_tokens | 1 to model max | L | **H** | **H** | |
+| cached_content | string handle | M (consistency) | **H** (savings) | M | Context caching can dramatically cut cost for long-context agents. |
+| response_mime_type | `"text/plain"`, `"application/json"` | **M–H** (JSON tasks) | L | L | |
+| response_schema | OpenAPI-flavor JSON schema | M | L | L | Structured output enforcement. Massively reduces parsing failure on extraction tasks. |
+| temperature | 0 to 2 | M | none | none | Pure-accuracy knob. |
+| top_p | 0 to 1 | L–M | none | none | Pure-accuracy knob. |
+| top_k | integer | L | none | none | Pure-accuracy knob. |
+| safety_settings | array of {category, threshold} | L (rejection rate) | none | none | Affects how often the model refuses, not how well it answers. |
 
 ### Open-source (Llama / Mistral / Qwen / DeepSeek via vLLM / TGI / llama.cpp / Ollama)
 
-Open-source servers expose a *much* larger surface than the closed providers — because nothing is hidden behind a SaaS façade. The headline knob now is the explicit reasoning toggle on newer families (Qwen 3, DeepSeek R1). Quantization and speculative decoding aren't runtime knobs in the strict sense — they're deploy-time configuration — but they dominate cost and latency to a degree that's worth listing alongside the sampling knobs. The biggest *silent* accuracy killer on this list is `prompt_format`: using the wrong chat template for a model (Llama instruct vs Mistral instruct vs ChatML) commonly costs 10–30 points on benchmarks before you realize what's wrong. **Table 7.**
+Open-source servers expose a *much* larger surface than the closed providers — because nothing is hidden behind a SaaS façade. The headline knob now is the explicit reasoning toggle on newer families (Qwen 3, DeepSeek R1). Quantization and speculative decoding aren't runtime knobs in the strict sense — they're deploy-time configuration — but they dominate cost and latency to a degree that's worth listing alongside the sampling knobs. The biggest *silent* accuracy killer on this list is prompt_format: using the wrong chat template for a model (Llama instruct vs Mistral instruct vs ChatML) commonly costs 10–30 points on benchmarks before you realize what's wrong. **Table 7.**
 
 ### Table 7 — Open-source model serving stacks
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
-| `enable_thinking` (Qwen 3, DeepSeek R1, others) | bool | **H** | **H** | **H** | Reasoning toggle on newer open models. |
+| enable_thinking (Qwen 3, DeepSeek R1, others) | bool | **H** | **H** | **H** | Reasoning toggle on newer open models. |
 | Quantization (server-side) | fp16, fp8, int8, int4, awq, gptq, etc. | L–M | **H** (compute) | M | Deploy-time configuration that dominates cost. |
-| `n_ctx` allocation | tokens | L (if you have enough) | M (VRAM) | M | Bigger context allocation costs memory and can slow attention. |
+| n_ctx allocation | tokens | L (if you have enough) | M (VRAM) | M | Bigger context allocation costs memory and can slow attention. |
 | Speculative decoding draft model | model name | none | L | **M–H** | Speed without accuracy loss, *if* the draft model agrees often enough. |
-| `prompt_format` template | provider-specific | **H** | none | none | Wrong chat template = silent accuracy killer. Pure-accuracy knob with huge leverage. |
-| `mirostat_mode` / `mirostat_eta` / `mirostat_tau` | mode 0/1/2, floats | M | none | none | Adaptive sampling. llama.cpp / text-generation-webui only. Pure-accuracy. |
-| `min_p` | 0 to 1 | L–M | none | none | Newer sampling method; some teams prefer over top_p/top_k. Pure-accuracy. |
-| `repetition_penalty` | ~0.5 to 2 | L–M | none | none | Independent of presence/frequency penalty. Pure-accuracy. |
+| prompt_format template | provider-specific | **H** | none | none | Wrong chat template = silent accuracy killer. Pure-accuracy knob with huge leverage. |
+| mirostat_mode / mirostat_eta / mirostat_tau | mode 0/1/2, floats | M | none | none | Adaptive sampling. llama.cpp / text-generation-webui only. Pure-accuracy. |
+| min_p | 0 to 1 | L–M | none | none | Newer sampling method; some teams prefer over top_p/top_k. Pure-accuracy. |
+| repetition_penalty | ~0.5 to 2 | L–M | none | none | Independent of presence/frequency penalty. Pure-accuracy. |
 | Sampler order | list (e.g. `["top_k", "tfs", "typical_p", "top_p", "min_p", "temp"]`) | L–M | none | none | llama.cpp-style fine control. Pure-accuracy. |
-| `typical_p` | 0 to 1 | L | none | none | Locally typical sampling. Rarely worth tuning. Pure-accuracy. |
-| `repeat_last_n` | integer | L | none | none | How far back the repetition penalty looks. Pure-accuracy. |
+| typical_p | 0 to 1 | L | none | none | Locally typical sampling. Rarely worth tuning. Pure-accuracy. |
+| repeat_last_n | integer | L | none | none | How far back the repetition penalty looks. Pure-accuracy. |
 
 ---
 
@@ -216,13 +216,13 @@ Take a *modest* production agent: GPT-4o with chat-completion knobs only (no rea
 
 **Model side (7 reasonable knobs × ~5 reasonable values each):**
 
-- `temperature` ∈ {0, 0.2, 0.4, 0.7, 1.0}
-- `top_p` ∈ {0.5, 0.8, 0.95, 1.0, "off"}
-- `max_tokens` ∈ {256, 512, 1024, 2048, 4096}
-- `presence_penalty` ∈ {-0.5, 0, 0.5, 1, 1.5}
-- `response_format` ∈ {text, json_object, json_schema}
-- `parallel_tool_calls` ∈ {true, false}
-- `tool_choice` ∈ {auto, required}
+- temperature ∈ {0, 0.2, 0.4, 0.7, 1.0}
+- top_p ∈ {0.5, 0.8, 0.95, 1.0, "off"}
+- max_tokens ∈ {256, 512, 1024, 2048, 4096}
+- presence_penalty ∈ {-0.5, 0, 0.5, 1, 1.5}
+- response_format ∈ {text, json_object, json_schema}
+- parallel_tool_calls ∈ {true, false}
+- tool_choice ∈ {auto, required}
 
 5 × 5 × 5 × 5 × 3 × 2 × 2 = **15,000** combinations.
 
@@ -230,7 +230,7 @@ Take a *modest* production agent: GPT-4o with chat-completion knobs only (no rea
 
 - System prompt template ∈ {v1, v2, v3, v4}
 - Few-shot count ∈ {0, 2, 4, 8}
-- RAG `top_k` ∈ {3, 5, 10, 20}
+- RAG top_k ∈ {3, 5, 10, 20}
 - Embedding model ∈ {ada-3-small, ada-3-large, voyage-3, cohere-v3}
 - Reranker ∈ {none, cross-encoder, LLM}
 
@@ -238,7 +238,7 @@ Take a *modest* production agent: GPT-4o with chat-completion knobs only (no rea
 
 **Combined: ~11.5 million configurations.**
 
-This is the *conservative* version — five agent knobs out of the fifteen in Table 1. Drop in a reasoning model with `reasoning_effort` (×4) and a confidence threshold (×4), use all fifteen agent-level knobs, and you're well into the billions. None of this counts seeds, retries, fallback policies, or any kind of caching. None of this counts running the search against multiple evaluation datasets.
+This is the *conservative* version — five agent knobs out of the fifteen in Table 1. Drop in a reasoning model with reasoning_effort (×4) and a confidence threshold (×4), use all fifteen agent-level knobs, and you're well into the billions. None of this counts seeds, retries, fallback policies, or any kind of caching. None of this counts running the search against multiple evaluation datasets.
 
 A single LLM eval pass on a serious benchmark takes seconds to minutes. Eleven million seconds is four months. *Per model.* Per benchmark.
 
@@ -256,11 +256,11 @@ The skeptic's argument, in its strongest form:
 
 The first sentence is mostly true for model-level knobs taken in isolation. The second — the load-bearing one — falls apart on two counts.
 
-First, the agent-level tier breaks it on its own. As Table 1 lays out, the typical agent has roughly fifteen knobs *above* the model layer, and most of them are individually in the H column for accuracy. The agent layer doesn't need compounding for its effect to be large; one knob (system prompt, few-shot count, RAG `top_k`) often delivers an H-magnitude swing by itself.
+First, the agent-level tier breaks it on its own. As Table 1 lays out, the typical agent has roughly fifteen knobs *above* the model layer, and most of them are individually in the H column for accuracy. The agent layer doesn't need compounding for its effect to be large; one knob (system prompt, few-shot count, RAG top_k) often delivers an H-magnitude swing by itself.
 
 Second, the model-level tier doesn't survive compounding either. A few percent here, a few percent there, stacked across the model knobs in Tables 2–7, routinely compounds to 2–5× on cost and 10–30 percentage points on accuracy — well-known territory in the gap between a *bad* model-tier config and an *optimized* one.
 
-There's also a second-order effect that the skeptic underestimates: **the knobs aren't independent.** Raising `reasoning_effort` changes which `temperature` is optimal. Increasing RAG `top_k` changes which `top_p` is optimal. Swapping the embedding model changes which system prompt variant works best. These interactions are exactly what makes the configuration space too big to navigate by intuition — and exactly what an optimizer with memory of prior runs can exploit.
+There's also a second-order effect that the skeptic underestimates: **the knobs aren't independent.** Raising reasoning_effort changes which temperature is optimal. Increasing RAG top_k changes which top_p is optimal. Swapping the embedding model changes which system prompt variant works best. These interactions are exactly what makes the configuration space too big to navigate by intuition — and exactly what an optimizer with memory of prior runs can exploit.
 
 The skeptic's mistake isn't believing individual knobs are minor. It's believing the *consequences* are minor. They aren't.
 
@@ -271,7 +271,7 @@ The skeptic's mistake isn't believing individual knobs are minor. It's believing
 Three options, in increasing order of seriousness:
 
 1. **Acknowledge the space.** Stop shipping "we set temperature to 0 and called it a day." Treat configuration as a real engineering surface and write it down — which knobs, which values, which trade-offs. Tables 1–7 above are a starting template.
-2. **Sweep a small subset by hand.** Pick the 3–4 highest-leverage agent-level knobs for your specific workload (almost always: system prompt, few-shot count, RAG `top_k`, model choice). Run a manual A/B/C/D. Document what you found and why. This will get you most of the way there for the cost of a sprint.
+2. **Sweep a small subset by hand.** Pick the 3–4 highest-leverage agent-level knobs for your specific workload (almost always: system prompt, few-shot count, RAG top_k, model choice). Run a manual A/B/C/D. Document what you found and why. This will get you most of the way there for the cost of a sprint.
 3. **Use an optimizer.** Outsource the search to a system that picks the next configuration intelligently, converges on the cost-performance frontier, and re-optimizes when the world changes. That's exactly what Traigent does — and it's why we exist.
 
 There is no fourth option where you pick a config by gut and the math works out.

--- a/src/content/blog/the-config-multiverse.md
+++ b/src/content/blog/the-config-multiverse.md
@@ -2,7 +2,7 @@
 title: "The Configuration Multiverse: A Directory of Every Knob in Every Major Model — and Why Skeptics Are Still Wrong"
 slug: "the-config-multiverse"
 date: "2026-05-24"
-summary: "Every agent has two layers of configuration: the knobs you build on top (agent-level) and the knobs the model exposes (model-level). Agent-level dominates. Model-level is more numerous. Together they cross-multiply into millions of combinations — and the 'temperature doesn't matter' skeptic isn't wrong about temperature alone. They're wrong about the math."
+summary: "Every AI agent in production is the product of ~25 configuration decisions across two layers — agent-level decisions you designed yourself, and model-level knobs your provider exposes. Each has a handful of reasonable values. Multiplied out, the space is in the millions per model per workload. This post explains the math, then catalogs every knob in seven sorted tables."
 author: "Amir Barnea"
 readingTime: "13 min read"
 tags: "optimization,configuration,models,benchmarks,reasoning"
@@ -13,29 +13,23 @@ order: 7
 
 ---
 
-> *"Temperature doesn't matter much."*
->
-> *"top_p? Same thing as temperature. Skip it."*
->
-> *"I just pick `gpt-4o` at temperature 0 and ship. Done."*
+## The problem in one paragraph
 
-You've heard a version of this in every Slack channel that ships AI agents. It's not a stupid take. Any *one* of the knobs the major providers expose, taken in isolation, on a typical benchmark, will usually move a single metric by a handful of percentage points at most. Sometimes less.
+Every AI agent in production is the product of roughly twenty-five configuration decisions — about fifteen at the agent layer you designed yourself, about ten at the model layer your provider exposes. Each decision has a small handful of reasonable values. Multiplied out, this gives a configuration space in the millions, per model, per workload. Most teams pick one point in that space by gut and ship; many of them ship the wrong one and never find out.
 
-The trap is the word "isolation." You don't ship one knob. You ship *all* of them, at once, against a real workload — and the values you didn't think about get picked by your SDK's defaults, which were chosen by someone who has no idea what your agent does.
+The rest of this post does three things. **First**, it shows the math of *why* the configuration space is that big — the two-tier structure, the multiplication, the way small effects compound. **Second**, it provides a directory — seven tables, sorted by impact — covering the agent-layer knobs you build on top plus every model-layer knob the major providers expose. **Third**, it explains what to do about all this without spending a quarter on grid search.
 
-This post is two things at once. The article makes the qualitative and quantitative argument. The tables — seven of them, sorted by impact — are the reference directory you can come back to when you're tuning a specific stack.
+---
 
-## The two tiers, in order of importance
+## The configuration space, in two tiers
 
-Every agent has two distinct layers of configuration, and they're not equal.
+The first thing to understand is that there are two distinct layers of configuration, and they're not equal.
 
-**Agent-level knobs** are the ones *you* design when you build the agent: system prompt structure, few-shot examples, retrieval top_k, embedding model, reranker, memory window, retry policy, tool selection, caching. They live in your code, not in the model's API. They are mostly invisible to the model provider's docs.
+**Agent-level knobs** are decisions you make when you build the agent: system prompt structure, few-shot examples, retrieval top_k, embedding model, reranker, memory window, retry policy, tool selection, caching. They live in your code, not in the model's API. They are mostly invisible to the model provider's docs.
 
-**Model-level knobs** are the ones the provider exposes: temperature, top_p, max_tokens, response_format, tool_choice, reasoning_effort, thinking_budget. They live in the request body. The provider's docs enumerate them; their defaults are picked for the median customer, who is not you.
+**Model-level knobs** are decisions the provider exposes: temperature, top_p, max_tokens, response_format, tool_choice, reasoning_effort, thinking_budget. They live in the request body. The provider's docs enumerate them; their defaults are picked for the median customer, who is not you.
 
-**Agent-level knobs dominate model-level knobs in impact, by a wide margin.**
-
-This sounds counter-intuitive — the model is the expensive part, the model has the cool brand names, the model is where the press releases live. But every working production agent we've seen says the same thing: changing the system prompt structure, the few-shot count, or the retrieval top_k reliably swings accuracy 10–30 percentage points on the same eval. Changing temperature on the same agent rarely moves it more than 3–5. The model layer is the engine. The agent layer is the chassis, the transmission, the route, and the driver. The engine matters; everything else matters more, in aggregate.
+**Agent-level knobs dominate model-level knobs in impact, by a wide margin.** Changing the system prompt structure, the few-shot count, or retrieval top_k reliably swings accuracy 10–30 percentage points on the same eval. Changing temperature on the same agent rarely moves it more than 3–5. The model is the engine; the agent layer is the chassis, the transmission, the route, and the driver. The engine matters; everything else matters more, in aggregate.
 
 Why the agent layer dominates:
 
@@ -43,37 +37,83 @@ Why the agent layer dominates:
 2. **Agent-level knobs change the model's *input*.** Model-level knobs change how the model decodes a *given* input. Changing the input is almost always more powerful than re-decoding the same input differently.
 3. **Agent-level knobs interact with the model's strengths and weaknesses.** A good system prompt on a mediocre model often beats a mediocre system prompt on a flagship model — and costs a third as much.
 
-So the article proceeds in order of importance: agent-level first (Table 1), then the model-level tier that's universal across providers (Table 2), then the per-provider model-level knobs (Tables 3–7). The math at the end multiplies everything together.
+### The math, with realistic numbers
 
-### How to read the tables
+Take a *modest* production agent: GPT-4o (chat-completion, no reasoning model), plus a basic RAG pipeline.
 
-For each knob you'll see three impact tags:
+**Model side** — 7 reasonable knobs × ~5 reasonable values each:
+
+- temperature ∈ {0, 0.2, 0.4, 0.7, 1.0}
+- top_p ∈ {0.5, 0.8, 0.95, 1.0, "off"}
+- max_tokens ∈ {256, 512, 1024, 2048, 4096}
+- presence_penalty ∈ {-0.5, 0, 0.5, 1, 1.5}
+- response_format ∈ {text, json_object, json_schema}
+- parallel_tool_calls ∈ {true, false}
+- tool_choice ∈ {auto, required}
+
+5 × 5 × 5 × 5 × 3 × 2 × 2 = **15,000** combinations.
+
+**Agent side** — 5 knobs × ~4 values each:
+
+- System prompt template ∈ {v1, v2, v3, v4}
+- Few-shot count ∈ {0, 2, 4, 8}
+- RAG top_k ∈ {3, 5, 10, 20}
+- Embedding model ∈ {ada-3-small, ada-3-large, voyage-3, cohere-v3}
+- Reranker ∈ {none, cross-encoder, LLM}
+
+4 × 4 × 4 × 4 × 3 = **768** combinations.
+
+**Combined: ~11.5 million configurations.**
+
+This is the *conservative* version — five agent knobs out of the fifteen catalogued in Table 1 below. Drop in a reasoning model with reasoning_effort (×4 more), use all fifteen agent-level knobs, and you're well into the billions. None of this counts running the search against multiple evaluation datasets, different seeds, retry policies, fallback models, or caching layers.
+
+A single LLM eval pass on a serious benchmark takes seconds to minutes. Eleven million seconds is four months. *Per model. Per benchmark.*
+
+You can't grid-search this. You can't even random-search it meaningfully — sparse random sampling in a 12-dimensional space hits sub-1% coverage almost immediately. **The only sane response is empirical optimization that converges** — picks the next configuration based on what previous configurations revealed, instead of sampling blindly.
+
+### The compounding problem
+
+A common objection at this point is that yes, the space is big, but each individual knob is small — so picking sensible defaults and moving on is fine. The math doesn't agree.
+
+**The agent-level tier breaks the objection on its own.** The typical agent has roughly fifteen knobs above the model layer (Table 1), and most of them are individually in the H column for accuracy. The agent layer doesn't need compounding for its effect to be large; one knob — a better system prompt, a better few-shot strategy, a better retrieval top_k — often delivers an H-magnitude swing by itself.
+
+**The model-level tier doesn't survive compounding either.** A few percent here, a few percent there, stacked across the model knobs in Tables 2–7, routinely compounds to 2–5× on cost and 10–30 percentage points on accuracy. That's the well-known gap between a bad model-tier config and an optimized one.
+
+**And the knobs aren't independent.** Raising reasoning_effort changes which temperature is optimal. Increasing RAG top_k changes which top_p is optimal. Swapping the embedding model changes which system prompt variant works best. These interactions are exactly what makes the space too big to navigate by intuition — and exactly what an optimizer with memory of prior runs can exploit.
+
+The mistake isn't believing individual knobs are minor. It's believing the consequences are minor.
+
+The full directory of every knob, sorted by impact, follows in **Tables 1–7 below**. If you want the punchline before the reference material:
+
+## What to do about it
+
+Three options, in increasing order of seriousness:
+
+1. **Acknowledge the space.** Stop shipping "we set temperature to 0 and called it a day." Treat configuration as a real engineering surface and write it down — which knobs, which values, which trade-offs. Tables 1–7 below are a starting template.
+2. **Sweep a small subset by hand.** Pick the 3–4 highest-leverage agent-level knobs for your specific workload (almost always: system prompt, few-shot count, RAG top_k, model choice). Run a manual A/B/C/D. Document what you found and why. This will get you most of the way there for the cost of a sprint.
+3. **Use an optimizer.** Outsource the search to a system that picks the next configuration intelligently, converges on the cost-performance frontier, and re-optimizes when the world changes. That's exactly what Traigent does — and it's why we exist.
+
+There is no fourth option where you pick a config by gut and the math works out.
+
+---
+
+## The directory: seven tables, sorted by impact
+
+For each knob below you'll see three impact tags:
 
 - **L (Low)** — typical isolated effect under ~3 percentage points on the relevant metric for most workloads.
 - **M (Medium)** — typical isolated effect 3–15 percentage points. Big enough to notice on an A/B test.
 - **H (High)** — typical isolated effect can exceed 15 percentage points. Order-of-magnitude swings on specific workloads are routine.
 
-A few rules before the tables:
+A few caveats before you read them:
 
-- **No global percentages.** Anyone who quotes "temperature shifts accuracy by 4.2%" without naming a benchmark and a workload is selling something. The L/M/H tags are *typical ranges across the kinds of agent workloads we see* — not promises for your specific use case.
+- **No global percentages.** Anyone who quotes "temperature shifts accuracy by 4.2%" without naming a benchmark and a workload is selling something. The L/M/H tags are typical ranges across the kinds of agent workloads we see — not promises for your specific use case.
 - **A, C, and L are independent dimensions.** A knob can be L on accuracy and H on cost (e.g., max_tokens), and that asymmetry is itself a configuration decision.
 - **Tables are sorted by impact within each tier.** Knobs at the top affect multiple dimensions (accuracy *and* cost, or accuracy *and* latency). Knobs at the bottom typically affect only one dimension — often accuracy alone, which makes them important when you have the budget to optimize but easy to deprioritize when you don't.
 
----
-
-## Layer 1 — Agent-level knobs (the dominant tier)
-
-This is where most of the variance in your agent's behavior lives. Three concrete examples before the table.
-
-**System prompt structure.** Same model, same task, two different system prompts. We routinely see 20+ point accuracy swings between a 3-line "you are a helpful assistant" template and a structured 200-line system with role definition, examples, hard constraints, and output schema. On Claude specifically, the *format* of the system prompt (XML tags vs prose vs markdown) is itself a knob that can swing accuracy further. This is rarely treated as a hyperparameter, but it should be.
-
-**Few-shot count.** Going from 0 to 4 well-chosen examples typically delivers more accuracy than swapping `gpt-4o-mini` for `gpt-4o` on the same task — at a fraction of the per-call cost increase. The optimum is workload-specific (too many examples and you blow context budget or trigger "lost in the middle" effects) and almost nobody finds it by intuition. **Table 1** shows the rest of the agent-level tier.
-
-**Retrieval top_k and chunk size.** In any agent with a RAG component, the retrieval parameters dominate the downstream model parameters. Doubling top_k from 5 to 10 commonly shifts accuracy 5–15 points on QA tasks — comparable to a model-tier upgrade, at a marginal cost. Halving chunk size from 800 to 400 tokens often improves retrieval precision but doubles index size and latency. These are the knobs nobody at the LLM provider can tune for you.
-
-What follows is the full agent-level table. Note that the last three rows (embedding model, few-shot selection method, few-shot ordering) are listed last *not because they're unimportant* — they all can swing accuracy heavily — but because their effect is concentrated on the accuracy axis with no direct cost or latency impact. They're the items easiest to overlook in a quarterly review focused on the bill.
-
 ### Table 1 — Agent-level knobs
+
+The dominant tier. Fifteen knobs covering system-prompt design, few-shot strategy, retrieval pipeline, memory, retries, tool routing, and caching. The last three rows (embedding model, few-shot selection, few-shot ordering) are listed last *not because they're unimportant* — they all swing accuracy heavily — but because their effect is concentrated on accuracy with no direct cost or latency impact, which makes them easy to overlook in a quarterly review focused on the bill.
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
@@ -93,21 +133,9 @@ What follows is the full agent-level table. Note that the last three rows (embed
 | Few-shot selection method | random / semantic-similar / hard-coded / diverse | **H** | none | none | Free upgrade for retrieval-augmented few-shotting. Pure-accuracy knob. |
 | Few-shot ordering | first, last, random | M | none | none | "Lost in the middle" is real: position matters. Pure-accuracy knob. |
 
-Fifteen knobs, ~4 reasonable values each. That alone is on the order of 10⁹ combinations *before* you touch the model layer.
-
----
-
-## Layer 2 — Model-level knobs (the long tail)
-
-Smaller per-knob, but more numerous, and they compound. Five tables: one for the knobs nearly every model exposes (the universal tier), then one per major provider family.
-
-### The universal tier
-
-Every chat model exposes most of these. Defaults vary wildly between SDKs and you've probably never thought about most of them.
-
-The two top entries — n / candidate_count (best-of-n) and max_tokens — are special: both are H on cost and latency. They're the model-level knobs most directly tied to your bill and your p99 latency. Everything below the line is mostly an accuracy/determinism trade. **Table 2.**
-
 ### Table 2 — Universal tier (chat models, all providers)
+
+The knobs nearly every chat model exposes. Defaults vary wildly between SDKs and you've probably never thought about most of them. The top entries — n / candidate_count (best-of-n) and max_tokens — are special: both are H on cost and latency. They're the model-level knobs most directly tied to your bill and your p99. Everything below the line is mostly an accuracy/determinism trade.
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
@@ -119,15 +147,9 @@ The two top entries — n / candidate_count (best-of-n) and max_tokens — are s
 | top_k | 1 to vocab size | L | none | none | Hard cap on candidate tokens. Most providers default it sensibly. |
 | seed (where supported) | integer | 0 *on average* | none | none | Determinism, not quality. Critical for reproducible evals — irrelevant for users. |
 
-### OpenAI
+### Table 3 — OpenAI chat models (GPT-4o, GPT-4o-mini, GPT-3.5-turbo)
 
-OpenAI now ships two distinct families with different knob surfaces. Worth treating them separately because the *reasoning* family has knobs that frequently dwarf everything else in this entire directory.
-
-For the **chat family** (GPT-4o, GPT-4o-mini, GPT-3.5-turbo), the qualitative point is: tool_choice and parallel_tool_calls are the action-shaping knobs that change the agent's *behavior class*, not just its decoding. Forcing `tool_choice: required` versus `auto` is the difference between a deterministic pipeline and an open-ended agent. Disabling parallel_tool_calls serializes a plan that would otherwise run concurrently, which can double end-to-end latency on multi-tool agents. **Table 3.**
-
-For the **reasoning family** (o1, o3, o3-mini, o3-pro, o4-mini, GPT-5, GPT-5-mini, GPT-5-nano), one knob — reasoning_effort — typically swamps every other model-level knob. Moving from `low` to `high` on a hard math or code benchmark can double accuracy and 10× the bill. There is no other model-level decision in this whole post with that kind of leverage. **Table 4.**
-
-### Table 3 — OpenAI chat models
+For the OpenAI chat family, tool_choice and parallel_tool_calls are the action-shaping knobs that change the agent's behavior class, not just its decoding. Forcing tool_choice: required versus auto is the difference between a deterministic pipeline and an open-ended agent. Disabling parallel_tool_calls serializes a plan that would otherwise run concurrently — commonly a 2× latency hit on multi-tool agents.
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
@@ -136,10 +158,12 @@ For the **reasoning family** (o1, o3, o3-mini, o3-pro, o4-mini, GPT-5, GPT-5-min
 | service_tier (where available) | `"auto"` / `"default"` / `"flex"` | L (if any) | M | M | Trades cost for predictable latency. |
 | response_format | `{type: "text" \| "json_object" \| "json_schema"}` | **M–H** (on JSON tasks) | L | L | Schema-enforced JSON dramatically reduces parsing-failure cost on extraction agents. |
 | logprobs / top_logprobs | bool, integer | none | L | L (overhead) | Critical for self-consistency / confidence routing; otherwise noise. |
-| presence_penalty | -2 to 2 | L | none | none | Pushes the model toward (or away from) novel tokens. Subtle on most chat tasks. Pure-accuracy knob. |
-| frequency_penalty | -2 to 2 | L | none | none | Suppresses repetition. Bigger effect on long outputs. Pure-accuracy knob. |
+| presence_penalty | -2 to 2 | L | none | none | Pushes the model toward (or away from) novel tokens. Subtle on most chat tasks. Pure-accuracy. |
+| frequency_penalty | -2 to 2 | L | none | none | Suppresses repetition. Bigger effect on long outputs. Pure-accuracy. |
 
-### Table 4 — OpenAI reasoning models (o-series, GPT-5)
+### Table 4 — OpenAI reasoning models (o1, o3, o3-mini, o4-mini, GPT-5, GPT-5-mini, GPT-5-nano)
+
+The reasoning family adds a knob — reasoning_effort — that typically swamps every other model-level knob in this whole directory. Moving from `"low"` to `"high"` on a hard math or code benchmark can double accuracy and 10× the bill. There is no other model-level decision in this post with that kind of leverage.
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
@@ -149,11 +173,9 @@ For the **reasoning family** (o1, o3, o3-mini, o3-pro, o4-mini, GPT-5, GPT-5-min
 | reasoning.summary | `"auto"`, `"detailed"`, `null` | L | L | M | Whether to expose a reasoning summary. Affects payload size and parsing. |
 | store | bool | none | L (long term) | none | Whether responses persist for evals. Indirect knob. |
 
-### Anthropic
+### Table 5 — Anthropic (Claude 3.5 / 3.7 / 4 / 4.5 — Haiku / Sonnet / Opus)
 
-The Claude family (3.5, 3.7, 4, 4.5 — Haiku, Sonnet, Opus) is unique in two ways. First, the system field is far more load-bearing than on most providers — its structure and length consistently swing accuracy more than temperature does. Second, the extended-thinking knob on 3.7+ and Sonnet 4.5 has the same kind of dominance as OpenAI's reasoning_effort: large accuracy gains for proportionally larger cost. **Table 5.**
-
-### Table 5 — Anthropic (Claude family)
+Claude is unique in two ways. First, the `system` field is far more load-bearing than on most providers — its structure and length consistently swing accuracy more than temperature does. Second, the extended-thinking knob on 3.7+ and Sonnet 4.5 has the same kind of dominance as OpenAI's reasoning_effort.
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
@@ -162,18 +184,16 @@ The Claude family (3.5, 3.7, 4, 4.5 — Haiku, Sonnet, Opus) is unique in two wa
 | tools | array of definitions | **H** | M | M | Tool count + descriptions strongly bias which path the model takes. |
 | tool_choice | `"auto"`, `"any"`, `"tool"`, `"none"` | **H** | M | M | |
 | max_tokens | 1 to model max | L | **H** | **H** | Required parameter on Claude — there is no "model default." |
-| disable_parallel_tool_use | bool | M | M | **M–H** | Same shape as OpenAI's `parallel_tool_calls=false`. |
+| disable_parallel_tool_use | bool | M | M | **M–H** | Same shape as OpenAI's parallel_tool_calls=false. |
 | stop_sequences | array | L–M | L | L | |
-| temperature | 0 to 1 | M | none | none | Same role as OpenAI's. Reasoning Claude tolerates it less. Pure-accuracy knob. |
-| top_p | 0 to 1 | L–M | none | none | Pure-accuracy knob. |
-| top_k | integer ≥ 1 | L | none | none | Pure-accuracy knob. |
+| temperature | 0 to 1 | M | none | none | Same role as OpenAI's. Reasoning Claude tolerates it less. Pure-accuracy. |
+| top_p | 0 to 1 | L–M | none | none | Pure-accuracy. |
+| top_k | integer ≥ 1 | L | none | none | Pure-accuracy. |
 | metadata.user_id | string | none | none | none | Compliance/abuse routing. Not a quality knob. |
 
-### Google Gemini
+### Table 6 — Google Gemini (1.5 / 2.0 / 2.5 — Pro / Flash / Flash-Lite)
 
-Gemini (1.5 / 2.0 / 2.5 — Pro / Flash / Flash-Lite) deserves a callout for two specific knobs that are easy to miss: cached_content and thinking_config. Context caching is a real cost knob — if your agent ships a long, mostly-static system prompt and/or tool catalog, *not* caching can leave 30–50% savings on the table. thinking_config is the 2.5 family's reasoning toggle, same dominance pattern as OpenAI's and Anthropic's. **Table 6.**
-
-### Table 6 — Google Gemini
+Gemini has two specific knobs worth a callout: cached_content and thinking_config. Context caching is a real cost knob — if your agent ships a long, mostly-static system prompt and/or tool catalog, *not* caching can leave 30–50% savings on the table. thinking_config is the 2.5 family's reasoning toggle, same dominance pattern as OpenAI's and Anthropic's.
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
@@ -183,16 +203,14 @@ Gemini (1.5 / 2.0 / 2.5 — Pro / Flash / Flash-Lite) deserves a callout for two
 | cached_content | string handle | M (consistency) | **H** (savings) | M | Context caching can dramatically cut cost for long-context agents. |
 | response_mime_type | `"text/plain"`, `"application/json"` | **M–H** (JSON tasks) | L | L | |
 | response_schema | OpenAPI-flavor JSON schema | M | L | L | Structured output enforcement. Massively reduces parsing failure on extraction tasks. |
-| temperature | 0 to 2 | M | none | none | Pure-accuracy knob. |
-| top_p | 0 to 1 | L–M | none | none | Pure-accuracy knob. |
-| top_k | integer | L | none | none | Pure-accuracy knob. |
+| temperature | 0 to 2 | M | none | none | Pure-accuracy. |
+| top_p | 0 to 1 | L–M | none | none | Pure-accuracy. |
+| top_k | integer | L | none | none | Pure-accuracy. |
 | safety_settings | array of {category, threshold} | L (rejection rate) | none | none | Affects how often the model refuses, not how well it answers. |
 
-### Open-source (Llama / Mistral / Qwen / DeepSeek via vLLM / TGI / llama.cpp / Ollama)
+### Table 7 — Open-source model serving stacks (Llama / Mistral / Qwen / DeepSeek via vLLM / TGI / llama.cpp / Ollama)
 
-Open-source servers expose a *much* larger surface than the closed providers — because nothing is hidden behind a SaaS façade. The headline knob now is the explicit reasoning toggle on newer families (Qwen 3, DeepSeek R1). Quantization and speculative decoding aren't runtime knobs in the strict sense — they're deploy-time configuration — but they dominate cost and latency to a degree that's worth listing alongside the sampling knobs. The biggest *silent* accuracy killer on this list is prompt_format: using the wrong chat template for a model (Llama instruct vs Mistral instruct vs ChatML) commonly costs 10–30 points on benchmarks before you realize what's wrong. **Table 7.**
-
-### Table 7 — Open-source model serving stacks
+Open-source servers expose a much larger surface than the closed providers — nothing is hidden behind a SaaS façade. The headline knob now is the explicit reasoning toggle on newer families (Qwen 3, DeepSeek R1). Quantization and speculative decoding aren't runtime knobs in the strict sense — they're deploy-time configuration — but they dominate cost and latency to a degree that's worth listing alongside the sampling knobs. The biggest *silent* accuracy killer on this list is prompt_format: using the wrong chat template for a model (Llama instruct vs Mistral instruct vs ChatML) commonly costs 10–30 points on benchmarks before you realize what's wrong.
 
 | Knob | Range / values | A | C | L | Why it matters |
 |---|---|---|---|---|---|
@@ -207,74 +225,6 @@ Open-source servers expose a *much* larger surface than the closed providers —
 | Sampler order | list (e.g. `["top_k", "tfs", "typical_p", "top_p", "min_p", "temp"]`) | L–M | none | none | llama.cpp-style fine control. Pure-accuracy. |
 | typical_p | 0 to 1 | L | none | none | Locally typical sampling. Rarely worth tuning. Pure-accuracy. |
 | repeat_last_n | integer | L | none | none | How far back the repetition penalty looks. Pure-accuracy. |
-
----
-
-## The cardinality, with the math actually written out
-
-Take a *modest* production agent: GPT-4o with chat-completion knobs only (no reasoning model, no fancy tool routing), plus a basic RAG pipeline.
-
-**Model side (7 reasonable knobs × ~5 reasonable values each):**
-
-- temperature ∈ {0, 0.2, 0.4, 0.7, 1.0}
-- top_p ∈ {0.5, 0.8, 0.95, 1.0, "off"}
-- max_tokens ∈ {256, 512, 1024, 2048, 4096}
-- presence_penalty ∈ {-0.5, 0, 0.5, 1, 1.5}
-- response_format ∈ {text, json_object, json_schema}
-- parallel_tool_calls ∈ {true, false}
-- tool_choice ∈ {auto, required}
-
-5 × 5 × 5 × 5 × 3 × 2 × 2 = **15,000** combinations.
-
-**Agent side (5 knobs × ~4 values each):**
-
-- System prompt template ∈ {v1, v2, v3, v4}
-- Few-shot count ∈ {0, 2, 4, 8}
-- RAG top_k ∈ {3, 5, 10, 20}
-- Embedding model ∈ {ada-3-small, ada-3-large, voyage-3, cohere-v3}
-- Reranker ∈ {none, cross-encoder, LLM}
-
-4 × 4 × 4 × 4 × 3 = **768** combinations.
-
-**Combined: ~11.5 million configurations.**
-
-This is the *conservative* version — five agent knobs out of the fifteen in Table 1. Drop in a reasoning model with reasoning_effort (×4) and a confidence threshold (×4), use all fifteen agent-level knobs, and you're well into the billions. None of this counts seeds, retries, fallback policies, or any kind of caching. None of this counts running the search against multiple evaluation datasets.
-
-A single LLM eval pass on a serious benchmark takes seconds to minutes. Eleven million seconds is four months. *Per model.* Per benchmark.
-
-You can't grid-search this. You can't even random-search it meaningfully — sparse random sampling in a 12-dimensional space hits sub-1% coverage almost immediately. The only sane response is empirical optimization that converges — picks the next configuration based on what previous configurations revealed, instead of sampling blindly.
-
-That's the actual rebuttal to the skeptic. Not "temperature matters more than you think." It's "you don't have time to *check* whether temperature matters more than you think."
-
----
-
-## The skeptic, addressed directly
-
-The skeptic's argument, in its strongest form:
-
-> "Each individual knob, on a typical workload, shifts accuracy by a few percentage points at most. Engineering time spent tuning is engineering time not spent shipping. Pick reasonable defaults and move on."
-
-The first sentence is mostly true for model-level knobs taken in isolation. The second — the load-bearing one — falls apart on two counts.
-
-First, the agent-level tier breaks it on its own. As Table 1 lays out, the typical agent has roughly fifteen knobs *above* the model layer, and most of them are individually in the H column for accuracy. The agent layer doesn't need compounding for its effect to be large; one knob (system prompt, few-shot count, RAG top_k) often delivers an H-magnitude swing by itself.
-
-Second, the model-level tier doesn't survive compounding either. A few percent here, a few percent there, stacked across the model knobs in Tables 2–7, routinely compounds to 2–5× on cost and 10–30 percentage points on accuracy — well-known territory in the gap between a *bad* model-tier config and an *optimized* one.
-
-There's also a second-order effect that the skeptic underestimates: **the knobs aren't independent.** Raising reasoning_effort changes which temperature is optimal. Increasing RAG top_k changes which top_p is optimal. Swapping the embedding model changes which system prompt variant works best. These interactions are exactly what makes the configuration space too big to navigate by intuition — and exactly what an optimizer with memory of prior runs can exploit.
-
-The skeptic's mistake isn't believing individual knobs are minor. It's believing the *consequences* are minor. They aren't.
-
----
-
-## What to do about it
-
-Three options, in increasing order of seriousness:
-
-1. **Acknowledge the space.** Stop shipping "we set temperature to 0 and called it a day." Treat configuration as a real engineering surface and write it down — which knobs, which values, which trade-offs. Tables 1–7 above are a starting template.
-2. **Sweep a small subset by hand.** Pick the 3–4 highest-leverage agent-level knobs for your specific workload (almost always: system prompt, few-shot count, RAG top_k, model choice). Run a manual A/B/C/D. Document what you found and why. This will get you most of the way there for the cost of a sprint.
-3. **Use an optimizer.** Outsource the search to a system that picks the next configuration intelligently, converges on the cost-performance frontier, and re-optimizes when the world changes. That's exactly what Traigent does — and it's why we exist.
-
-There is no fourth option where you pick a config by gut and the math works out.
 
 ---
 

--- a/src/content/blog/the-model-myth.md
+++ b/src/content/blog/the-model-myth.md
@@ -7,7 +7,7 @@ author: "Amir Barnea"
 readingTime: "6 min read"
 tags: "optimization,configuration,llm-cost"
 featured: true
-order: 2
+order: 3
 ---
 
 *A common assumption in AI engineering goes like this:*

--- a/src/content/blog/the-reoptimization-imperative.md
+++ b/src/content/blog/the-reoptimization-imperative.md
@@ -7,7 +7,7 @@ author: "Amir Barnea"
 readingTime: "5 min read"
 tags: "optimization,lifecycle,cost"
 featured: true
-order: 3
+order: 4
 ---
 
 *The most common reason teams under-invest in optimization:*

--- a/src/lib/blog.js
+++ b/src/lib/blog.js
@@ -29,6 +29,7 @@ const posts = Object.entries(modules).map(([path, raw]) => {
   return {
     slug: meta.slug || filename,
     title: meta.title || filename,
+    subtitle: meta.subtitle || "",
     date: meta.date || "",
     summary: meta.summary || "",
     author: meta.author || "",

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -54,9 +54,14 @@ export default function Blog() {
                 >
                   <Link to={`/blog/${post.slug}`} className="block group">
                     <PostMetadata post={post} className="mb-3" />
-                    <h2 className="text-2xl md:text-3xl font-bold text-white mb-3 group-hover:text-[#4D8EF8] transition-colors leading-tight">
+                    <h2 className="text-2xl md:text-3xl font-bold text-white mb-2 group-hover:text-[#4D8EF8] transition-colors leading-tight">
                       {post.title}
                     </h2>
+                    {post.subtitle && (
+                      <p className="text-base md:text-lg text-slate-300 italic leading-relaxed mb-3">
+                        {post.subtitle}
+                      </p>
+                    )}
                     <p className="text-slate-400 leading-relaxed mb-4">{post.summary}</p>
                     <div className="inline-flex items-center gap-1.5 text-sm font-medium text-[#1A6BF5] group-hover:text-[#4D8EF8] transition-colors">
                       Read →

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -46,9 +46,32 @@ const mdComponents = {
       {...props}
     />
   ),
-  a: ({ node, ...props }) => (
-    <a className="text-[#1A6BF5] hover:text-[#4D8EF8] underline underline-offset-4 transition-colors" {...props} />
-  ),
+  a: ({ node, href, children, ...props }) => {
+    const linkClass = "text-[#1A6BF5] hover:text-[#4D8EF8] underline underline-offset-4 transition-colors";
+    // External: open in new tab.
+    if (href && /^https?:\/\//i.test(href)) {
+      return (
+        <a href={href} target="_blank" rel="noopener noreferrer" className={linkClass} {...props}>
+          {children}
+        </a>
+      );
+    }
+    // Internal app route — must go through React Router Link so HashRouter
+    // prepends the `#`, otherwise the browser does a hard nav to /roi and 404s.
+    if (href && href.startsWith("/")) {
+      return (
+        <Link to={href} className={linkClass} {...props}>
+          {children}
+        </Link>
+      );
+    }
+    // In-page anchor (#section) or other — leave as a plain anchor.
+    return (
+      <a href={href} className={linkClass} {...props}>
+        {children}
+      </a>
+    );
+  },
   code: ({ node, inline, className, children, ...props }) =>
     inline ? (
       <code className="px-1.5 py-0.5 rounded bg-slate-800 text-[#93c5fd] text-[0.9em] font-mono" {...props}>

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -132,6 +132,11 @@ export default function BlogPost() {
             <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white tracking-tight leading-tight">
               {post.title}
             </h1>
+            {post.subtitle && (
+              <p className="mt-3 text-lg md:text-xl text-slate-300 italic leading-relaxed">
+                {post.subtitle}
+              </p>
+            )}
             {post.author && (
               <p className="mt-6 text-slate-500 text-sm">By {post.author}</p>
             )}

--- a/src/pages/OnePager.jsx
+++ b/src/pages/OnePager.jsx
@@ -1,237 +1,322 @@
-import { ArrowRight } from "lucide-react";
+// Outreach one-pager: 2-slide A4 landscape artifact for sales/marketing use.
+// Renders at native A4 landscape (1123×794 @ 96 DPI). Print CSS forces one
+// slide per page. URL links are absolute https://www.traigent.ai/... so they
+// resolve correctly when a recipient clicks them from inside a PDF.
 import { Helmet } from "react-helmet-async";
-import ProblemSolutionSection from "../components/ProblemSolutionSection";
+import {
+  AlertTriangle,
+  Clock,
+  Layers,
+  Target,
+  ArrowRight,
+  Zap,
+  TrendingDown,
+  ShieldCheck,
+} from "lucide-react";
 
-const SectionHeader = ({ children }) => (
-  <div className="bg-blue-500 text-white font-bold text-xl md:text-2xl px-6 py-3 rounded-lg mb-4">
-    {children}
-  </div>
-);
+const BLUE = "#1A6BF5";
+const BLUE_LIGHT = "#4D8EF8";
+const AMBER = "#f59e0b";
+const RED = "#f87171";
+const SITE = "https://www.traigent.ai";
 
-export default function OnePager() {
+const LOGO_SRC =
+  "https://qtrypzzcjebvfcihiynt.supabase.co/storage/v1/object/public/base44-prod/public/057ce2_TraigentLogoWhiteCropped.png";
+
+// ---------- Small building blocks ----------
+function ACTag() {
   return (
-    <div className="bg-slate-950 min-h-screen">
-      <Helmet>
-        <title>One Pager · Traigent</title>
-        <meta name="description" content="Traigent at a glance — the AI Agent Optimization Platform that finds the best cost-performance configuration in hours, automatically." />
-        <meta property="og:title" content="Traigent — One Pager" />
-        <meta property="og:description" content="Traigent at a glance: AI Agent Optimization Platform. Hours not weeks. Automatically not manually." />
-        <meta property="og:type" content="website" />
-      </Helmet>
-      <div className="max-w-6xl mx-auto px-6 py-12">
-        {/* Logo */}
-        <div className="mb-10">
-          <img
-            src="https://qtrypzzcjebvfcihiynt.supabase.co/storage/v1/object/public/base44-prod/public/057ce2_TraigentLogoWhiteCropped.png"
-            alt="Traigent"
-            className="h-14"
+    <div className="flex items-center gap-1.5">
+      <span
+        className="inline-block text-[10px] font-mono font-bold px-1.5 py-0.5 rounded"
+        style={{ color: BLUE_LIGHT, backgroundColor: `${BLUE}22`, border: `1px solid ${BLUE}55` }}
+        title="Affects Accuracy"
+      >
+        A
+      </span>
+      <span
+        className="inline-block text-[10px] font-mono font-bold px-1.5 py-0.5 rounded"
+        style={{ color: AMBER, backgroundColor: `${AMBER}22`, border: `1px solid ${AMBER}55` }}
+        title="Affects Cost"
+      >
+        C
+      </span>
+    </div>
+  );
+}
+
+function ProblemPanel({ icon: Icon, title, number, numberColor, line }) {
+  return (
+    <div className="bg-slate-900/70 border border-slate-700/60 rounded-xl p-5 flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-slate-400">
+          <Icon className="w-4 h-4" />
+          <span className="text-[11px] font-mono uppercase tracking-wider">{title}</span>
+        </div>
+        <ACTag />
+      </div>
+      <div className="text-3xl font-extrabold tracking-tight leading-tight" style={{ color: numberColor }}>
+        {number}
+      </div>
+      <p className="text-[13px] text-slate-300 leading-snug">{line}</p>
+    </div>
+  );
+}
+
+function SolutionStat({ value, label, color }) {
+  return (
+    <div className="bg-slate-900/70 border-2 rounded-xl p-5 text-center" style={{ borderColor: `${color}66` }}>
+      <div className="text-4xl font-extrabold tracking-tight leading-none mb-2" style={{ color }}>
+        {value}
+      </div>
+      <div className="text-xs font-mono uppercase tracking-wider text-slate-300 leading-snug">{label}</div>
+    </div>
+  );
+}
+
+function BenefitItem({ children }) {
+  return (
+    <li className="flex items-start gap-2 text-[13px] text-slate-200 leading-snug">
+      <span className="mt-1.5 w-1.5 h-1.5 rounded-full flex-shrink-0" style={{ backgroundColor: BLUE_LIGHT }} />
+      <span>{children}</span>
+    </li>
+  );
+}
+
+function FooterLink({ href, children, external }) {
+  return (
+    <a
+      href={href}
+      target={external ? "_blank" : "_self"}
+      rel={external ? "noopener noreferrer" : undefined}
+      className="inline-flex items-center gap-1 text-[13px] font-medium underline underline-offset-4 decoration-[#4D8EF8]/40 hover:decoration-[#4D8EF8] transition-colors"
+      style={{ color: BLUE_LIGHT }}
+    >
+      {children}
+      <ArrowRight className="w-3.5 h-3.5" />
+    </a>
+  );
+}
+
+function SlideShell({ slideNo, children }) {
+  return (
+    <section
+      className="relative w-[1123px] h-[794px] bg-[#080808] text-white overflow-hidden flex flex-col px-14 py-10"
+      style={{ pageBreakAfter: slideNo === 1 ? "always" : "auto" }}
+    >
+      {/* Header band */}
+      <div className="flex items-center justify-between mb-6">
+        <img src={LOGO_SRC} alt="Traigent" className="h-9" />
+        <div className="flex items-center gap-4 text-[11px] font-mono uppercase tracking-widest text-slate-500">
+          <span>AI Agent Optimization</span>
+          <span className="text-slate-700">·</span>
+          <span style={{ color: BLUE_LIGHT }}>One-Pager {slideNo}/2</span>
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+// ---------- Slide 1: The Problem ----------
+function SlideProblem() {
+  return (
+    <SlideShell slideNo={1}>
+      <div className="flex-1 flex flex-col gap-6">
+        {/* Title */}
+        <div>
+          <h1 className="text-[44px] font-bold tracking-tight leading-[1.05]">
+            AI Agent Optimization Is <span style={{ color: RED }}>Brutal</span> — and Manual
+          </h1>
+          <p className="text-[15px] text-slate-300 leading-relaxed mt-3 max-w-4xl">
+            Every production agent sits in a multi-thousand-configuration search space. The configuration you ship determines{" "}
+            <span className="text-white font-semibold">accuracy for users</span> and the{" "}
+            <span className="text-white font-semibold">monthly LLM bill for finance</span> — for as long as the agent runs.
+          </p>
+        </div>
+
+        {/* 2x2 problem grid */}
+        <div className="grid grid-cols-2 gap-4 flex-1">
+          <ProblemPanel
+            icon={Layers}
+            title="1. Configuration multiverse"
+            number="~648 → 30,000+"
+            numberColor={RED}
+            line="Universal knobs alone yield hundreds of configurations. Add reasoning models, tool use, or RAG and you're past 10,000 per agent per workload."
+          />
+          <ProblemPanel
+            icon={Clock}
+            title="2. Manual engineering effort"
+            number="~324 hrs · 8 FTE-weeks"
+            numberColor={RED}
+            line="At 30 minutes per config test, a full manual sweep eats months of senior engineering time. Per pass. Per agent. Per re-tune."
+          />
+          <ProblemPanel
+            icon={Target}
+            title="3. Confidence sacrificed"
+            number="80% of the space, blind"
+            numberColor={RED}
+            line="Real teams test ~20% of the space and ship. They didn't find the optimum — they found the best of what they happened to check."
+          />
+          <ProblemPanel
+            icon={AlertTriangle}
+            title="4. Long time-to-market"
+            number="Weeks → months / pass"
+            numberColor={RED}
+            line="Re-optimization is so painful it gets skipped. Configurations drift as models, prices, and usage patterns evolve. Silent ROI leak."
           />
         </div>
 
-        {/* Company Overview */}
-        <section className="mb-10">
-          <SectionHeader>Company Overview</SectionHeader>
-          <p className="text-slate-300 leading-relaxed">
-            Traigent is building the AI Agents Continuous <strong>Optimization</strong>{" "}
-            infrastructure. We automate the complex process of optimizing AI agent configurations by
-            balancing <strong>accuracy</strong>, <strong>latency</strong>, <strong>cost</strong>, or any other <strong>business KPI's</strong>
-            , so engineering teams can ship production-ready agents <strong>faster</strong> and with{" "}
-            <strong>confidence</strong>.
-          </p>
-        </section>
-
-        {/* Problem & Solution Side by Side */}
-        <ProblemSolutionSection showImages={true} solutionTitle="Traigent" />
-
-        {/* The Product */}
-        <section className="mb-10">
-          <SectionHeader>The Product: AI Agent Optimizer</SectionHeader>
-          <div className="rounded-2xl border border-slate-800 bg-gradient-to-b from-[#04103a] to-[#020617] p-4 md:p-5">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-stretch">
-              {/* Input Card */}
-              <div className="bg-slate-800/70 rounded-2xl p-5 border border-cyan-300/20 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-                <h4 className="font-bold text-white text-xl mb-4">
-                  <span className="text-white">Input: </span>
-                  <span className="text-blue-300">The Tunable Universe</span>
-                </h4>
-                <ul className="space-y-3 text-[15px] leading-relaxed">
-                  <li className="flex items-start gap-3 text-slate-200">
-                    <span className="w-2 h-2 rounded-full bg-blue-400 mt-2 shrink-0"></span>
-                    <span>
-                      <strong className="text-white">Search Space:</strong> Massive N-dimensional
-                      grid (Models × RAG × ... × k × Temp).
-                    </span>
-                  </li>
-                  <li className="flex items-start gap-3 text-slate-200">
-                    <span className="w-2 h-2 rounded-full bg-blue-400 mt-2 shrink-0"></span>
-                    <span>
-                      <strong className="text-white">Agent Blueprint:</strong> Initial logic,
-                      prompts, and tool definitions.
-                    </span>
-                  </li>
-                  <li className="flex items-start gap-3 text-slate-200">
-                    <span className="w-2 h-2 rounded-full bg-blue-400 mt-2 shrink-0"></span>
-                    <span>
-                      <strong className="text-white">Optimization Goal:</strong> Your EvalSet
-                      (.jsonl) and KPI weights.
-                    </span>
-                  </li>
-                </ul>
-              </div>
-
-              {/* Output Card */}
-              <div className="bg-slate-800/70 rounded-2xl p-5 border border-cyan-300/20 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-                <h4 className="font-bold text-white text-xl mb-4">
-                  <span className="text-white">Output: </span>
-                  <span className="text-emerald-300">The Safest Implementation</span>
-                </h4>
-                <ul className="space-y-3 text-[15px] leading-relaxed">
-                  <li className="flex items-start gap-3 text-slate-200">
-                    <span className="w-2 h-2 rounded-full bg-emerald-400 mt-2 shrink-0"></span>
-                    <span>
-                      <strong className="text-white">Optimal Config:</strong> The mathematically
-                      best-performing implementation.
-                    </span>
-                  </li>
-                  <li className="flex items-start gap-3 text-slate-200">
-                    <span className="w-2 h-2 rounded-full bg-emerald-400 mt-2 shrink-0"></span>
-                    <span>
-                      <strong className="text-white">Validated KPI:</strong> Proven accuracy, speed,
-                      and cost efficiency.
-                    </span>
-                  </li>
-                  <li className="flex items-start gap-3 text-slate-200">
-                    <span className="w-2 h-2 rounded-full bg-emerald-400 mt-2 shrink-0"></span>
-                    <span>
-                      <strong className="text-white">Evidence Report:</strong> Full trial history
-                      and KPI validation data.
-                    </span>
-                  </li>
-                </ul>
-              </div>
-            </div>
+        {/* Footer links */}
+        <div className="flex items-center justify-between pt-2 border-t border-slate-800">
+          <div className="text-[11px] font-mono uppercase tracking-widest text-slate-500">
+            <span style={{ color: BLUE_LIGHT }}>A</span> Accuracy ·{" "}
+            <span style={{ color: AMBER }}>C</span> Cost — every problem hits both
           </div>
-        </section>
-
-        {/* Personas */}
-        <section className="mb-10">
-          <SectionHeader>Personas</SectionHeader>
-          <div className="grid md:grid-cols-2 gap-x-8 gap-y-3">
-            <div>
-              <p className="text-slate-200">
-                <strong>AI/ML/DS Engineers:</strong> Integrate via decorator (SDK), optimize with
-                code.
-              </p>
-            </div>
-            <div>
-              <p className="text-slate-200">
-                <strong>No-Code Users:</strong> Visual interface for non-technical users.
-              </p>
-            </div>
-            <div>
-              <p className="text-slate-200">
-                <strong>QA Users:</strong> Scalable quality validation for agentic AI
-              </p>
-            </div>
-            <div>
-              <p className="text-slate-200">
-                <strong>Stakeholders:</strong> Track Business KPIs and cost-efficiency metrics
-              </p>
-            </div>
+          <div className="flex items-center gap-5">
+            <FooterLink href={`${SITE}/#/blog/the-config-multiverse`} external>
+              See the full multiverse
+            </FooterLink>
+            <FooterLink href={`${SITE}/#/ttm`} external>
+              Compute your TTM
+            </FooterLink>
+            <FooterLink href={`${SITE}/#/roi`} external>
+              Compute your ROI
+            </FooterLink>
           </div>
-        </section>
-
-        {/* POC */}
-        <section className="mb-10">
-          <SectionHeader>POC Program</SectionHeader>
-          <div className="grid md:grid-cols-3 gap-6">
-            <div>
-              <h4 className="font-bold text-white mb-2">Before</h4>
-              <p className="text-slate-400 text-sm">Define:</p>
-              <ul className="list-disc list-inside text-slate-300 text-sm">
-                <li>Benchmark (EvalSet + Eval)</li>
-                <li>POC success metrics</li>
-              </ul>
-            </div>
-            <div>
-              <h4 className="font-bold text-white mb-2">POC</h4>
-              <p className="text-slate-300 text-sm">
-                1-week integration & optimization on your system
-              </p>
-            </div>
-            <div>
-              <h4 className="font-bold text-white mb-2">After</h4>
-              <p className="text-slate-300 text-sm">
-                Compare optimized results vs. your baseline benchmark
-              </p>
-            </div>
-          </div>
-        </section>
-
-        {/* Contact */}
-        <section className="mb-10">
-          <SectionHeader>Contact</SectionHeader>
-          <div className="grid md:grid-cols-2 gap-8">
-            <div>
-              <p className="font-bold text-white">Achi Solomon | Co-founder, CEO</p>
-              <p className="text-slate-300">
-                <a href="mailto:achi@traigent.ai" className="text-indigo-400 hover:underline">
-                  achi@traigent.ai
-                </a>
-                {" | "}
-                <a
-                  href="https://linkedin.com/in/achisolomon"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-indigo-400 hover:underline"
-                >
-                  LinkedIn
-                </a>
-              </p>
-              <p className="text-slate-400">+972-54-7784395</p>
-            </div>
-            <div>
-              <p className="font-bold text-white">Dr. Nimrod Busany | Co-founder, CTO</p>
-              <p className="text-slate-300">
-                <a href="mailto:nimrod@traigent.ai" className="text-indigo-400 hover:underline">
-                  nimrod@traigent.ai
-                </a>
-                {" | "}
-                <a
-                  href="https://www.linkedin.com/in/nimrod-busany-phd-0b938216/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-indigo-400 hover:underline"
-                >
-                  LinkedIn
-                </a>
-              </p>
-              <p className="text-slate-400">+972-54-4553811</p>
-            </div>
-          </div>
-        </section>
-
-        {/* CTA */}
-        <div className="text-center mt-12">
-          <a
-            href="https://meetings-eu1.hubspot.com/amir8"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group relative inline-flex items-center bg-blue-500 text-white px-10 py-4 rounded-xl font-bold text-lg transition-all duration-300 hover:bg-blue-600 hover:scale-105 shadow-[0_0_20px_rgba(59,130,246,0.5)] hover:shadow-[0_0_40px_rgba(59,130,246,0.8)] overflow-hidden"
-          >
-            {/* Animated shine effect */}
-            <span className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-1000 ease-in-out"></span>
-
-            {/* Pulse ring */}
-            <span className="absolute inset-0 rounded-xl animate-ping bg-blue-400 opacity-20"></span>
-
-            <span className="relative z-10 flex items-center">
-              Request a Demo
-              <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-1 transition-transform" />
-            </span>
-          </a>
         </div>
       </div>
-    </div>
+    </SlideShell>
+  );
+}
+
+// ---------- Slide 2: The Solution ----------
+function SlideSolution() {
+  return (
+    <SlideShell slideNo={2}>
+      <div className="flex-1 flex flex-col gap-5">
+        {/* Title */}
+        <div>
+          <h1 className="text-[44px] font-bold tracking-tight leading-[1.05]">
+            Traigent — <span style={{ color: BLUE_LIGHT }}>Automated</span> AI Agent Optimization
+          </h1>
+          <p className="text-[15px] text-slate-300 leading-relaxed mt-3 max-w-4xl">
+            One hour of engineer setup. The optimizer runs unattended. You ship the converged
+            optimum — not the best of what you happened to test.
+          </p>
+        </div>
+
+        {/* 3 headline stats */}
+        <div className="grid grid-cols-3 gap-4">
+          <SolutionStat value="~1 hr" label="Engineer time per optimization pass" color={BLUE_LIGHT} />
+          <SolutionStat value="30–60%" label="LLM cost reduction at same accuracy" color={AMBER} />
+          <SolutionStat value="8 FTE-wks" label="Engineering time reclaimed per pass" color={BLUE_LIGHT} />
+        </div>
+
+        {/* Two audience columns */}
+        <div className="grid grid-cols-2 gap-4 flex-1">
+          <div className="bg-slate-900/70 border border-slate-700/60 rounded-xl p-5">
+            <div className="flex items-center gap-2 mb-3">
+              <ShieldCheck className="w-4 h-4" style={{ color: BLUE_LIGHT }} />
+              <h3 className="text-sm font-bold uppercase tracking-wider" style={{ color: BLUE_LIGHT }}>
+                For Developers / Eng Leads
+              </h3>
+            </div>
+            <ul className="space-y-2.5">
+              <BenefitItem>Search the <span className="text-white font-semibold">full</span> configuration space — not a 20% slice</BenefitItem>
+              <BenefitItem>Reclaim <span className="text-white font-semibold">8+ FTE-weeks</span> per optimization pass</BenefitItem>
+              <BenefitItem>Ship with <span className="text-white font-semibold">100% confidence</span> in your optimum</BenefitItem>
+              <BenefitItem>Re-optimize on every model release in <span className="text-white font-semibold">hours, not weeks</span></BenefitItem>
+            </ul>
+          </div>
+          <div className="bg-slate-900/70 border rounded-xl p-5" style={{ borderColor: `${AMBER}55` }}>
+            <div className="flex items-center gap-2 mb-3">
+              <TrendingDown className="w-4 h-4" style={{ color: AMBER }} />
+              <h3 className="text-sm font-bold uppercase tracking-wider" style={{ color: AMBER }}>
+                For FinOps / CTO
+              </h3>
+            </div>
+            <ul className="space-y-2.5">
+              <BenefitItem><span className="text-white font-semibold">30–60% LLM cost reduction</span> at the same accuracy</BenefitItem>
+              <BenefitItem>Payback typically <span className="text-white font-semibold">&lt; 1 month</span> at $10K+ monthly spend</BenefitItem>
+              <BenefitItem>Recurring savings <span className="text-white font-semibold">for the agent's lifetime</span></BenefitItem>
+              <BenefitItem>Tier-based pricing <span className="text-white font-semibold">scales with agent volume</span></BenefitItem>
+            </ul>
+          </div>
+        </div>
+
+        {/* How it works ribbon */}
+        <div className="flex items-center justify-between bg-slate-900/50 border border-slate-800 rounded-xl px-5 py-3">
+          <div className="text-[11px] font-mono uppercase tracking-widest text-slate-400">How it works</div>
+          <div className="flex items-center gap-3 text-[13px]">
+            <span className="flex items-center gap-2">
+              <span className="w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold" style={{ backgroundColor: `${BLUE}33`, color: BLUE_LIGHT }}>1</span>
+              <span className="text-slate-200"><span className="text-white font-semibold">Define</span> — wrap your agent, declare KPIs</span>
+            </span>
+            <ArrowRight className="w-3.5 h-3.5 text-slate-600" />
+            <span className="flex items-center gap-2">
+              <span className="w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold" style={{ backgroundColor: `${BLUE}33`, color: BLUE_LIGHT }}>2</span>
+              <span className="text-slate-200"><span className="text-white font-semibold">Optimize</span> — searches the space overnight</span>
+            </span>
+            <ArrowRight className="w-3.5 h-3.5 text-slate-600" />
+            <span className="flex items-center gap-2">
+              <span className="w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold" style={{ backgroundColor: `${BLUE}33`, color: BLUE_LIGHT }}>3</span>
+              <span className="text-slate-200"><span className="text-white font-semibold">Ship</span> — promote with full evidence</span>
+            </span>
+          </div>
+        </div>
+
+        {/* Footer links / CTAs */}
+        <div className="flex items-center justify-between pt-2 border-t border-slate-800">
+          <div className="flex items-center gap-2">
+            <Zap className="w-4 h-4" style={{ color: AMBER }} />
+            <span className="text-[12px] text-slate-300">
+              <span className="text-white font-semibold">Free POC</span> — zero investment, one agent, overnight optimum
+            </span>
+          </div>
+          <div className="flex items-center gap-5">
+            <FooterLink href="https://meetings-eu1.hubspot.com/amir8" external>
+              Book 15-min call
+            </FooterLink>
+            <FooterLink href="https://portal.traigent.ai" external>
+              Start free POC
+            </FooterLink>
+            <FooterLink href={`${SITE}/#/blog/the-business-case`} external>
+              Business case
+            </FooterLink>
+            <FooterLink href={`${SITE}/#/roi`} external>
+              ROI on your numbers
+            </FooterLink>
+          </div>
+        </div>
+      </div>
+    </SlideShell>
+  );
+}
+
+export default function OnePager() {
+  return (
+    <>
+      <Helmet>
+        <title>Traigent — One-Pager</title>
+        <meta
+          name="description"
+          content="Traigent at a glance for outreach. Two slides: the brutal magnitude of manual AI agent optimization, and the automated alternative. Built for engineering leads and FinOps."
+        />
+        <meta property="og:title" content="Traigent — One-Pager" />
+        <meta property="og:description" content="Two-slide outreach one-pager. Problem + solution. For Devs and FinOps." />
+      </Helmet>
+      {/* Print CSS: A4 landscape, no page margins, hide scroll container chrome */}
+      <style>{`
+        @media print {
+          @page { size: A4 landscape; margin: 0; }
+          html, body { background: #080808; margin: 0; padding: 0; }
+        }
+      `}</style>
+      <div className="bg-slate-950 min-h-screen flex flex-col items-center gap-8 py-8 print:gap-0 print:py-0 overflow-x-auto">
+        <SlideProblem />
+        <SlideSolution />
+      </div>
+    </>
   );
 }

--- a/src/pages/TTMCalculator.jsx
+++ b/src/pages/TTMCalculator.jsx
@@ -56,7 +56,7 @@ function Card({ children, accent = BLUE }) {
   );
 }
 
-function SliderRow({ icon: Icon, label, value, valuePrefix = "", suffix, min, max, step, onChange, minLabel, maxLabel, examples, accent = BLUE }) {
+function SliderRow({ icon: Icon, label, value, valuePrefix = "", suffix, min, max, step, onChange, minLabel, maxLabel, examples, link, accent = BLUE }) {
   return (
     <Card accent={accent}>
       <div className="flex items-start gap-2 text-xs font-mono uppercase tracking-wider mb-3 min-h-[2.5rem]" style={{ color: accent === BLUE ? "#94a3b8" : accent }}>
@@ -81,13 +81,18 @@ function SliderRow({ icon: Icon, label, value, valuePrefix = "", suffix, min, ma
         <span>{minLabel}</span>
         <span>{maxLabel}</span>
       </div>
-      {examples && (
+      {(examples || link) && (
         <div
           className="mt-auto pt-3 border-t border-slate-800/80 text-xs text-slate-400 font-mono leading-snug min-h-[4.5rem]"
           title={examples}
         >
-          <span className="text-slate-500 uppercase tracking-wider text-[10px] mr-2">e.g.</span>
-          {examples}
+          {examples && (
+            <>
+              <span className="text-slate-500 uppercase tracking-wider text-[10px] mr-2">e.g.</span>
+              {examples}
+            </>
+          )}
+          {link && <div className="mt-2">{link}</div>}
         </div>
       )}
     </Card>
@@ -95,21 +100,18 @@ function SliderRow({ icon: Icon, label, value, valuePrefix = "", suffix, min, ma
 }
 
 // ----- Example value generators per dimension --------------------------------
-// These produce illustrative values so the prospect sees what "5 temperatures"
-// or "4 top_p variants" actually looks like in practice.
+// These produce illustrative values so the prospect sees what "4 few-shot counts"
+// or "3 self-consistency n" actually looks like in practice.
 
-function temperatureExamples(n) {
-  if (n <= 1) return ["0.7"];
-  const out = [];
-  for (let i = 0; i < n; i++) {
-    out.push((i / (n - 1)).toFixed(2));
-  }
-  return out;
+function fewShotExamples(n) {
+  // Standard few-shot ladder — 0-shot to many-shot.
+  const ladder = [0, 2, 5, 10, 15, 20, 30];
+  return ladder.slice(0, n).map(String);
 }
 
-function retrievalKExamples(n) {
-  // Typical retrieval-k values tested in RAG pipelines.
-  const ladder = [1, 3, 5, 8, 10, 15, 20, 30];
+function selfConsistencyExamples(n) {
+  // Typical n-of-vote sample counts (Wang et al., self-consistency).
+  const ladder = [1, 3, 5, 10, 20, 40];
   return ladder.slice(0, n).map(String);
 }
 
@@ -147,11 +149,13 @@ function promptExamples(n) {
 // catch-all slider so the user can multiply the search space by however
 // much extra knob-space their setup actually has.
 const OTHER_DIMENSIONS = [
-  "chunk size", "chunk overlap", "embedding model",
+  "temperature", "top_p", "top_k",
+  "reasoning effort (if reasoning model)",
+  "tool-call budget (if agentic)",
+  "retrieval k", "chunk size", "chunk overlap", "embedding model",
   "reranker choice", "query-rewrite strategy", "hybrid-search weights",
-  "few-shot example count", "output format (JSON / text / structured)",
-  "tool-selection strategy", "max tool-call iterations",
-  "frequency penalty", "presence penalty", "top_p", "stop sequences",
+  "output format (JSON / text / structured)", "tool-selection strategy",
+  "frequency penalty", "presence penalty", "stop sequences",
   "retry policy", "timeout", "fallback model", "cache policy",
   "streaming behavior", "validation / repair logic",
 ];
@@ -165,9 +169,9 @@ function otherDimensionsExamples() {
 export default function TTMCalculator() {
   const [models, setModels] = useState(6);
   const [prompts, setPrompts] = useState(3);
-  const [temperatures, setTemperatures] = useState(5);
-  const [retrievalK, setRetrievalK] = useState(4);
-  const [maxTokensVariants, setMaxTokensVariants] = useState(2);
+  const [maxTokensVariants, setMaxTokensVariants] = useState(3);
+  const [fewShots, setFewShots] = useState(4);
+  const [selfConsistency, setSelfConsistency] = useState(3);
   const [otherDims, setOtherDims] = useState(1);
   const [minPerConfig, setMinPerConfig] = useState(MIN_PER_CONFIG_DEFAULT);
   // Shared across TTM + ROI calculators via localStorage.
@@ -184,9 +188,9 @@ export default function TTMCalculator() {
   function resetToDefaults() {
     setModels(6);
     setPrompts(3);
-    setTemperatures(5);
-    setRetrievalK(4);
-    setMaxTokensVariants(2);
+    setMaxTokensVariants(3);
+    setFewShots(4);
+    setSelfConsistency(3);
     setOtherDims(1);
     setMinPerConfig(MIN_PER_CONFIG_DEFAULT);
     setHourlyRate(DEFAULT_HOURLY_RATE);
@@ -195,7 +199,7 @@ export default function TTMCalculator() {
   }
 
   const r = useMemo(() => {
-    const totalConfigs = models * prompts * temperatures * retrievalK * maxTokensVariants * otherDims;
+    const totalConfigs = models * prompts * maxTokensVariants * fewShots * selfConsistency * otherDims;
     const manualConfigsTested = Math.max(1, Math.round(totalConfigs * manualCoveragePct / 100));
     const manualEngineerHours = (manualConfigsTested * minPerConfig) / 60;
     const manualFteWeeks = manualEngineerHours / FTE_HOURS_PER_WEEK;
@@ -236,7 +240,7 @@ export default function TTMCalculator() {
       dollarsSaved,
       fullSweepDollarsSaved,
     };
-  }, [models, prompts, temperatures, retrievalK, maxTokensVariants, otherDims, minPerConfig, manualCoveragePct, hourlyRate]);
+  }, [models, prompts, maxTokensVariants, fewShots, selfConsistency, otherDims, minPerConfig, manualCoveragePct, hourlyRate]);
 
   // Republish the per-pass manual hours whenever it changes — ROI Calculator
   // listens on this key for its engineering-hours derivation.
@@ -326,7 +330,7 @@ export default function TTMCalculator() {
                   <div>to explore</div>
                 </div>
                 <span className="text-5xl md:text-7xl lg:text-8xl font-extrabold text-white tracking-tight">{r.totalConfigs.toLocaleString()}</span>
-                <span className="text-sm md:text-base text-slate-300 font-mono font-semibold">= {models} × {prompts} × {temperatures} × {retrievalK} × {maxTokensVariants} × {otherDims}</span>
+                <span className="text-sm md:text-base text-slate-300 font-mono font-semibold">= {models} × {prompts} × {maxTokensVariants} × {fewShots} × {selfConsistency} × {otherDims}</span>
               </div>
               <a
                 href="#dimension-sliders"
@@ -393,12 +397,12 @@ export default function TTMCalculator() {
             className="text-center mb-12"
           >
             <p className="text-xs md:text-sm text-slate-500 max-w-2xl mx-auto leading-relaxed">
-              The sliders below reflect <span className="text-slate-300">the most common choices</span>, but many other selection dimensions exist — to keep things simple, we've embodied them all in <span className="text-slate-300">"Other tunable options"</span>.{" "}
+              The sliders below reflect <span className="text-slate-300">the most impactful, universal choices</span> — knobs that apply to every agent and hit Accuracy <em>and</em> Cost. Many other dimensions exist (temperature, top_p, retrieval k, chunk size, reranker, reasoning effort, tool-call budget, …) and are folded into <span className="text-slate-300">"Other tunable options"</span>.{" "}
               <Link
-                to="/blog/the-business-case"
+                to="/blog/the-config-multiverse"
                 className="text-[#4D8EF8] hover:text-[#1A6BF5] underline underline-offset-2 transition-colors"
               >
-                See the full inventory and cost ratios →
+                See the full inventory and their A/C/L impacts →
               </Link>
             </p>
           </motion.div>
@@ -452,32 +456,6 @@ export default function TTMCalculator() {
             />
             <SliderRow
               icon={SlidersHorizontal}
-              label="Temperature values"
-              value={temperatures}
-              suffix="settings"
-              min={1}
-              max={10}
-              step={1}
-              onChange={setTemperatures}
-              minLabel="1"
-              maxLabel="10"
-              examples={temperatureExamples(temperatures).join(", ")}
-            />
-            <SliderRow
-              icon={SlidersHorizontal}
-              label="Retrieval k values"
-              value={retrievalK}
-              suffix="settings"
-              min={1}
-              max={8}
-              step={1}
-              onChange={setRetrievalK}
-              minLabel="1"
-              maxLabel="8"
-              examples={retrievalKExamples(retrievalK).join(", ")}
-            />
-            <SliderRow
-              icon={SlidersHorizontal}
               label="max_tokens values"
               value={maxTokensVariants}
               suffix="settings"
@@ -491,6 +469,32 @@ export default function TTMCalculator() {
             />
             <SliderRow
               icon={SlidersHorizontal}
+              label="Few-shot example count"
+              value={fewShots}
+              suffix="settings"
+              min={1}
+              max={7}
+              step={1}
+              onChange={setFewShots}
+              minLabel="1"
+              maxLabel="7"
+              examples={fewShotExamples(fewShots).join(", ")}
+            />
+            <SliderRow
+              icon={SlidersHorizontal}
+              label="Self-consistency n"
+              value={selfConsistency}
+              suffix="settings"
+              min={1}
+              max={6}
+              step={1}
+              onChange={setSelfConsistency}
+              minLabel="1"
+              maxLabel="6"
+              examples={selfConsistencyExamples(selfConsistency).join(", ")}
+            />
+            <SliderRow
+              icon={SlidersHorizontal}
               label="Other tunable options"
               value={otherDims}
               suffix="options ×"
@@ -501,6 +505,14 @@ export default function TTMCalculator() {
               minLabel="1"
               maxLabel="100"
               examples={otherDimensionsExamples().join(", ")}
+              link={
+                <Link
+                  to="/blog/the-config-multiverse"
+                  className="text-[#4D8EF8] hover:text-[#1A6BF5] underline underline-offset-2"
+                >
+                  See full inventory & A/C/L impacts →
+                </Link>
+              }
             />
           </motion.div>
 


### PR DESCRIPTION
## Summary
Bundle of recent work accumulated locally. Shipping to main so the outreach one-pager links resolve on production.

- **Outreach one-pager** at `/one-pager` — 2-slide A4 landscape artifact for dual-audience outreach (Devs + FinOps/CTO). Moved out of `Layout` so it renders clean for PDF export.
- **TTM Calculator rework** — dropped pure-accuracy knob (Temperature), added **Few-shot count** + **Self-consistency n** as universal-strong sliders. New defaults `6 × 3 × 3 × 4 × 3 × 1 = 648`. Demoted into "Other tunable options" examples: temperature, top_p, retrieval k, chunk size, reranker, reasoning effort, tool-call budget. Magnitude blog link inside the Other-tunable card.
- **Magnitude blog** (`/blog/the-config-multiverse`) — new long-form post with full A/C/L impact map across model + agent + RAG knobs, subtitle field added. Promoted to position 1 on the Why Traigent index; other featured posts shifted down.
- **Mobile nav** — hamburger drawer for narrow viewports (previously hidden behind \`lg:flex\`).
- **Blog link bug fix** — \`BlogPost.jsx\` markdown link renderer now routes internal \`/...\` paths through React Router \`Link\` so HashRouter prepends the \`#\`. Fixes 18 broken in-blog links that 404'd on GitHub Pages.

Supersedes PRs #21 and #22 — both will be closed.

## Test plan
- [ ] CI checks pass (the 3 required status checks)
- [ ] Manual: https://www.traigent.ai/#/one-pager renders both slides clean
- [ ] Manual: /blog/the-config-multiverse loads and ROI/TTM links inside work
- [ ] Manual: TTM calculator shows new sliders, "Other tunable" card has Magnitude link
- [ ] Manual: mobile nav drawer opens on phones

🤖 Generated with [Claude Code](https://claude.com/claude-code)