### PR TITLE
feat: /pitch-short-2 vertical-scroll deck + compact OnePager2 layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import TableDemo from './pages/TableDemo'
 import Pitch from './pages/Pitch'
 import PitchFull from './pages/PitchFull'
 import PitchShort from './pages/PitchShort'
+import PitchShort2 from './pages/PitchShort2'
 import Blog from './pages/Blog'
 import BlogPost from './pages/BlogPost'
 import ROICalculator from './pages/ROICalculator'
@@ -32,6 +33,7 @@ export default function App() {
       <Route path="pitch" element={<Pitch />} />
       <Route path="pitch-full" element={<PitchFull />} />
       <Route path="pitch-short" element={<PitchShort />} />
+      <Route path="pitch-short-2" element={<PitchShort2 />} />
       <Route path="one-pager" element={<OnePager />} />
       <Route path="one-pager-2" element={<OnePager2 />} />
 

--- a/src/pages/OnePager2.jsx
+++ b/src/pages/OnePager2.jsx
@@ -68,7 +68,7 @@ export function OnePager2Slide({ showHeader = true, showFooter = true, costStatV
   const useFixedHeight = showHeader && showFooter;
   return (
     <section
-      className={`relative w-[1280px] ${useFixedHeight ? "h-[720px]" : ""} bg-[#080808] text-white overflow-hidden flex flex-col px-10 pt-6 pb-8`}
+      className={`relative w-[1280px] ${useFixedHeight ? "h-[720px]" : ""} bg-[#080808] text-white overflow-hidden flex flex-col px-10 pt-4 pb-4`}
     >
       {showHeader && (
         <div className="flex items-center justify-between mb-3">
@@ -90,15 +90,15 @@ export function OnePager2Slide({ showHeader = true, showFooter = true, costStatV
       )}
 
       {/* Solution hero */}
-          <div className="mb-6">
-            <h2 className="text-[68px] font-bold tracking-tight leading-[1.05]">
+          <div className="mb-3">
+            <h2 className="text-[56px] font-bold tracking-tight leading-[1.05]">
               AI Agent Optimization —<br />
               <span style={{ color: BLUE_LIGHT }}>Fully Automated</span>
             </h2>
-            <p className="text-[36px] text-slate-300 leading-snug mt-5">
+            <p className="text-[28px] text-slate-300 leading-snug mt-3">
               <span className="font-bold text-white">Rapidly</span> finds <span className="font-bold" style={{ color: AMBER }}>Low Cost</span> and <span className="font-bold" style={{ color: BLUE_LIGHT }}>High Accuracy</span> options
             </p>
-            <p className="text-[36px] text-slate-300 leading-snug mt-2">
+            <p className="text-[28px] text-slate-300 leading-snug mt-1">
               among{" "}
               <a
                 href={`${SITE}/#/blog/the-config-multiverse`}

--- a/src/pages/PitchShort.jsx
+++ b/src/pages/PitchShort.jsx
@@ -63,7 +63,7 @@ function SlideROIPreviewShort() {
   );
 }
 
-const SHORT_SLIDES = [
+export const SHORT_SLIDES = [
   // ----- ONE-PAGER SUMMARY (opener) -----
   { title: "One-Pager Summary", section: "Traigent intro", component: SlideOnePagerSummary },
   // ----- PROBLEM -----

--- a/src/pages/PitchShort2.jsx
+++ b/src/pages/PitchShort2.jsx
@@ -1,0 +1,72 @@
+// /pitch-short-2 — same slides as /pitch-short, but rendered as a vertical
+// scrollable page (one slide per viewport-height section). No top bar, no
+// bottom nav, no keyboard handlers, no animated transitions. Designed for
+// recipients who prefer scrolling over slide-by-slide presentation chrome.
+import { Helmet } from "react-helmet-async";
+import { SHORT_SLIDES } from "./PitchShort";
+import { OnePager2Slide } from "./OnePager2";
+
+// Slide 1 in /pitch-short uses SlideOnePagerSummary which wraps OnePager2Slide
+// with deck-specific negative margins (-my-24) to cancel the PitchDeck's
+// py-24 padding. In scroll mode there's no parent padding to cancel, so
+// render OnePager2Slide directly here.
+function ScrollOnePagerOpener() {
+  return <OnePager2Slide showHeader={false} showFooter={false} />;
+}
+
+const SCROLL_SLIDES = SHORT_SLIDES.map((s, i) =>
+  i === 0 ? { ...s, component: ScrollOnePagerOpener } : s
+);
+
+export default function PitchShort2() {
+  return (
+    <>
+      <Helmet>
+        <title>Traigent — Pitch (Scroll)</title>
+      </Helmet>
+      {/* Suppress HubSpot chat widget + cookie banner — this is a clean
+          presentation surface, no chat needed. */}
+      <style>{`
+        #hubspot-messages-iframe-container,
+        .hs-messages-mobile,
+        .hs-banner-iframe,
+        #hs-eu-cookie-confirmation,
+        #hs-eu-cookie-confirmation-inner { display: none !important; visibility: hidden !important; }
+      `}</style>
+      <div className="bg-[#080808] text-white">
+        {SCROLL_SLIDES.map((slide, i) => {
+          const Slide = slide.component;
+          return (
+            <section
+              key={`${i}-${slide.title}`}
+              className="min-h-screen flex items-center justify-center bg-[#080808] border-b border-slate-900/60 last:border-b-0"
+            >
+              {/* Visible 16:9 grey-framed rectangle (1280x720) consistent
+                  across every slide. Traigent.ai brand mark sits at its
+                  top-left corner; the slide content fills the rest of the box. */}
+              <div className="relative w-[1280px] h-[720px] max-w-full border border-slate-600 rounded-lg">
+                <a
+                  href="https://www.traigent.ai/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="absolute top-4 left-4 z-10 flex items-center gap-2 hover:opacity-80 transition-opacity"
+                  aria-label="Traigent.ai"
+                >
+                  <img src="/images/traigent-logo-icon.png" alt="" aria-hidden="true" className="h-6 w-auto" />
+                  <span className="text-white text-base md:text-lg font-bold tracking-tight">Traigent.ai</span>
+                </a>
+                <div className="absolute inset-0 flex items-center justify-center px-6 md:px-10">
+                  <Slide />
+                </div>
+                {/* Slide number at bottom-right of the frame */}
+                <span className="absolute bottom-3 right-4 text-slate-500 text-xs md:text-sm font-mono">
+                  {i + 1} / {SCROLL_SLIDES.length}
+                </span>
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
New /pitch-short-2 route — same 18 slides as /pitch-short rendered as a scrollable page with no chrome. Each slide in a 16:9 grey-framed box with Traigent.ai brand mark top-left and slide number bottom-right. Also compacts OnePager2 to fit its full content in 1280x720.