### PR TITLE
fix(deck): scale OnePager2 slide to fit mobile viewports + PPT 16:9 layout

### DIFF
--- a/src/components/OnePagerAtoms.jsx
+++ b/src/components/OnePagerAtoms.jsx
@@ -56,7 +56,7 @@ export const ONEPAGER_STYLE = `
   #hs-eu-cookie-confirmation,
   #hs-eu-cookie-confirmation-inner { display: none !important; visibility: hidden !important; }
   @media print {
-    @page { size: A4 landscape; margin: 0; }
+    @page { size: 13.333in 7.5in; margin: 0; }
     html, body { background: #080808; margin: 0; padding: 0; }
   }
 `;

--- a/src/pages/OnePager2.jsx
+++ b/src/pages/OnePager2.jsx
@@ -68,7 +68,7 @@ export function OnePager2Slide({ showHeader = true, showFooter = true, costStatV
   const useFixedHeight = showHeader && showFooter;
   return (
     <section
-      className={`relative w-[1123px] ${useFixedHeight ? "h-[794px]" : ""} bg-[#080808] text-white overflow-hidden flex flex-col px-10 py-6`}
+      className={`relative w-[1280px] ${useFixedHeight ? "h-[720px]" : ""} bg-[#080808] text-white overflow-hidden flex flex-col px-10 pt-6 pb-8`}
     >
       {showHeader && (
         <div className="flex items-center justify-between mb-3">
@@ -90,13 +90,16 @@ export function OnePager2Slide({ showHeader = true, showFooter = true, costStatV
       )}
 
       {/* Solution hero */}
-          <div className="mb-14">
+          <div className="mb-6">
             <h2 className="text-[68px] font-bold tracking-tight leading-[1.05]">
               AI Agent Optimization —<br />
               <span style={{ color: BLUE_LIGHT }}>Fully Automated</span>
             </h2>
             <p className="text-[36px] text-slate-300 leading-snug mt-5">
-              <span className="font-bold text-white">Rapidly</span> finds <span className="font-bold" style={{ color: AMBER }}>Low Cost</span> and <span className="font-bold" style={{ color: BLUE_LIGHT }}>High Accuracy</span> options among{" "}
+              <span className="font-bold text-white">Rapidly</span> finds <span className="font-bold" style={{ color: AMBER }}>Low Cost</span> and <span className="font-bold" style={{ color: BLUE_LIGHT }}>High Accuracy</span> options
+            </p>
+            <p className="text-[36px] text-slate-300 leading-snug mt-2">
+              among{" "}
               <a
                 href={`${SITE}/#/blog/the-config-multiverse`}
                 target="_blank"

--- a/src/pages/PitchFull.jsx
+++ b/src/pages/PitchFull.jsx
@@ -1121,9 +1121,31 @@ export function SlideROIPreview({ subtitle, footer } = {}) {
 // scrolling on 768px+ heights.
 // ===================================================================
 export function SlideOnePagerSummary() {
+  // The slide is fixed at 1280x720 to match the standalone /one-pager-2 page
+  // and the PPT 16:9 PDF output. On viewports narrower than 1280 (iPhone
+  // Safari, narrow tablets), the deck's `overflow-hidden` would otherwise
+  // clip the right side. Wrap the slide so it scales down to fit available
+  // width while preserving its 16:9 aspect ratio.
   return (
-    <div className="-my-24 flex items-center justify-center pt-14 pb-16">
-      <OnePager2Slide showHeader={false} showFooter={false} />
+    <div className="-my-24 pt-14 pb-16 w-full flex items-center justify-center overflow-hidden">
+      <div
+        className="relative"
+        style={{ width: "min(1280px, 100vw)", aspectRatio: "1280 / 720" }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: 1280,
+            height: 720,
+            transformOrigin: "top left",
+            transform: "scale(min(1, calc(100vw / 1280)))",
+          }}
+        >
+          <OnePager2Slide showHeader={false} showFooter={false} />
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Mobile fix**: SlideOnePagerSummary now scales the embedded OnePager2 slide via CSS transform to fit viewports narrower than 1280px (iPhone Safari etc.). Previously the deck's \`overflow-hidden\` clipped the right side, making /pitch-short look broken on mobile.
- **PPT 16:9 dimensions**: OnePager2Slide moved from A4 landscape (1123×794) to PowerPoint widescreen (1280×720). The standalone /one-pager-2 PDF now drops straight into a PPT deck pixel-for-pixel.
- **Layout fits**: hero margin reduced (mb-14 → mb-6), section padding bumped (py-6 → pt-6 pb-8), @page rule updated to 13.333in × 7.5in.

## Test plan
- [ ] CI green
- [ ] Manual: open https://www.traigent.ai/#/pitch-short on iPhone — slide 1 renders fully (scaled to fit)
- [ ] Manual: https://www.traigent.ai/#/one-pager-2 still renders cleanly on desktop
- [ ] Manual: /pitch-full slide 2 still works on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)