### PR TITLE
chore(ci): bump remaining 2 workflows to Node 24-compatible actions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'


### PR DESCRIPTION
## Summary
Follow-up to #25, which only bumped `deploy-gh-pages.yml`. The other two workflows in this repo (`code-quality.yml` and `security-checks.yml`) still pin `actions/checkout@v4` and `actions/setup-node@v4`, so they continue to log the **Node.js 20 deprecation warning** on every push/PR run.

This brings them in line with the deploy workflow.

## Changes
Per workflow (× 2):
- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v6`

## Out of scope (worth a separate PR if you want it)
Both files keep `node-version: '20'` for the user-installed Node runtime (what `npm`/`prettier` run on), while `deploy-gh-pages.yml` uses `'22'`. That's an inconsistency, but it's about the *user* runtime — completely separate from the *actions* runtime being deprecated. Left untouched to keep this PR focused.

## Test plan
- [ ] Merge to `main`
- [ ] Wait for the auto-triggered push runs of `code-quality` and `security-checks`
- [ ] Confirm neither run shows the Node.js 20 deprecation annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)