### PR TITLE
ship: new homepage meta description + /pitch-short-2 polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,18 +5,18 @@
     <link rel="icon" type="image/png" href="./favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Traigent — Agent Optimization Platform</title>
-    <meta name="description" content="If you can measure it, we can improve it. Traigent helps companies ship AI agents from lab to production, at scale, with confidence." />
+    <meta name="description" content="Rapidly finds Low Cost and High Accuracy options among thousands possible." />
 
     <!-- Open Graph / Social Media -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Traigent — Agent Optimization Platform" />
-    <meta property="og:description" content="If you can measure it, we can improve it. Traigent helps companies ship AI agents from lab to production, at scale, with confidence." />
+    <meta property="og:description" content="Rapidly finds Low Cost and High Accuracy options among thousands possible." />
     <meta property="og:url" content="https://traigent.ai/" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Traigent — Agent Optimization Platform" />
-    <meta name="twitter:description" content="If you can measure it, we can improve it. Traigent helps companies ship AI agents from lab to production, at scale, with confidence." />
+    <meta name="twitter:description" content="Rapidly finds Low Cost and High Accuracy options among thousands possible." />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://forms.hubspot.com; script-src 'self' https://www.googletagmanager.com https://*.clarity.ms https://*.hs-scripts.com https://*.hs-analytics.net https://*.hs-banner.com https://*.hscollectedforms.net https://*.hubspot.com https://*.hsforms.net https://*.hsforms.com https://*.hubapi.com https://*.usemessages.com https://*.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com https://*.hubspot.com https://*.usemessages.com; connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://*.clarity.ms https://*.hubspot.com https://*.hs-analytics.net https://*.hs-banner.com https://*.hscollectedforms.net https://*.hsforms.com https://*.hubapi.com https://*.usemessages.com wss://*.hubspot.com wss://*.usemessages.com https://*.posthog.com; frame-src https://*.hubspot.com https://*.usemessages.com https://*.hsforms.com; upgrade-insecure-requests" />
     
     <!-- GitHub Pages SPA routing fix -->

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -73,14 +73,14 @@ export default function Homepage() {
     <div className="bg-white">
       <Helmet>
         <title>Traigent — Agent Optimization Platform</title>
-        <meta name="description" content="Traigent finds the optimum agent configuration in hours not weeks, automatically not manually. Optimization + Benchmark Evolution + Observability and Tracing — in one platform." />
+        <meta name="description" content="Rapidly finds Low Cost and High Accuracy options among thousands possible." />
         <meta property="og:title" content="Traigent — AI Agent Optimization Platform" />
-        <meta property="og:description" content="Find the optimum agent configuration in hours, automatically. Optimization + Benchmark Evolution + Observability — in one platform." />
+        <meta property="og:description" content="Rapidly finds Low Cost and High Accuracy options among thousands possible." />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://traigent.ai" />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content="Traigent — AI Agent Optimization Platform" />
-        <meta name="twitter:description" content="Find the optimum agent configuration in hours, automatically." />
+        <meta name="twitter:description" content="Rapidly finds Low Cost and High Accuracy options among thousands possible." />
         <script type="application/ld+json">
           {JSON.stringify({
             "@context": "https://schema.org",

--- a/src/pages/OnePager2.jsx
+++ b/src/pages/OnePager2.jsx
@@ -16,11 +16,11 @@ import {
 // ---------- Solution stat (full-size for one-pager-2) ----------
 function SolutionStat({ value, label, color }) {
   return (
-    <div className="bg-slate-900/70 border-2 rounded-xl p-5 text-center" style={{ borderColor: `${color}66` }}>
-      <div className="text-4xl font-extrabold tracking-tight leading-none mb-2" style={{ color }}>
+    <div className="bg-slate-900/70 border-2 rounded-xl px-5 py-3 text-center" style={{ borderColor: `${color}66` }}>
+      <div className="text-4xl font-extrabold tracking-tight leading-none mb-1" style={{ color }}>
         {value}
       </div>
-      <div className="text-[16px] font-mono uppercase tracking-wider text-slate-300 leading-snug">{label}</div>
+      <div className="text-[15px] font-mono uppercase tracking-wider text-slate-300 leading-snug">{label}</div>
     </div>
   );
 }
@@ -68,7 +68,7 @@ export function OnePager2Slide({ showHeader = true, showFooter = true, costStatV
   const useFixedHeight = showHeader && showFooter;
   return (
     <section
-      className={`relative w-[1280px] ${useFixedHeight ? "h-[720px]" : ""} bg-[#080808] text-white overflow-hidden flex flex-col px-10 pt-4 pb-4`}
+      className={`relative w-[1280px] ${useFixedHeight ? "h-[720px]" : ""} bg-[#080808] text-white overflow-hidden flex flex-col px-10 ${showHeader ? "pt-4" : "pt-1"} pb-4`}
     >
       {showHeader && (
         <div className="flex items-center justify-between mb-3">
@@ -90,7 +90,7 @@ export function OnePager2Slide({ showHeader = true, showFooter = true, costStatV
       )}
 
       {/* Solution hero */}
-          <div className="mb-3">
+          <div className="mb-12 text-center">
             <h2 className="text-[56px] font-bold tracking-tight leading-[1.05]">
               AI Agent Optimization —<br />
               <span style={{ color: BLUE_LIGHT }}>Fully Automated</span>
@@ -138,10 +138,10 @@ export function OnePager2Slide({ showHeader = true, showFooter = true, costStatV
           <div className="grid grid-cols-2 gap-4 mb-4">
             <div className="bg-slate-900/70 border rounded-xl p-5" style={{ borderColor: `${AMBER}55` }}>
               <ul className="space-y-2">
-                <BenefitItem><span className="text-white font-semibold">Rapidly Converges</span> to <span className="text-white font-semibold">Best Cost-Performance</span></BenefitItem>
-                <BenefitItem><span className="text-white font-semibold">Slashes costs</span> while maintaining high quality</BenefitItem>
+                <BenefitItem><span className="text-white font-semibold">Rapidly Converge</span> to <span className="font-semibold">Best </span><span className="font-semibold" style={{ color: AMBER }}>Cost</span><span className="font-semibold">-</span><span className="font-semibold" style={{ color: BLUE_LIGHT }}>Performance</span></BenefitItem>
+                <BenefitItem><span className="text-white font-semibold">Slash costs</span> while maintaining high quality</BenefitItem>
                 <BenefitItem>Recurring savings <span className="text-white font-semibold">through agent's lifetime</span></BenefitItem>
-                <BenefitItem><span className="text-white font-semibold">Control costs</span> with confidence</BenefitItem>
+                <BenefitItem><span className="text-white font-semibold">Faster TTM</span>, <span className="text-white font-semibold">More productivity</span></BenefitItem>
               </ul>
               <div className="pt-3">
                 <FooterLink href={`${SITE}/#/roi`} color={AMBER}>Compute your ROI</FooterLink>
@@ -149,10 +149,10 @@ export function OnePager2Slide({ showHeader = true, showFooter = true, costStatV
             </div>
             <div className="bg-slate-900/70 border rounded-xl p-5" style={{ borderColor: `${BLUE}55` }}>
               <ul className="space-y-2">
-                <BenefitItem><span className="text-white font-semibold">Rapidly Converges</span> to <span className="text-white font-semibold">Best Accuracy</span></BenefitItem>
-                <BenefitItem>Ship with <span className="text-white font-semibold">100% confidence</span> — <span className="text-white font-semibold">eliminate guesswork</span></BenefitItem>
+                <BenefitItem><span className="text-white font-semibold">Rapidly Converge</span> to <span className="font-semibold" style={{ color: BLUE_LIGHT }}>Best Accuracy</span></BenefitItem>
+                <BenefitItem>Ship <span className="text-white font-semibold">fast</span> with <span className="text-white font-semibold">100% confidence</span> — <span className="text-white font-semibold">no guesswork</span></BenefitItem>
                 <BenefitItem>Re-optimize on every new release</BenefitItem>
-                <BenefitItem>Includes <span className="text-white font-semibold">benchmark optimization and observability</span> for free</BenefitItem>
+                <BenefitItem><span className="text-white font-semibold">Observability and benchmark optimization</span> included</BenefitItem>
               </ul>
               <div className="pt-3">
                 <FooterLink href={`${SITE}/#/ttm`} color={BLUE_LIGHT}>Compute your TTM</FooterLink>

--- a/src/pages/PitchFull.jsx
+++ b/src/pages/PitchFull.jsx
@@ -977,7 +977,7 @@ export function Slide21Closing() {
         <span style={{ color: BLUE }}>Higher Confidence.</span>
       </h1>
       <p className="text-2xl md:text-3xl text-slate-300 font-medium mb-16 max-w-3xl mx-auto" style={{ textWrap: "balance" }}>
-        <span style={{ color: BLUE }} className="font-bold">Traigent</span> — AI Agent <span style={{ color: BLUE }} className="font-semibold">Cost-Performance</span>. Optimized. <span style={{ color: BLUE }} className="font-semibold">Automatically.</span>
+        <span className="whitespace-nowrap"><span style={{ color: BLUE }} className="font-bold">Traigent</span> — AI Agent <span style={{ color: BLUE }} className="font-semibold">Cost-Performance</span>.</span> Optimized. <span style={{ color: BLUE }} className="font-semibold">Automatically.</span>
       </p>
       <p className="text-lg text-slate-500 font-mono">amir@traigent.ai · traigent.ai</p>
     </div>


### PR DESCRIPTION
- Replaces homepage meta description (index.html + Homepage.jsx Helmet) with 'Rapidly finds Low Cost and High Accuracy options among thousands possible.' — used by Google search results + LinkedIn/Twitter/Slack link previews.
- /pitch-short-2 (OnePager2Slide) bullet rewordings + color tweaks + layout polish.
- Slide21Closing in PitchFull: nowrap on 'Traigent — AI Agent Cost-Performance.' so the hyphen no longer breaks the line.