### PR TITLE
chore(ci): bump GitHub Actions to versions supporting Node.js 24

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -47,7 +47,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
+        uses: peaceiris/actions-gh-pages@1ef5a1b1df4c63fe21a2242edbee6cac921ece01 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist


### PR DESCRIPTION
## Summary
Production deploys currently log a warning that `actions/checkout@v4`, `actions/setup-node@v4`, and `peaceiris/actions-gh-pages@v4` (SHA-pinned) all run on Node.js 20, which the GitHub Actions runner is **forcing to Node 24 on 2026-06-02** and **removing entirely on 2026-09-16**.

This bumps each action to a version that natively supports Node 24, so deploys keep working past the deadline without surprises.

## Changes
- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v6` (we already use `cache: npm`, which is the supported path under v6's breaking change)
- `peaceiris/actions-gh-pages@4f9cc66…` (v4.0.0) → `@1ef5a1b…` (v4.1.0) — kept SHA-pinned since it's third-party

## Test plan
- [ ] Merge to `main`
- [ ] Trigger `Deploy to GitHub Pages` via `workflow_dispatch`
- [ ] Confirm the Node.js 20 deprecation warning is gone in the run annotations
- [ ] Confirm traigent.ai still serves the latest bundle (HubSpot + PostHog scripts still load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)