### PR TITLE
fix(seo): page title to 'Traigent — Agent Optimization Platform'

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="./favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Traigent - Trust Your AI Agents at Scale</title>
+    <title>Traigent — Agent Optimization Platform</title>
     <meta name="description" content="If you can measure it, we can improve it. Traigent helps companies ship AI agents from lab to production, at scale, with confidence." />
 
     <!-- Open Graph / Social Media -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Traigent - Trust Your AI Agents at Scale" />
+    <meta property="og:title" content="Traigent — Agent Optimization Platform" />
     <meta property="og:description" content="If you can measure it, we can improve it. Traigent helps companies ship AI agents from lab to production, at scale, with confidence." />
     <meta property="og:url" content="https://traigent.ai/" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Traigent - Trust Your AI Agents at Scale" />
+    <meta name="twitter:title" content="Traigent — Agent Optimization Platform" />
     <meta name="twitter:description" content="If you can measure it, we can improve it. Traigent helps companies ship AI agents from lab to production, at scale, with confidence." />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://forms.hubspot.com; script-src 'self' https://www.googletagmanager.com https://*.clarity.ms https://*.hs-scripts.com https://*.hs-analytics.net https://*.hs-banner.com https://*.hscollectedforms.net https://*.hubspot.com https://*.hsforms.net https://*.hsforms.com https://*.hubapi.com https://*.usemessages.com https://*.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com https://*.hubspot.com https://*.usemessages.com; connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://*.clarity.ms https://*.hubspot.com https://*.hs-analytics.net https://*.hs-banner.com https://*.hscollectedforms.net https://*.hsforms.com https://*.hubapi.com https://*.usemessages.com wss://*.hubspot.com wss://*.usemessages.com https://*.posthog.com; frame-src https://*.hubspot.com https://*.usemessages.com https://*.hsforms.com; upgrade-insecure-requests" />
     

--- a/src/pages/Investors.jsx
+++ b/src/pages/Investors.jsx
@@ -312,7 +312,7 @@ export default function Investors() {
     document.head.appendChild(link)
 
     return () => {
-      document.title = 'Traigent - Trust Your AI Agents at Scale'
+      document.title = 'Traigent — Agent Optimization Platform'
     }
   }, [])
 


### PR DESCRIPTION
Replaces stale 'Trust Your AI Agents at Scale' tagline that was in index.html (title + og + twitter) and Investors.jsx fallback. Search/social crawlers will now pick up the correct title.