### PR TITLE
content: refine /one-pager-2 hero + homepage hero bullets

### DIFF
--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -167,8 +167,8 @@ export default function Homepage() {
                 <ul className="space-y-3">
                   {[
                     <><span className="text-white font-semibold underline underline-offset-4 decoration-2 decoration-[#4D8EF8]/70">Finds the optimal model and configuration combo</span> in <span className="text-white font-semibold">hours, not weeks</span>.</>,
+                    <><span className="font-semibold" style={{ color: "#f59e0b" }}>Low Cost</span> with <span className="font-semibold" style={{ color: "#4D8EF8" }}>High Accuracy</span>.</>,
                     <><span className="text-white font-semibold">Automatically</span>, not manually.</>,
-                    <>Requires only a <span className="text-white font-semibold">fraction of the search space.</span></>,
                     <>With <span className="text-white font-semibold">confidence</span>, not guesswork.</>,
                   ].map((item, i) => (
                     <li key={i} className="flex items-start gap-2.5 text-slate-300 leading-snug">

--- a/src/pages/OnePager2.jsx
+++ b/src/pages/OnePager2.jsx
@@ -96,7 +96,15 @@ export default function OnePager2() {
               <span style={{ color: BLUE_LIGHT }}>Fully Automated</span>
             </h2>
             <p className="text-[36px] text-slate-300 leading-snug mt-5">
-              <span className="font-bold" style={{ color: AMBER }}>Cost Optimization</span> on top of <span className="font-bold" style={{ color: BLUE_LIGHT }}>Accuracy Optimization</span>
+              <span className="font-bold text-white">Rapidly</span> finds <span className="font-bold" style={{ color: AMBER }}>Low Cost</span> and <span className="font-bold" style={{ color: BLUE_LIGHT }}>High Accuracy</span> configurations among{" "}
+              <a
+                href={`${SITE}/#/blog/the-config-multiverse`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-bold text-white underline underline-offset-4 decoration-white/40 hover:decoration-white transition-colors"
+              >
+                thousands possible
+              </a>
             </p>
           </div>
 
@@ -119,8 +127,8 @@ export default function OnePager2() {
 
           {/* 2 solution stats — audience-grouped under their headers */}
           <div className="grid grid-cols-2 gap-4 mb-4">
-            <SolutionStat value="up to 80%" label="LLM cost reduction with optimal accuracy" color={AMBER} />
-            <SolutionStat value="up to 8 wks" label="Engineering time reclaimed per pass" color={BLUE_LIGHT} />
+            <SolutionStat value="up to 80%" label="LLM cost reduction" color={AMBER} />
+            <SolutionStat value="up to 8 wks" label="Engineering time reclaimed" color={BLUE_LIGHT} />
           </div>
 
           {/* 2 audience benefits boxes — FinOps on left to match the swap above */}


### PR DESCRIPTION
## Summary
- **/one-pager-2 hero sub-line** rewritten: *Rapidly finds Low Cost and High Accuracy configurations among **thousands possible***. \`thousands possible\` is a link to the magnitude blog.
- **Stat tile labels** trimmed: \`LLM cost reduction\` (was *...with high accuracy*) and \`Engineering time reclaimed\` (was *...per pass*).
- **Homepage hero LEFT card**: new bullet **Low Cost with High Accuracy** (amber + blue, matching A/C theme). Dropped *"Requires only a fraction of the search space"*.

## Test plan
- [ ] CI green
- [ ] Manual: https://www.traigent.ai/#/one-pager-2 renders the new hero copy and the link works
- [ ] Manual: https://www.traigent.ai/ shows the new "Low Cost with High Accuracy" bullet on the homepage hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)