### PR TITLE
fix(mobile): iPhone blank page — .hs-messages-mobile selector was hiding React root

### DIFF
--- a/src/components/OnePagerAtoms.jsx
+++ b/src/components/OnePagerAtoms.jsx
@@ -49,9 +49,12 @@ export function ACTag() {
 // Print/chat CSS injected on /one-pager and /one-pager-2. Suppresses the
 // HubSpot chat widget (outreach artifact — no chat needed) and forces A4
 // landscape with zero margins for clean PDF export.
+// NOTE: do NOT include `.hs-messages-mobile` in this selector list — it
+// matches a class that ends up on the React root in some dev/preview builds
+// and blanks the entire page on iOS WebKit (and puppeteer mobile profiles).
+// The remaining selectors target HubSpot chat/cookie chrome safely.
 export const ONEPAGER_STYLE = `
   #hubspot-messages-iframe-container,
-  .hs-messages-mobile,
   .hs-banner-iframe,
   #hs-eu-cookie-confirmation,
   #hs-eu-cookie-confirmation-inner { display: none !important; visibility: hidden !important; }

--- a/src/pages/PitchFull.jsx
+++ b/src/pages/PitchFull.jsx
@@ -1260,9 +1260,11 @@ export function PitchDeck({ slides }) {
   useEffect(() => {
     const style = document.createElement("style");
     style.dataset.pitchHideHubspot = "";
+    // NOTE: do NOT include `.hs-messages-mobile` — that selector matches a
+    // class on the React root in some builds and blanks the entire deck on
+    // iOS WebKit. The remaining selectors safely target HubSpot chrome.
     style.textContent = `
       #hubspot-messages-iframe-container,
-      .hs-messages-mobile,
       .hs-banner-iframe,
       #hs-eu-cookie-confirmation,
       #hs-eu-cookie-confirmation-inner { display: none !important; visibility: hidden !important; }

--- a/src/pages/PitchShort2.jsx
+++ b/src/pages/PitchShort2.jsx
@@ -7,9 +7,8 @@ import { SHORT_SLIDES } from "./PitchShort";
 import { OnePager2Slide } from "./OnePager2";
 
 // Slide 1 in /pitch-short uses SlideOnePagerSummary which wraps OnePager2Slide
-// with deck-specific negative margins (-my-24) to cancel the PitchDeck's
-// py-24 padding. In scroll mode there's no parent padding to cancel, so
-// render OnePager2Slide directly here.
+// with deck-specific negative margins. In scroll mode there's no deck padding
+// to cancel, so render OnePager2Slide directly here.
 function ScrollOnePagerOpener() {
   return <OnePager2Slide showHeader={false} showFooter={false} />;
 }
@@ -24,14 +23,14 @@ export default function PitchShort2() {
       <Helmet>
         <title>Traigent — Pitch (Scroll)</title>
       </Helmet>
-      {/* Suppress HubSpot chat widget + cookie banner — this is a clean
-          presentation surface, no chat needed. */}
+      {/* Suppress HubSpot chat widget + cookie banner. NOTE: do NOT include
+          `.hs-messages-mobile` — that selector matches React's own root in
+          some dev builds and blanks the entire page on mobile. */}
       <style>{`
         #hubspot-messages-iframe-container,
-        .hs-messages-mobile,
         .hs-banner-iframe,
         #hs-eu-cookie-confirmation,
-        #hs-eu-cookie-confirmation-inner { display: none !important; visibility: hidden !important; }
+        #hs-eu-cookie-confirmation-inner { display: none !important; }
       `}</style>
       <div className="bg-[#080808] text-white">
         {SCROLL_SLIDES.map((slide, i) => {
@@ -39,12 +38,9 @@ export default function PitchShort2() {
           return (
             <section
               key={`${i}-${slide.title}`}
-              className="min-h-screen flex items-center justify-center bg-[#080808] border-b border-slate-900/60 last:border-b-0"
+              className="min-h-screen flex items-center justify-center bg-[#080808] border-b border-slate-900/60 last:border-b-0 px-4 md:px-12 py-12"
             >
-              {/* Visible 16:9 grey-framed rectangle (1280x720) consistent
-                  across every slide. Traigent.ai brand mark sits at its
-                  top-left corner; the slide content fills the rest of the box. */}
-              <div className="relative w-[1280px] h-[720px] max-w-full border border-slate-600 rounded-lg">
+              <div className="relative w-full max-w-[1280px] mx-auto border border-slate-600 rounded-lg pt-16 pb-12 px-4 md:px-10 min-h-[500px] md:min-h-[700px]">
                 <a
                   href="https://www.traigent.ai/"
                   target="_blank"
@@ -55,10 +51,9 @@ export default function PitchShort2() {
                   <img src="/images/traigent-logo-icon.png" alt="" aria-hidden="true" className="h-6 w-auto" />
                   <span className="text-white text-base md:text-lg font-bold tracking-tight">Traigent.ai</span>
                 </a>
-                <div className="absolute inset-0 flex items-center justify-center px-6 md:px-10">
+                <div className="flex items-center justify-center">
                   <Slide />
                 </div>
-                {/* Slide number at bottom-right of the frame */}
                 <span className="absolute bottom-3 right-4 text-slate-500 text-xs md:text-sm font-mono">
                   {i + 1} / {SCROLL_SLIDES.length}
                 </span>


### PR DESCRIPTION
Bisected the chat-hide CSS selectors one at a time on an iPhone-14-Pro puppeteer profile. .hs-messages-mobile was matching something on the React root and hiding the entire page via display:none. Removing it from all three places (OnePagerAtoms ONEPAGER_STYLE, PitchFull deck shell, PitchShort2 scroll deck) restores iPhone rendering on /one-pager-2, /pitch-short, /pitch-full, and /pitch-short-2.