### PR TITLE
revert: /pitch-short opens with OnePager2 summary again

### DIFF
--- a/src/pages/PitchShort.jsx
+++ b/src/pages/PitchShort.jsx
@@ -7,7 +7,7 @@
 import { ArrowRight } from "lucide-react";
 import {
   PitchDeck,
-  SlideHero,
+  SlideOnePagerSummary,
   Slide03Explosion,
   Slide06KillerStat,
   Slide07FeedbackLoop,
@@ -64,12 +64,8 @@ function SlideROIPreviewShort() {
 }
 
 const SHORT_SLIDES = [
-  // ----- HERO (opener) -----
-  // Was using the embedded one-pager slide here, but the fixed 1280x720
-  // layout crashes iOS WebKit (Safari + Chrome). The standalone
-  // /one-pager-2 page + its PDF are still the outreach artifacts; the deck
-  // opens with the regular hero now.
-  { title: "Hero", section: "Traigent intro", component: SlideHero },
+  // ----- ONE-PAGER SUMMARY (opener) -----
+  { title: "One-Pager Summary", section: "Traigent intro", component: SlideOnePagerSummary },
   // ----- PROBLEM -----
   { title: "The Configuration Explosion", section: "Problem", component: Slide03ExplosionShort },
   // ----- SOLUTION -----


### PR DESCRIPTION
Restoring the OnePager2 summary as the first slide of /pitch-short. User accepts the iPhone WebKit issue for now to keep the deck PDF + desktop view as designed.