### PR TITLE
ship: site-wide brand mark — icon + Traigent.ai

### DIFF
--- a/src/components/BrandMark.jsx
+++ b/src/components/BrandMark.jsx
@@ -1,0 +1,55 @@
+// Brand mark — small icon + "Traigent.ai" text, mirroring the slide-deck
+// chrome (PitchShort2 frame). Single source so every header / nav / hero on
+// the site speaks with one voice.
+//
+// Size variants:
+//   sm    — sticky nav / inline chrome (h-5 icon + text-xl)        DEFAULT
+//   md    — slide / page header        (h-6 icon + text-base/lg)
+//   lg    — section header / wordmark replacement (h-10 icon + text-3xl)
+//   hero  — deck slide-1 / page hero  (h-14 md:h-20 icon + text-5xl…7xl)
+const SIZES = {
+  sm: {
+    iconClass: "h-5 w-auto",
+    textClass: "text-xl font-bold tracking-tight",
+    gapClass: "gap-2",
+  },
+  md: {
+    iconClass: "h-6 w-auto",
+    textClass: "text-base md:text-lg font-bold tracking-tight",
+    gapClass: "gap-2",
+  },
+  lg: {
+    iconClass: "h-10 md:h-12 w-auto",
+    textClass: "text-2xl md:text-3xl font-bold tracking-tight",
+    gapClass: "gap-3",
+  },
+  hero: {
+    iconClass: "h-14 md:h-16 lg:h-20 w-auto",
+    textClass: "text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-tight",
+    gapClass: "gap-3 md:gap-4",
+  },
+};
+
+export default function BrandMark({
+  size = "sm",
+  className = "",
+  iconClassName,
+  textClassName,
+  textColorClass = "text-white",
+  as: As = "span",
+}) {
+  const preset = SIZES[size] ?? SIZES.sm;
+  return (
+    <As className={`inline-flex items-center leading-none ${preset.gapClass} ${className}`}>
+      <img
+        src="/images/traigent-logo-icon.png"
+        alt=""
+        aria-hidden="true"
+        className={iconClassName ?? preset.iconClass}
+      />
+      <span className={`${textColorClass} ${textClassName ?? preset.textClass}`}>
+        Traigent.ai
+      </span>
+    </As>
+  );
+}

--- a/src/components/OnePagerAtoms.jsx
+++ b/src/components/OnePagerAtoms.jsx
@@ -8,9 +8,6 @@ export const AMBER = "#f59e0b";
 export const RED = "#f87171";
 export const SITE = "https://www.traigent.ai";
 
-export const LOGO_SRC =
-  "https://qtrypzzcjebvfcihiynt.supabase.co/storage/v1/object/public/base44-prod/public/057ce2_TraigentLogoWhiteCropped.png";
-
 // A/C badges — used inline in prose and in panel headers. Same visual language
 // throughout the one-pager artifacts.
 export function ATag() {

--- a/src/components/PlatformShowcase.jsx
+++ b/src/components/PlatformShowcase.jsx
@@ -1,0 +1,248 @@
+// Shared "platform components" + "beyond optimization" card bodies.
+// Used by the homepage product section AND the /pitch-short(-2) appendix
+// slides so the SVG-heavy markup lives in exactly one place.
+
+import { Sparkles, Eye } from "lucide-react";
+
+// ---------- Optimization Engine ----------
+export function OptimizationEngineBody() {
+  return (
+    <>
+      <div className="flex items-center gap-3 mb-3">
+        <h3 className="text-lg font-bold text-white">Optimization Engine</h3>
+      </div>
+      <p className="text-slate-400 text-sm mb-6 leading-relaxed">
+        Learns from previous model and configuration combo results and determines the next best combination to test.
+      </p>
+      <svg viewBox="0 0 320 260" className="w-full" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="optArrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon points="0 0, 8 3, 0 6" fill="#1A6BF5"/>
+          </marker>
+        </defs>
+        <rect x="8" y="50" width="88" height="80" rx="8" fill="#1e293b" stroke="#334155" strokeWidth="1"/>
+        <text x="52" y="68" textAnchor="middle" fill="#64748b" fontSize="8" fontFamily="monospace">Previous Results</text>
+        <line x1="16" y1="74" x2="88" y2="74" stroke="#334155" strokeWidth="0.5"/>
+        <text x="52" y="86" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">gpt-4o / t=0.7</text>
+        <text x="52" y="97" textAnchor="middle" fill="#4ade80" fontSize="7.5" fontFamily="monospace">72% acc · $0.003</text>
+        <text x="52" y="108" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">gpt-4o-mini / t=0.3</text>
+        <text x="52" y="119" textAnchor="middle" fill="#facc15" fontSize="7.5" fontFamily="monospace">61% acc · $0.001</text>
+        <line x1="96" y1="90" x2="118" y2="90" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#optArrow)"/>
+        <rect x="118" y="58" width="76" height="64" rx="10" fill="#1A6BF5" fillOpacity="0.12" stroke="#1A6BF5" strokeWidth="1.5"/>
+        <text x="156" y="88" textAnchor="middle" fill="#93c5fd" fontSize="8.5" fontFamily="monospace">Optimizer</text>
+        <text x="156" y="110" textAnchor="middle" fill="#1A6BF5" fontSize="20">⚙</text>
+        <line x1="194" y1="90" x2="216" y2="90" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#optArrow)"/>
+        <rect x="216" y="55" width="96" height="70" rx="8" fill="#1e293b" stroke="#1A6BF5" strokeWidth="1" strokeDasharray="4,2"/>
+        <text x="264" y="74" textAnchor="middle" fill="#93c5fd" fontSize="8.5" fontFamily="monospace">Next Combo</text>
+        <line x1="224" y1="79" x2="304" y2="79" stroke="#1A6BF5" strokeWidth="0.5" strokeOpacity="0.4"/>
+        <text x="264" y="92" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">o3-mini</text>
+        <text x="264" y="104" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">temp: 0.2</text>
+        <text x="264" y="116" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">top_p: 0.85</text>
+        <rect x="28" y="145" width="280" height="88" rx="4" fill="#0f172a"/>
+        <line x1="36" y1="225" x2="304" y2="225" stroke="#334155" strokeWidth="0.8"/>
+        <line x1="36" y1="148" x2="36" y2="225" stroke="#334155" strokeWidth="0.8"/>
+        <rect x="204" y="148" width="104" height="77" fill="#1e293b" fillOpacity="0.8"/>
+        <circle cx="218" cy="163" r="1.5" fill="#334155"/><circle cx="234" cy="177" r="1.5" fill="#334155"/>
+        <circle cx="248" cy="159" r="1.5" fill="#334155"/><circle cx="263" cy="188" r="1.5" fill="#334155"/>
+        <circle cx="276" cy="171" r="1.5" fill="#334155"/><circle cx="289" cy="165" r="1.5" fill="#334155"/>
+        <circle cx="221" cy="198" r="1.5" fill="#334155"/><circle cx="239" cy="211" r="1.5" fill="#334155"/>
+        <circle cx="255" cy="218" r="1.5" fill="#334155"/><circle cx="268" cy="203" r="1.5" fill="#334155"/>
+        <circle cx="281" cy="191" r="1.5" fill="#334155"/><circle cx="293" cy="213" r="1.5" fill="#334155"/>
+        <circle cx="225" cy="220" r="1.5" fill="#334155"/><circle cx="244" cy="155" r="1.5" fill="#334155"/>
+        <circle cx="259" cy="179" r="1.5" fill="#334155"/><circle cx="273" cy="189" r="1.5" fill="#334155"/>
+        <circle cx="286" cy="221" r="1.5" fill="#334155"/><circle cx="297" cy="170" r="1.5" fill="#334155"/>
+        <circle cx="230" cy="185" r="1.5" fill="#334155"/><circle cx="252" cy="207" r="1.5" fill="#334155"/>
+        <line x1="204" y1="148" x2="204" y2="225" stroke="#1A6BF5" strokeWidth="1" strokeOpacity="0.4" strokeDasharray="3,2"/>
+        <line x1="36" y1="164" x2="204" y2="164" stroke="#4ade80" strokeWidth="0.8" strokeDasharray="3,2" strokeOpacity="0.5"/>
+        <path d="M 50 222 C 72 210, 92 196, 114 181 S 154 169, 174 165 S 192 164, 204 164" stroke="#1A6BF5" strokeWidth="2" fill="none"/>
+        <circle cx="50" cy="222" r="3" fill="#1A6BF5"/>
+        <circle cx="74" cy="209" r="3" fill="#1A6BF5"/>
+        <circle cx="96" cy="195" r="3" fill="#1A6BF5"/>
+        <circle cx="118" cy="181" r="3" fill="#1A6BF5"/>
+        <circle cx="140" cy="171" r="3" fill="#1A6BF5"/>
+        <circle cx="160" cy="166" r="3" fill="#1A6BF5"/>
+        <circle cx="180" cy="164" r="3" fill="#1A6BF5"/>
+        <circle cx="204" cy="164" r="4" fill="#4ade80"/>
+        <text x="172" y="159" textAnchor="middle" fill="#4ade80" fontSize="7" fontFamily="monospace">✓ optimal</text>
+        <text x="30" y="152" fill="#475569" fontSize="7" fontFamily="monospace">KPI ↑</text>
+        <text x="120" y="238" textAnchor="middle" fill="#94a3b8" fontSize="8" fontFamily="monospace">tested (under 10%)</text>
+        <text x="254" y="238" textAnchor="middle" fill="#475569" fontSize="8" fontFamily="monospace">not needed</text>
+      </svg>
+      <p className="text-slate-400 text-sm text-center mt-3">Finds the optimum needing only a fraction of the model and configuration combinations to experiment with</p>
+    </>
+  );
+}
+
+// ---------- Feedback loop connector ----------
+export function FeedbackLoopConnector() {
+  return (
+    <div className="flex lg:flex-col items-center justify-center gap-3 py-4 lg:py-0 lg:min-w-[180px]">
+      <span className="text-[#1A6BF5] text-base font-semibold font-mono whitespace-nowrap">next combo</span>
+      <svg width="160" height="94" viewBox="0 0 160 94" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <line x1="4" y1="14" x2="142" y2="14" stroke="#1A6BF5" strokeWidth="3" strokeLinecap="round"/>
+        <polygon points="140,6 156,14 140,22" fill="#1A6BF5"/>
+        <line x1="18" y1="80" x2="156" y2="80" stroke="#1A6BF5" strokeWidth="3" strokeLinecap="round"/>
+        <polygon points="20,72 4,80 20,88" fill="#1A6BF5"/>
+      </svg>
+      <span className="text-[#1A6BF5] text-base font-semibold font-mono whitespace-nowrap">KPI results</span>
+    </div>
+  );
+}
+
+// ---------- Agent Wrapper ----------
+export function AgentWrapperBody() {
+  return (
+    <>
+      <div className="flex items-center gap-3 mb-3">
+        <h3 className="text-lg font-bold text-white">Agent Wrapper</h3>
+      </div>
+      <p className="text-slate-400 text-sm mb-6 leading-relaxed">
+        Executes a given model and configuration on the benchmark test bed and measures agent KPIs.
+      </p>
+      <svg viewBox="0 0 320 260" className="w-full" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="wrapArrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon points="0 0, 8 3, 0 6" fill="#475569"/>
+          </marker>
+          <marker id="wrapArrowBlue" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon points="0 0, 8 3, 0 6" fill="#1A6BF5"/>
+          </marker>
+        </defs>
+        <rect x="8" y="18" width="304" height="235" rx="12" fill="none" stroke="#334155" strokeWidth="1.5" strokeDasharray="6,3"/>
+        <text x="20" y="32" fill="#475569" fontSize="8.5" fontFamily="monospace">[ Agent Wrapper ]</text>
+        <rect x="14" y="40" width="68" height="26" rx="6" fill="#1e293b" stroke="#1A6BF5" strokeWidth="1" strokeDasharray="3,2"/>
+        <text x="48" y="51" textAnchor="middle" fill="#64748b" fontSize="7.5" fontFamily="monospace">Model</text>
+        <text x="48" y="61" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">o3-mini</text>
+        <rect x="14" y="76" width="68" height="40" rx="6" fill="#1e293b" stroke="#1A6BF5" strokeWidth="1" strokeDasharray="3,2"/>
+        <text x="48" y="89" textAnchor="middle" fill="#64748b" fontSize="7.5" fontFamily="monospace">Config</text>
+        <text x="48" y="101" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">temp: 0.2</text>
+        <text x="48" y="111" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">top_p: 0.85</text>
+        <line x1="82" y1="53" x2="104" y2="70" stroke="#475569" strokeWidth="1.2" markerEnd="url(#wrapArrow)"/>
+        <line x1="82" y1="96" x2="104" y2="84" stroke="#475569" strokeWidth="1.2" markerEnd="url(#wrapArrow)"/>
+        <rect x="104" y="57" width="72" height="48" rx="8" fill="#1A6BF5" fillOpacity="0.12" stroke="#1A6BF5" strokeWidth="1.5"/>
+        <text x="140" y="74" textAnchor="middle" fill="#93c5fd" fontSize="8" fontFamily="monospace">Execute Agent</text>
+        <text x="140" y="95" textAnchor="middle" fill="#1A6BF5" fontSize="16">▶</text>
+        <line x1="140" y1="105" x2="140" y2="147" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#wrapArrowBlue)"/>
+        <rect x="86" y="148" width="116" height="86" rx="8" fill="#1e293b" stroke="#334155" strokeWidth="1"/>
+        <text x="144" y="164" textAnchor="middle" fill="#64748b" fontSize="8" fontFamily="monospace">Benchmark Test Bed</text>
+        <line x1="94" y1="169" x2="194" y2="169" stroke="#334155" strokeWidth="0.5"/>
+        <circle cx="97" cy="184" r="4" fill="#4ade80" fillOpacity="0.85"/>
+        <text x="97" y="187" textAnchor="middle" fill="white" fontSize="6">✓</text>
+        <text x="107" y="187" fill="#94a3b8" fontSize="7.5" fontFamily="monospace"> query_1  pass</text>
+        <circle cx="97" cy="198" r="4" fill="#4ade80" fillOpacity="0.85"/>
+        <text x="97" y="201" textAnchor="middle" fill="white" fontSize="6">✓</text>
+        <text x="107" y="201" fill="#94a3b8" fontSize="7.5" fontFamily="monospace"> query_2  pass</text>
+        <circle cx="97" cy="212" r="4" fill="#1A6BF5" fillOpacity="0.6"/>
+        <text x="97" y="215" textAnchor="middle" fill="white" fontSize="6.5">…</text>
+        <text x="107" y="215" fill="#475569" fontSize="7.5" fontFamily="monospace"> query_3  running</text>
+        <text x="193" y="228" textAnchor="end" fill="#334155" fontSize="7" fontFamily="monospace">N queries total</text>
+        <line x1="202" y1="191" x2="212" y2="191" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#wrapArrowBlue)"/>
+        <rect x="214" y="40" width="90" height="194" rx="8" fill="#1e293b" stroke="#334155" strokeWidth="1"/>
+        <text x="259" y="57" textAnchor="middle" fill="#64748b" fontSize="8.5" fontFamily="monospace">KPIs</text>
+        <line x1="222" y1="62" x2="296" y2="62" stroke="#334155" strokeWidth="0.5"/>
+        <text x="259" y="84" textAnchor="middle" fill="#4ade80" fontSize="8" fontFamily="monospace">accuracy  90%</text>
+        <text x="259" y="106" textAnchor="middle" fill="#facc15" fontSize="8" fontFamily="monospace">cost    $0.0002</text>
+        <text x="259" y="128" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">latency   1.2s</text>
+        <text x="259" y="150" textAnchor="middle" fill="#f472b6" fontSize="8" fontFamily="monospace">safety      ✓</text>
+        <text x="259" y="172" textAnchor="middle" fill="#a78bfa" fontSize="8" fontFamily="monospace">custom KPI  …</text>
+        <line x1="222" y1="190" x2="296" y2="190" stroke="#334155" strokeWidth="0.5"/>
+        <text x="259" y="208" textAnchor="middle" fill="#64748b" fontSize="7.5" fontFamily="monospace">weighted score</text>
+        <text x="259" y="226" textAnchor="middle" fill="#4ade80" fontSize="12" fontFamily="monospace" fontWeight="bold">0.86</text>
+        <line x1="20" y1="241" x2="300" y2="241" stroke="#f59e0b" strokeWidth="0.5" strokeOpacity="0.35" strokeDasharray="2,2"/>
+        <text x="20" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace" fontWeight="bold">+ benchmark insights:</text>
+        <text x="112" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace">⊘ easy</text>
+        <text x="155" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace">⨯ always-fail</text>
+        <text x="218" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace">↻ redundant</text>
+      </svg>
+      <p className="text-slate-400 text-sm text-center mt-3">Automated injection of model and configurations allows Optimizer to run successive tests seamlessly</p>
+    </>
+  );
+}
+
+// ---------- Self-Improving Benchmark ----------
+export function BenchmarkCardBody() {
+  return (
+    <>
+      <div className="flex items-center gap-3 mb-3">
+        <div className="w-10 h-10 rounded-lg bg-amber-500/10 border border-amber-500/30 flex items-center justify-center text-amber-400">
+          <Sparkles className="w-5 h-5" />
+        </div>
+        <h3 className="text-lg font-bold text-white">Self-Improving Benchmark</h3>
+      </div>
+      <p className="text-slate-400 text-sm mb-6 leading-relaxed">
+        Hundreds of runs across the same test bed reveal patterns. Traigent flags them automatically so your benchmark gets sharper — and every future run gets faster and cheaper.
+      </p>
+      <ul className="space-y-4">
+        <li className="flex gap-3">
+          <span className="flex-shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-xs">
+            <span>⊘</span><span>too easy</span>
+          </span>
+          <span className="text-slate-400 text-sm leading-relaxed">Every model & config passes — provides no discrimination. Safe to drop.</span>
+        </li>
+        <li className="flex gap-3">
+          <span className="flex-shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-xs">
+            <span>⨯</span><span>always fails</span>
+          </span>
+          <span className="text-slate-400 text-sm leading-relaxed">Nothing passes — fix the agent itself (code, flow, RAG) before optimization can help.</span>
+        </li>
+        <li className="flex gap-3">
+          <span className="flex-shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-xs">
+            <span>↻</span><span>redundant</span>
+          </span>
+          <span className="text-slate-400 text-sm leading-relaxed">Batches where a small sample carries the same signal — trim them and shorten every wrapper run.</span>
+        </li>
+      </ul>
+    </>
+  );
+}
+
+// ---------- Full Observability & Tracing ----------
+export function ObservabilityCardBody() {
+  return (
+    <>
+      <div className="flex items-center gap-3 mb-3">
+        <div className="w-10 h-10 rounded-lg bg-amber-500/10 border border-amber-500/30 flex items-center justify-center text-amber-400">
+          <Eye className="w-5 h-5" />
+        </div>
+        <h3 className="text-lg font-bold text-white">Full Observability & Tracing</h3>
+      </div>
+      <p className="text-slate-400 text-sm mb-6 leading-relaxed">
+        Every wrapper run is fully instrumented — spans, tokens, costs, and errors captured end-to-end. Production-grade tracing built in, with no separate observability stack to run.
+      </p>
+      <svg viewBox="0 0 320 200" className="w-full" xmlns="http://www.w3.org/2000/svg">
+        <rect x="4" y="4" width="312" height="192" rx="8" fill="#0f172a" stroke="#334155" strokeWidth="1"/>
+        <text x="14" y="22" fill="#f59e0b" fontSize="9" fontFamily="monospace" fontWeight="bold">Trace</text>
+        <text x="40" y="22" fill="#64748b" fontSize="8.5" fontFamily="monospace">· agent_run_42</text>
+        <text x="306" y="22" textAnchor="end" fill="#4ade80" fontSize="8.5" fontFamily="monospace">1.24s ✓</text>
+        <line x1="14" y1="30" x2="306" y2="30" stroke="#334155" strokeWidth="0.5"/>
+        <text x="14" y="46" fill="#93c5fd" fontSize="8" fontFamily="monospace">▾ agent_run</text>
+        <rect x="170" y="40" width="120" height="8" rx="2" fill="#1A6BF5" fillOpacity="0.45"/>
+        <text x="296" y="46" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">1240ms</text>
+        <text x="22" y="62" fill="#94a3b8" fontSize="8" fontFamily="monospace">├─ retrieve_context</text>
+        <rect x="170" y="56" width="18" height="8" rx="2" fill="#a78bfa" fillOpacity="0.65"/>
+        <text x="296" y="62" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">180ms</text>
+        <text x="36" y="76" fill="#64748b" fontSize="7" fontFamily="monospace">└─ vector_search · top_k=8</text>
+        <rect x="170" y="71" width="13" height="6" rx="1.5" fill="#a78bfa" fillOpacity="0.4"/>
+        <text x="296" y="76" textAnchor="end" fill="#475569" fontSize="6.5" fontFamily="monospace">120ms</text>
+        <text x="22" y="92" fill="#94a3b8" fontSize="8" fontFamily="monospace">├─ llm_call · gpt-4o-mini</text>
+        <rect x="188" y="86" width="74" height="8" rx="2" fill="#60a5fa" fillOpacity="0.65"/>
+        <text x="296" y="92" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">740ms</text>
+        <text x="36" y="106" fill="#475569" fontSize="7" fontFamily="monospace">tokens: 312 in · 89 out</text>
+        <text x="296" y="106" textAnchor="end" fill="#facc15" fontSize="7" fontFamily="monospace">$0.0006</text>
+        <text x="22" y="122" fill="#94a3b8" fontSize="8" fontFamily="monospace">└─ evaluator</text>
+        <rect x="262" y="116" width="32" height="8" rx="2" fill="#4ade80" fillOpacity="0.55"/>
+        <text x="296" y="122" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">320ms</text>
+        <text x="36" y="136" fill="#4ade80" fontSize="7" fontFamily="monospace">score: 0.92 ✓</text>
+        <line x1="14" y1="148" x2="306" y2="148" stroke="#334155" strokeWidth="0.5" strokeDasharray="2,2"/>
+        <text x="14" y="161" fill="#f59e0b" fontSize="7" fontFamily="monospace" fontWeight="bold">Timeline</text>
+        <text x="306" y="161" textAnchor="end" fill="#475569" fontSize="6.5" fontFamily="monospace">0 ──── 1.24s</text>
+        <rect x="14" y="166" width="292" height="22" rx="2" fill="#0a1424"/>
+        <rect x="14" y="169" width="282" height="4" rx="1" fill="#1A6BF5" fillOpacity="0.55"/>
+        <rect x="14" y="175" width="42" height="3.5" rx="1" fill="#a78bfa" fillOpacity="0.7"/>
+        <rect x="56" y="180" width="174" height="3.5" rx="1" fill="#60a5fa" fillOpacity="0.7"/>
+        <rect x="230" y="185" width="72" height="3.5" rx="1" fill="#4ade80" fillOpacity="0.7"/>
+      </svg>
+      <p className="text-slate-400 text-sm text-center mt-3">Inspect any agent execution end-to-end · debug failures · monitor production</p>
+    </>
+  );
+}

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { ChevronDown, Github, Menu, X } from "lucide-react";
 import StartNowModal from "./StartNowModal";
+import BrandMark from "./BrandMark";
 import { trackEvent } from "../lib/analytics";
 
 const PORTAL_URL = "https://portal.traigent.ai";
@@ -202,15 +203,10 @@ export default function TopNav() {
                   window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
                 }
               }}
-              className="flex items-center text-xl font-bold text-white leading-none"
+              className="flex items-center leading-none"
+              aria-label="Traigent.ai"
             >
-              <img
-                src="/images/traigent-logo-icon.png"
-                alt=""
-                aria-hidden="true"
-                className="h-5 w-auto mr-2"
-              />
-              Traigent
+              <BrandMark size="sm" />
             </Link>
 
             {/* Desktop tabs */}
@@ -330,15 +326,10 @@ export default function TopNav() {
               <Link
                 to="/"
                 onClick={closeMobile}
-                className="flex items-center text-lg font-bold text-white leading-none"
+                className="flex items-center leading-none"
+                aria-label="Traigent.ai"
               >
-                <img
-                  src="/images/traigent-logo-icon.png"
-                  alt=""
-                  aria-hidden="true"
-                  className="h-5 w-auto mr-2"
-                />
-                Traigent
+                <BrandMark size="sm" />
               </Link>
               <button
                 type="button"

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -117,32 +117,40 @@ export default function Homepage() {
           background: 'radial-gradient(ellipse, rgba(26,107,245,0.18) 0%, transparent 70%)'
         }}></div>
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 md:pt-14 pb-6 md:pb-8">
-          {/* Traigent Logo */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
-            className="mb-5 text-center"
-          >
-            <img
-              src="https://qtrypzzcjebvfcihiynt.supabase.co/storage/v1/object/public/base44-prod/public/057ce2_TraigentLogoWhiteCropped.png"
-              alt="Traigent Logo"
-              className="h-16 md:h-20 lg:h-24 w-auto mx-auto"
-            />
-          </motion.div>
-
           {/* Centered hero content */}
           <div className="text-center max-w-4xl mx-auto">
             <motion.h1
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.1 }}
-              className="text-5xl md:text-6xl lg:text-7xl font-bold leading-[1.05] tracking-tight mb-6"
+              className="text-5xl md:text-6xl lg:text-7xl font-bold leading-[1.55] tracking-tight mb-6"
               style={{ fontFamily: "'Inter', sans-serif", letterSpacing: '-0.03em' }}
             >
-              <span className="whitespace-nowrap">AI Agent <span className="text-[#1A6BF5]">Cost-Performance</span></span><br/>
-              Optimized. <span className="text-[#1A6BF5]">Automatically.</span>
+              AI Agent Optimization —<br />
+              <span className="text-[#4D8EF8]">Fully Automated</span>
             </motion.h1>
+            <motion.p
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.15 }}
+              className="text-2xl md:text-3xl lg:text-[2rem] text-slate-300 leading-snug mb-3"
+            >
+              <span className="font-bold text-white">Rapidly</span> finds <span className="font-bold text-[#f59e0b]">Low Cost</span> and <span className="font-bold text-[#4D8EF8]">High Accuracy</span> options
+            </motion.p>
+            <motion.p
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.18 }}
+              className="text-2xl md:text-3xl lg:text-[2rem] text-slate-300 leading-snug mb-10"
+            >
+              among{" "}
+              <Link
+                to="/blog/the-config-multiverse"
+                className="font-bold text-white underline underline-offset-4 decoration-white/40 hover:decoration-white transition-colors"
+              >
+                thousands possible
+              </Link>
+            </motion.p>
             {/* Two-column value summary: HOW (method) + BENEFITS (outcomes) */}
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -225,136 +233,9 @@ export default function Homepage() {
                     </li>
                   ))}
                 </ul>
-                {/* Benefits dropdown — at bottom of Benefits card */}
-                <div ref={benefitsRef} className="relative mt-5 pt-4 border-t border-blue-500/30 text-center">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setBenefitsOpen((v) => !v);
-                      trackEvent("hero_benefits_dropdown_toggled", { open: !benefitsOpen });
-                    }}
-                    aria-haspopup="menu"
-                    aria-expanded={benefitsOpen}
-                    className="group inline-flex items-center gap-1.5 text-base md:text-lg transition-colors"
-                    style={{ color: "#4D8EF8" }}
-                  >
-                    <span className="underline underline-offset-4 decoration-[#4D8EF8]/50 group-hover:decoration-[#4D8EF8] font-semibold">
-                      Benefits explained
-                    </span>
-                    <ChevronDown
-                      className={`w-4 h-4 transition-transform ${benefitsOpen ? "rotate-180" : ""}`}
-                      aria-hidden="true"
-                    />
-                  </button>
-                  {benefitsOpen && (
-                    <div
-                      role="menu"
-                      className="absolute left-1/2 -translate-x-1/2 mt-2 w-[min(92vw,640px)] z-30 bg-slate-950 border border-slate-700 rounded-xl shadow-2xl overflow-hidden text-left grid grid-cols-1 md:grid-cols-2 md:divide-x md:divide-slate-800"
-                    >
-                    {/* Left column — calculators */}
-                    <div>
-                      <div className="px-4 pt-3 pb-1 text-[10px] font-mono uppercase tracking-widest text-slate-500">
-                        See it on your numbers
-                      </div>
-                      <Link
-                        to="/roi"
-                        role="menuitem"
-                        onClick={() => {
-                          setBenefitsOpen(false);
-                          trackEvent("hero_roi_hook_clicked", { destination: "roi" });
-                        }}
-                        className="block px-4 py-3 text-sm text-slate-200 hover:bg-slate-900 hover:text-white border-b border-slate-800 transition-colors"
-                      >
-                        <div className="font-semibold text-[#4D8EF8]">ROI Calculator</div>
-                        <div className="text-xs text-slate-400 mt-0.5">12-month savings</div>
-                      </Link>
-                      <Link
-                        to="/ttm"
-                        role="menuitem"
-                        onClick={() => {
-                          setBenefitsOpen(false);
-                          trackEvent("hero_ttm_hook_clicked", { destination: "ttm" });
-                        }}
-                        className="block px-4 py-3 text-sm text-slate-200 hover:bg-slate-900 hover:text-white transition-colors"
-                      >
-                        <div className="font-semibold text-[#4D8EF8]">TTM Calculator</div>
-                        <div className="text-xs text-slate-400 mt-0.5">Engineering time saved</div>
-                      </Link>
-                    </div>
-
-                    {/* Right column — reading */}
-                    <div className="border-t border-slate-800 md:border-t-0">
-                      <div className="px-4 pt-3 pb-1 text-[10px] font-mono uppercase tracking-widest text-slate-500">
-                        Read more
-                      </div>
-                      <Link
-                        to="/blog/the-business-case"
-                        role="menuitem"
-                        onClick={() => {
-                          setBenefitsOpen(false);
-                          trackEvent("hero_skeptic_hook_clicked", { destination: "the-business-case" });
-                        }}
-                        className="block px-4 py-3 text-sm text-slate-200 hover:bg-slate-900 hover:text-white border-b border-slate-800 transition-colors"
-                      >
-                        <div className="font-semibold text-[#4D8EF8]">The business case</div>
-                        <div className="text-xs text-slate-400 mt-0.5">Quantified savings, the math behind ROI.</div>
-                      </Link>
-                      <Link
-                        to="/value-proposition"
-                        role="menuitem"
-                        onClick={() => {
-                          setBenefitsOpen(false);
-                          trackEvent("hero_problem_hook_clicked", { destination: "value-proposition" });
-                        }}
-                        className="block px-4 py-3 text-sm text-slate-200 hover:bg-slate-900 hover:text-white border-b border-slate-800 transition-colors"
-                      >
-                        <div className="font-semibold text-[#4D8EF8]">The problem we solve</div>
-                        <div className="text-xs text-slate-400 mt-0.5">The 6-truth chain that leads to Traigent.</div>
-                      </Link>
-                      <Link
-                        to="/blog"
-                        role="menuitem"
-                        onClick={() => {
-                          setBenefitsOpen(false);
-                          trackEvent("hero_blog_hook_clicked", { destination: "blog" });
-                        }}
-                        className="block px-4 py-3 text-sm text-slate-200 hover:bg-slate-900 hover:text-white transition-colors"
-                      >
-                        <div className="font-semibold text-[#4D8EF8]">Why Traigent</div>
-                        <div className="text-xs text-slate-400 mt-0.5">Deeper reading: model myth, eval trap, more.</div>
-                      </Link>
-                    </div>
-                  </div>
-                  )}
-                </div>
               </div>
             </motion.div>
 
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: 0.28 }}
-              className="mb-12 flex flex-wrap justify-center gap-3"
-            >
-              <Link
-                to={createPageUrl("/get-started")}
-                onClick={() => trackEvent("hero_get_started_clicked", { destination: "get-started" })}
-                className="inline-flex items-center justify-center bg-white text-slate-950 hover:bg-slate-100 px-5 py-3 rounded-lg text-sm font-semibold transition-colors whitespace-nowrap"
-              >
-                Get started
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </Link>
-              <a
-                href={PORTAL_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackEvent("portal_opened", { location: "hero" })}
-                className="inline-flex items-center justify-center border border-blue-400/70 text-white hover:bg-blue-500/15 px-5 py-3 rounded-lg text-sm font-semibold transition-colors whitespace-nowrap"
-              >
-                Open portal
-                <ExternalLink className="ml-2 h-4 w-4" />
-              </a>
-            </motion.div>
 
             {/* Design Partners & Early Adopters */}
             <motion.div
@@ -362,24 +243,24 @@ export default function Homepage() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.3 }}
-              className="mb-12 scroll-mt-20"
+              className="mt-6 md:mt-8 mb-20 md:mb-28 scroll-mt-20"
             >
-              <p className="text-center text-xs text-slate-500 uppercase tracking-widest font-medium mb-6">Customers</p>
+              <p className="text-center text-sm md:text-base text-slate-300 uppercase tracking-widest font-bold mb-8">Customers</p>
               <div className="relative overflow-hidden">
                 <div className="absolute left-0 top-0 bottom-0 w-24 bg-gradient-to-r from-[#080808] to-transparent z-10"></div>
                 <div className="absolute right-0 top-0 bottom-0 w-24 bg-gradient-to-l from-[#080808] to-transparent z-10"></div>
-                <div className="flex gap-12 items-center animate-scroll" style={{ width: 'max-content', animation: 'scroll 40s linear infinite' }}>
+                <div className="flex gap-16 items-center animate-scroll" style={{ width: 'max-content', animation: 'scroll 40s linear infinite' }}>
                   {/* 8 copies of the 5-logo set so total content is always wide
                       enough to keep the right half filled on large viewports.
                       The animation translates -50% (= 4 copies), which lands
                       on the visually-identical 5th copy → seamless loop. */}
                   {[...Array(8)].map((_, setIndex) => (
                     <React.Fragment key={setIndex}>
-                      <div className="text-slate-500 text-sm font-semibold whitespace-nowrap">Bazak</div>
-                      <div className="text-slate-500 text-sm font-semibold whitespace-nowrap">iForAI</div>
-                      <div className="text-slate-500 text-sm font-semibold whitespace-nowrap">Cloudzone</div>
-                      <div className="text-slate-500 text-sm font-semibold whitespace-nowrap">Profisea</div>
-                      <div className="text-slate-500 text-sm font-semibold whitespace-nowrap">Yotpo</div>
+                      <div className="text-slate-300 text-xl md:text-2xl font-bold whitespace-nowrap">Bazak</div>
+                      <div className="text-slate-300 text-xl md:text-2xl font-bold whitespace-nowrap">iForAI</div>
+                      <div className="text-slate-300 text-xl md:text-2xl font-bold whitespace-nowrap">Cloudzone</div>
+                      <div className="text-slate-300 text-xl md:text-2xl font-bold whitespace-nowrap">Profisea</div>
+                      <div className="text-slate-300 text-xl md:text-2xl font-bold whitespace-nowrap">Yotpo</div>
                     </React.Fragment>
                   ))}
                 </div>
@@ -1047,12 +928,12 @@ def answer_question(question: str) -> str:
           <div className="border-t border-slate-800 mt-12 pt-8 text-center text-slate-500">
             <p>
               © {new Date().getFullYear()} Traigent Ltd. All rights reserved.{" "}
-              {/* Hidden sales-deck shortcut: right-click the dot to open /pitch-short in a new tab.
+              {/* Hidden sales-deck shortcut: right-click the dot to open /pitch-short-2 in a new tab.
                   Looks decorative to visitors. No left-click handler. */}
               <span
                 onContextMenu={(e) => {
                   e.preventDefault();
-                  window.open("#/pitch-short", "_blank", "noopener,noreferrer");
+                  window.open("#/pitch-short-2", "_blank", "noopener,noreferrer");
                 }}
                 aria-hidden="true"
                 title=""

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -1,6 +1,13 @@
 ﻿import React, { useState, useRef, useEffect } from "react";
 import { motion } from "framer-motion";
-import { ArrowRight, Check, ChevronRight, ChevronDown, ExternalLink, Play, Pause, Sparkles, Eye } from "lucide-react";
+import { ArrowRight, Check, ChevronRight, ChevronDown, ExternalLink, Play, Pause } from "lucide-react";
+import {
+  OptimizationEngineBody,
+  FeedbackLoopConnector,
+  AgentWrapperBody,
+  BenchmarkCardBody,
+  ObservabilityCardBody,
+} from "../components/PlatformShowcase";
 import { Link } from "react-router-dom";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
@@ -306,92 +313,11 @@ export default function Homepage() {
               transition={{ duration: 0.5, delay: 0.1 }}
               className="flex-1 bg-slate-900/60 border border-slate-700/50 rounded-2xl p-8"
             >
-              <div className="flex items-center gap-3 mb-3">
-                <h3 className="text-lg font-bold text-white">Optimization Engine</h3>
-              </div>
-              <p className="text-slate-400 text-sm mb-6 leading-relaxed">
-                Learns from previous model and configuration combo results and determines the next best combination to test.
-              </p>
-              <svg viewBox="0 0 320 260" className="w-full" xmlns="http://www.w3.org/2000/svg">
-                <defs>
-                  <marker id="optArrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-                    <polygon points="0 0, 8 3, 0 6" fill="#1A6BF5"/>
-                  </marker>
-                </defs>
-                <rect x="8" y="50" width="88" height="80" rx="8" fill="#1e293b" stroke="#334155" strokeWidth="1"/>
-                <text x="52" y="68" textAnchor="middle" fill="#64748b" fontSize="8" fontFamily="monospace">Previous Results</text>
-                <line x1="16" y1="74" x2="88" y2="74" stroke="#334155" strokeWidth="0.5"/>
-                <text x="52" y="86" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">gpt-4o / t=0.7</text>
-                <text x="52" y="97" textAnchor="middle" fill="#4ade80" fontSize="7.5" fontFamily="monospace">72% acc · $0.003</text>
-                <text x="52" y="108" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">gpt-4o-mini / t=0.3</text>
-                <text x="52" y="119" textAnchor="middle" fill="#facc15" fontSize="7.5" fontFamily="monospace">61% acc · $0.001</text>
-                <line x1="96" y1="90" x2="118" y2="90" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#optArrow)"/>
-                <rect x="118" y="58" width="76" height="64" rx="10" fill="#1A6BF5" fillOpacity="0.12" stroke="#1A6BF5" strokeWidth="1.5"/>
-                <text x="156" y="88" textAnchor="middle" fill="#93c5fd" fontSize="8.5" fontFamily="monospace">Optimizer</text>
-                <text x="156" y="110" textAnchor="middle" fill="#1A6BF5" fontSize="20">⚙</text>
-                <line x1="194" y1="90" x2="216" y2="90" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#optArrow)"/>
-                <rect x="216" y="55" width="96" height="70" rx="8" fill="#1e293b" stroke="#1A6BF5" strokeWidth="1" strokeDasharray="4,2"/>
-                <text x="264" y="74" textAnchor="middle" fill="#93c5fd" fontSize="8.5" fontFamily="monospace">Next Combo</text>
-                <line x1="224" y1="79" x2="304" y2="79" stroke="#1A6BF5" strokeWidth="0.5" strokeOpacity="0.4"/>
-                <text x="264" y="92" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">o3-mini</text>
-                <text x="264" y="104" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">temp: 0.2</text>
-                <text x="264" y="116" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">top_p: 0.85</text>
-
-                {/* Chart background */}
-                <rect x="28" y="145" width="280" height="88" rx="4" fill="#0f172a"/>
-                {/* Axes */}
-                <line x1="36" y1="225" x2="304" y2="225" stroke="#334155" strokeWidth="0.8"/>
-                <line x1="36" y1="148" x2="36" y2="225" stroke="#334155" strokeWidth="0.8"/>
-                {/* "Not needed" shaded zone */}
-                <rect x="204" y="148" width="104" height="77" fill="#1e293b" fillOpacity="0.8"/>
-                {/* Gray dots representing untried combinations */}
-                <circle cx="218" cy="163" r="1.5" fill="#334155"/><circle cx="234" cy="177" r="1.5" fill="#334155"/>
-                <circle cx="248" cy="159" r="1.5" fill="#334155"/><circle cx="263" cy="188" r="1.5" fill="#334155"/>
-                <circle cx="276" cy="171" r="1.5" fill="#334155"/><circle cx="289" cy="165" r="1.5" fill="#334155"/>
-                <circle cx="221" cy="198" r="1.5" fill="#334155"/><circle cx="239" cy="211" r="1.5" fill="#334155"/>
-                <circle cx="255" cy="218" r="1.5" fill="#334155"/><circle cx="268" cy="203" r="1.5" fill="#334155"/>
-                <circle cx="281" cy="191" r="1.5" fill="#334155"/><circle cx="293" cy="213" r="1.5" fill="#334155"/>
-                <circle cx="225" cy="220" r="1.5" fill="#334155"/><circle cx="244" cy="155" r="1.5" fill="#334155"/>
-                <circle cx="259" cy="179" r="1.5" fill="#334155"/><circle cx="273" cy="189" r="1.5" fill="#334155"/>
-                <circle cx="286" cy="221" r="1.5" fill="#334155"/><circle cx="297" cy="170" r="1.5" fill="#334155"/>
-                <circle cx="230" cy="185" r="1.5" fill="#334155"/><circle cx="252" cy="207" r="1.5" fill="#334155"/>
-                {/* Separator line */}
-                <line x1="204" y1="148" x2="204" y2="225" stroke="#1A6BF5" strokeWidth="1" strokeOpacity="0.4" strokeDasharray="3,2"/>
-                {/* Optimal horizontal dashed line */}
-                <line x1="36" y1="164" x2="204" y2="164" stroke="#4ade80" strokeWidth="0.8" strokeDasharray="3,2" strokeOpacity="0.5"/>
-                {/* Convergence curve */}
-                <path d="M 50 222 C 72 210, 92 196, 114 181 S 154 169, 174 165 S 192 164, 204 164" stroke="#1A6BF5" strokeWidth="2" fill="none"/>
-                {/* Experiment dots */}
-                <circle cx="50" cy="222" r="3" fill="#1A6BF5"/>
-                <circle cx="74" cy="209" r="3" fill="#1A6BF5"/>
-                <circle cx="96" cy="195" r="3" fill="#1A6BF5"/>
-                <circle cx="118" cy="181" r="3" fill="#1A6BF5"/>
-                <circle cx="140" cy="171" r="3" fill="#1A6BF5"/>
-                <circle cx="160" cy="166" r="3" fill="#1A6BF5"/>
-                <circle cx="180" cy="164" r="3" fill="#1A6BF5"/>
-                <circle cx="204" cy="164" r="4" fill="#4ade80"/>
-                {/* Labels */}
-                <text x="172" y="159" textAnchor="middle" fill="#4ade80" fontSize="7" fontFamily="monospace">✓ optimal</text>
-                <text x="30" y="152" fill="#475569" fontSize="7" fontFamily="monospace">KPI ↑</text>
-                <text x="120" y="238" textAnchor="middle" fill="#94a3b8" fontSize="8" fontFamily="monospace">tested (under 10%)</text>
-                <text x="254" y="238" textAnchor="middle" fill="#475569" fontSize="8" fontFamily="monospace">not needed</text>
-              </svg>
-              <p className="text-slate-400 text-sm text-center mt-3">Finds the optimum needing only a fraction of the model and configuration combinations to experiment with</p>
+              <OptimizationEngineBody />
             </motion.div>
 
             {/* Center: feedback loop connector */}
-            <div className="flex lg:flex-col items-center justify-center gap-3 py-4 lg:py-0 lg:min-w-[180px]">
-              <span className="text-[#1A6BF5] text-base font-semibold font-mono whitespace-nowrap">next combo</span>
-              <svg width="160" height="94" viewBox="0 0 160 94" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                {/* Top arrow: points RIGHT */}
-                <line x1="4" y1="14" x2="142" y2="14" stroke="#1A6BF5" strokeWidth="3" strokeLinecap="round"/>
-                <polygon points="140,6 156,14 140,22" fill="#1A6BF5"/>
-                {/* Bottom arrow: points LEFT — exact horizontal mirror of the top */}
-                <line x1="18" y1="80" x2="156" y2="80" stroke="#1A6BF5" strokeWidth="3" strokeLinecap="round"/>
-                <polygon points="20,72 4,80 20,88" fill="#1A6BF5"/>
-              </svg>
-              <span className="text-[#1A6BF5] text-base font-semibold font-mono whitespace-nowrap">KPI results</span>
-            </div>
+            <FeedbackLoopConnector />
 
             {/* Right: Agent Wrapper (component 1) */}
             <motion.div
@@ -401,78 +327,7 @@ export default function Homepage() {
               transition={{ duration: 0.5, delay: 0.2 }}
               className="flex-1 bg-slate-900/60 border border-slate-700/50 rounded-2xl p-8"
             >
-              <div className="flex items-center gap-3 mb-3">
-                <h3 className="text-lg font-bold text-white">Agent Wrapper</h3>
-              </div>
-              <p className="text-slate-400 text-sm mb-6 leading-relaxed">
-                Executes a given model and configuration on the benchmark test bed and measures agent KPIs.
-              </p>
-              <svg viewBox="0 0 320 260" className="w-full" xmlns="http://www.w3.org/2000/svg">
-                <defs>
-                  <marker id="wrapArrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-                    <polygon points="0 0, 8 3, 0 6" fill="#475569"/>
-                  </marker>
-                  <marker id="wrapArrowBlue" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-                    <polygon points="0 0, 8 3, 0 6" fill="#1A6BF5"/>
-                  </marker>
-                </defs>
-                {/* Wrapper dashed border */}
-                <rect x="8" y="18" width="304" height="235" rx="12" fill="none" stroke="#334155" strokeWidth="1.5" strokeDasharray="6,3"/>
-                <text x="20" y="32" fill="#475569" fontSize="8.5" fontFamily="monospace">[ Agent Wrapper ]</text>
-                {/* Model box — blue dashed = injected combo */}
-                <rect x="14" y="40" width="68" height="26" rx="6" fill="#1e293b" stroke="#1A6BF5" strokeWidth="1" strokeDasharray="3,2"/>
-                <text x="48" y="51" textAnchor="middle" fill="#64748b" fontSize="7.5" fontFamily="monospace">Model</text>
-                <text x="48" y="61" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">o3-mini</text>
-                {/* Config box — blue dashed = injected combo */}
-                <rect x="14" y="76" width="68" height="40" rx="6" fill="#1e293b" stroke="#1A6BF5" strokeWidth="1" strokeDasharray="3,2"/>
-                <text x="48" y="89" textAnchor="middle" fill="#64748b" fontSize="7.5" fontFamily="monospace">Config</text>
-                <text x="48" y="101" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">temp: 0.2</text>
-                <text x="48" y="111" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">top_p: 0.85</text>
-                {/* Arrows Model/Config → Execute */}
-                <line x1="82" y1="53" x2="104" y2="70" stroke="#475569" strokeWidth="1.2" markerEnd="url(#wrapArrow)"/>
-                <line x1="82" y1="96" x2="104" y2="84" stroke="#475569" strokeWidth="1.2" markerEnd="url(#wrapArrow)"/>
-                {/* Execute box */}
-                <rect x="104" y="57" width="72" height="48" rx="8" fill="#1A6BF5" fillOpacity="0.12" stroke="#1A6BF5" strokeWidth="1.5"/>
-                <text x="140" y="74" textAnchor="middle" fill="#93c5fd" fontSize="8" fontFamily="monospace">Execute Agent</text>
-                <text x="140" y="95" textAnchor="middle" fill="#1A6BF5" fontSize="16">▶</text>
-                {/* Arrow Execute ↓ Test Bed */}
-                <line x1="140" y1="105" x2="140" y2="147" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#wrapArrowBlue)"/>
-                {/* Benchmark Test Bed box */}
-                <rect x="86" y="148" width="116" height="86" rx="8" fill="#1e293b" stroke="#334155" strokeWidth="1"/>
-                <text x="144" y="164" textAnchor="middle" fill="#64748b" fontSize="8" fontFamily="monospace">Benchmark Test Bed</text>
-                <line x1="94" y1="169" x2="194" y2="169" stroke="#334155" strokeWidth="0.5"/>
-                <circle cx="97" cy="184" r="4" fill="#4ade80" fillOpacity="0.85"/>
-                <text x="97" y="187" textAnchor="middle" fill="white" fontSize="6">✓</text>
-                <text x="107" y="187" fill="#94a3b8" fontSize="7.5" fontFamily="monospace"> query_1  pass</text>
-                <circle cx="97" cy="198" r="4" fill="#4ade80" fillOpacity="0.85"/>
-                <text x="97" y="201" textAnchor="middle" fill="white" fontSize="6">✓</text>
-                <text x="107" y="201" fill="#94a3b8" fontSize="7.5" fontFamily="monospace"> query_2  pass</text>
-                <circle cx="97" cy="212" r="4" fill="#1A6BF5" fillOpacity="0.6"/>
-                <text x="97" y="215" textAnchor="middle" fill="white" fontSize="6.5">…</text>
-                <text x="107" y="215" fill="#475569" fontSize="7.5" fontFamily="monospace"> query_3  running</text>
-                <text x="193" y="228" textAnchor="end" fill="#334155" fontSize="7" fontFamily="monospace">N queries total</text>
-                {/* Arrow Test Bed → KPIs */}
-                <line x1="202" y1="191" x2="212" y2="191" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#wrapArrowBlue)"/>
-                {/* KPI outputs */}
-                <rect x="214" y="40" width="90" height="194" rx="8" fill="#1e293b" stroke="#334155" strokeWidth="1"/>
-                <text x="259" y="57" textAnchor="middle" fill="#64748b" fontSize="8.5" fontFamily="monospace">KPIs</text>
-                <line x1="222" y1="62" x2="296" y2="62" stroke="#334155" strokeWidth="0.5"/>
-                <text x="259" y="84" textAnchor="middle" fill="#4ade80" fontSize="8" fontFamily="monospace">accuracy  90%</text>
-                <text x="259" y="106" textAnchor="middle" fill="#facc15" fontSize="8" fontFamily="monospace">cost    $0.0002</text>
-                <text x="259" y="128" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">latency   1.2s</text>
-                <text x="259" y="150" textAnchor="middle" fill="#f472b6" fontSize="8" fontFamily="monospace">safety      ✓</text>
-                <text x="259" y="172" textAnchor="middle" fill="#a78bfa" fontSize="8" fontFamily="monospace">custom KPI  …</text>
-                <line x1="222" y1="190" x2="296" y2="190" stroke="#334155" strokeWidth="0.5"/>
-                <text x="259" y="208" textAnchor="middle" fill="#64748b" fontSize="7.5" fontFamily="monospace">weighted score</text>
-                <text x="259" y="226" textAnchor="middle" fill="#4ade80" fontSize="12" fontFamily="monospace" fontWeight="bold">0.86</text>
-                {/* Secondary differentiator: benchmark insights — amber */}
-                <line x1="20" y1="241" x2="300" y2="241" stroke="#f59e0b" strokeWidth="0.5" strokeOpacity="0.35" strokeDasharray="2,2"/>
-                <text x="20" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace" fontWeight="bold">+ benchmark insights:</text>
-                <text x="112" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace">⊘ easy</text>
-                <text x="155" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace">⨯ always-fail</text>
-                <text x="218" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace">↻ redundant</text>
-              </svg>
-              <p className="text-slate-400 text-sm text-center mt-3">Automated injection of model and configurations allows Optimizer to run successive tests seamlessly</p>
+              <AgentWrapperBody />
             </motion.div>
 
           </div>
@@ -507,35 +362,7 @@ export default function Homepage() {
               transition={{ duration: 0.5, delay: 0.1 }}
               className="bg-slate-900/60 border border-amber-500/30 rounded-2xl p-8 scroll-mt-24"
             >
-              <div className="flex items-center gap-3 mb-3">
-                <div className="w-10 h-10 rounded-lg bg-amber-500/10 border border-amber-500/30 flex items-center justify-center text-amber-400">
-                  <Sparkles className="w-5 h-5" />
-                </div>
-                <h3 className="text-lg font-bold text-white">Self-Improving Benchmark</h3>
-              </div>
-              <p className="text-slate-400 text-sm mb-6 leading-relaxed">
-                Hundreds of runs across the same test bed reveal patterns. Traigent flags them automatically so your benchmark gets sharper — and every future run gets faster and cheaper.
-              </p>
-              <ul className="space-y-4">
-                <li className="flex gap-3">
-                  <span className="flex-shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-xs">
-                    <span>⊘</span><span>too easy</span>
-                  </span>
-                  <span className="text-slate-400 text-sm leading-relaxed">Every model & config passes — provides no discrimination. Safe to drop.</span>
-                </li>
-                <li className="flex gap-3">
-                  <span className="flex-shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-xs">
-                    <span>⨯</span><span>always fails</span>
-                  </span>
-                  <span className="text-slate-400 text-sm leading-relaxed">Nothing passes — fix the agent itself (code, flow, RAG) before optimization can help.</span>
-                </li>
-                <li className="flex gap-3">
-                  <span className="flex-shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-xs">
-                    <span>↻</span><span>redundant</span>
-                  </span>
-                  <span className="text-slate-400 text-sm leading-relaxed">Batches where a small sample carries the same signal — trim them and shorten every wrapper run.</span>
-                </li>
-              </ul>
+              <BenchmarkCardBody />
             </motion.div>
 
             {/* Card 2: Full Observability & Tracing */}
@@ -547,69 +374,7 @@ export default function Homepage() {
               transition={{ duration: 0.5, delay: 0.2 }}
               className="bg-slate-900/60 border border-amber-500/30 rounded-2xl p-8 scroll-mt-24"
             >
-              <div className="flex items-center gap-3 mb-3">
-                <div className="w-10 h-10 rounded-lg bg-amber-500/10 border border-amber-500/30 flex items-center justify-center text-amber-400">
-                  <Eye className="w-5 h-5" />
-                </div>
-                <h3 className="text-lg font-bold text-white">Full Observability & Tracing</h3>
-              </div>
-              <p className="text-slate-400 text-sm mb-6 leading-relaxed">
-                Every wrapper run is fully instrumented — spans, tokens, costs, and errors captured end-to-end. Production-grade tracing built in, with no separate observability stack to run.
-              </p>
-              <svg viewBox="0 0 320 200" className="w-full" xmlns="http://www.w3.org/2000/svg">
-                {/* Trace panel background */}
-                <rect x="4" y="4" width="312" height="192" rx="8" fill="#0f172a" stroke="#334155" strokeWidth="1"/>
-                {/* Header */}
-                <text x="14" y="22" fill="#f59e0b" fontSize="9" fontFamily="monospace" fontWeight="bold">Trace</text>
-                <text x="40" y="22" fill="#64748b" fontSize="8.5" fontFamily="monospace">· agent_run_42</text>
-                <text x="306" y="22" textAnchor="end" fill="#4ade80" fontSize="8.5" fontFamily="monospace">1.24s ✓</text>
-                <line x1="14" y1="30" x2="306" y2="30" stroke="#334155" strokeWidth="0.5"/>
-
-                {/* Root span */}
-                <text x="14" y="46" fill="#93c5fd" fontSize="8" fontFamily="monospace">▾ agent_run</text>
-                <rect x="170" y="40" width="120" height="8" rx="2" fill="#1A6BF5" fillOpacity="0.45"/>
-                <text x="296" y="46" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">1240ms</text>
-
-                {/* Child: retrieve_context */}
-                <text x="22" y="62" fill="#94a3b8" fontSize="8" fontFamily="monospace">├─ retrieve_context</text>
-                <rect x="170" y="56" width="18" height="8" rx="2" fill="#a78bfa" fillOpacity="0.65"/>
-                <text x="296" y="62" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">180ms</text>
-
-                {/* Grandchild: vector_search */}
-                <text x="36" y="76" fill="#64748b" fontSize="7" fontFamily="monospace">└─ vector_search · top_k=8</text>
-                <rect x="170" y="71" width="13" height="6" rx="1.5" fill="#a78bfa" fillOpacity="0.4"/>
-                <text x="296" y="76" textAnchor="end" fill="#475569" fontSize="6.5" fontFamily="monospace">120ms</text>
-
-                {/* Child: llm_call */}
-                <text x="22" y="92" fill="#94a3b8" fontSize="8" fontFamily="monospace">├─ llm_call · gpt-4o-mini</text>
-                <rect x="188" y="86" width="74" height="8" rx="2" fill="#60a5fa" fillOpacity="0.65"/>
-                <text x="296" y="92" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">740ms</text>
-
-                {/* tokens / cost info */}
-                <text x="36" y="106" fill="#475569" fontSize="7" fontFamily="monospace">tokens: 312 in · 89 out</text>
-                <text x="296" y="106" textAnchor="end" fill="#facc15" fontSize="7" fontFamily="monospace">$0.0006</text>
-
-                {/* Child: evaluator */}
-                <text x="22" y="122" fill="#94a3b8" fontSize="8" fontFamily="monospace">└─ evaluator</text>
-                <rect x="262" y="116" width="32" height="8" rx="2" fill="#4ade80" fillOpacity="0.55"/>
-                <text x="296" y="122" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">320ms</text>
-                <text x="36" y="136" fill="#4ade80" fontSize="7" fontFamily="monospace">score: 0.92 ✓</text>
-
-                {/* Timeline divider */}
-                <line x1="14" y1="148" x2="306" y2="148" stroke="#334155" strokeWidth="0.5" strokeDasharray="2,2"/>
-
-                {/* Mini Gantt timeline */}
-                <text x="14" y="161" fill="#f59e0b" fontSize="7" fontFamily="monospace" fontWeight="bold">Timeline</text>
-                <text x="306" y="161" textAnchor="end" fill="#475569" fontSize="6.5" fontFamily="monospace">0 ──── 1.24s</text>
-                {/* Background track */}
-                <rect x="14" y="166" width="292" height="22" rx="2" fill="#0a1424"/>
-                {/* Span bars proportional to durations */}
-                <rect x="14" y="169" width="282" height="4" rx="1" fill="#1A6BF5" fillOpacity="0.55"/>
-                <rect x="14" y="175" width="42" height="3.5" rx="1" fill="#a78bfa" fillOpacity="0.7"/>
-                <rect x="56" y="180" width="174" height="3.5" rx="1" fill="#60a5fa" fillOpacity="0.7"/>
-                <rect x="230" y="185" width="72" height="3.5" rx="1" fill="#4ade80" fillOpacity="0.7"/>
-              </svg>
-              <p className="text-slate-400 text-sm text-center mt-3">Inspect any agent execution end-to-end · debug failures · monitor production</p>
+              <ObservabilityCardBody />
             </motion.div>
 
           </div>

--- a/src/pages/Investors.jsx
+++ b/src/pages/Investors.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet-async'
+import BrandMark from '../components/BrandMark'
 
 const styles = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
@@ -325,7 +326,7 @@ export default function Investors() {
           <div className="pw-gate">
             <div className="pw-box">
               <a href="/" className="logo">
-                <img src="https://qtrypzzcjebvfcihiynt.supabase.co/storage/v1/object/public/base44-prod/public/057ce2_TraigentLogoWhiteCropped.png" alt="Traigent" height="22" style={{ display: 'block', height: '22px', width: 'auto' }} />
+                <BrandMark size="sm" />
               </a>
               <h2>Investor Access</h2>
               <p>This page contains confidential investor information. Please enter the password to continue.</p>
@@ -369,7 +370,7 @@ export default function Investors() {
         <nav>
           <div className="ni">
             <a href="/" className="logo">
-              <img src="https://qtrypzzcjebvfcihiynt.supabase.co/storage/v1/object/public/base44-prod/public/057ce2_TraigentLogoWhiteCropped.png" alt="Traigent" height="22" style={{ display: 'block', height: '22px', width: 'auto' }} />
+              <BrandMark size="sm" />
             </a>
             <div className="nl">
               <a href="#market" onClick={(e) => { e.preventDefault(); document.getElementById('market')?.scrollIntoView({ behavior: 'smooth' }) }}>Market</a>
@@ -649,7 +650,7 @@ export default function Investors() {
             <div className="ft">
               <div className="fb">
                 <a href="/" className="logo">
-                  <img src="https://qtrypzzcjebvfcihiynt.supabase.co/storage/v1/object/public/base44-prod/public/057ce2_TraigentLogoWhiteCropped.png" alt="Traigent" height="20" style={{ display: 'block', height: '20px', width: 'auto' }} />
+                  <BrandMark size="sm" />
                 </a>
                 <p>The continuous optimization infrastructure for enterprise GenAI. Trust your AI agent at scale.</p>
               </div>

--- a/src/pages/OnePager.jsx
+++ b/src/pages/OnePager.jsx
@@ -19,12 +19,12 @@ import {
   AMBER,
   RED,
   SITE,
-  LOGO_SRC,
   ATag,
   CTag,
   ACTag,
   ONEPAGER_STYLE,
 } from "../components/OnePagerAtoms";
+import BrandMark from "../components/BrandMark";
 
 function ProblemPanel({ icon: Icon, title, number, numberColor, line, extra, linkHref, linkLabel }) {
   return (
@@ -109,7 +109,7 @@ function SlideShell({ slideNo, children }) {
           className="inline-block hover:opacity-80 transition-opacity"
           aria-label="Traigent — visit homepage"
         >
-          <img src={LOGO_SRC} alt="Traigent" className="h-9" />
+          <BrandMark size="lg" />
         </a>
         <div className="flex items-center gap-4 text-[11px] font-mono uppercase tracking-widest text-slate-500">
           <span>AI Agent Optimization</span>

--- a/src/pages/OnePager2.jsx
+++ b/src/pages/OnePager2.jsx
@@ -9,9 +9,9 @@ import {
   BLUE_LIGHT,
   AMBER,
   SITE,
-  LOGO_SRC,
   ONEPAGER_STYLE,
 } from "../components/OnePagerAtoms";
+import BrandMark from "../components/BrandMark";
 
 // ---------- Solution stat (full-size for one-pager-2) ----------
 function SolutionStat({ value, label, color }) {
@@ -79,7 +79,7 @@ export function OnePager2Slide({ showHeader = true, showFooter = true, costStatV
             className="inline-block hover:opacity-80 transition-opacity"
             aria-label="Traigent — visit homepage"
           >
-            <img src={LOGO_SRC} alt="Traigent" className="h-8" />
+            <BrandMark size="md" />
           </a>
           <div className="flex items-center gap-3 text-[11px] font-mono uppercase tracking-widest text-slate-500">
             <span>AI Agent Optimization</span>

--- a/src/pages/Pitch.jsx
+++ b/src/pages/Pitch.jsx
@@ -19,7 +19,7 @@ function SlideHook() {
   return (
     <div className="text-center max-w-5xl mx-auto">
       <h1 className="text-6xl md:text-7xl lg:text-8xl font-extrabold text-white mb-8 tracking-tight">
-        Traigent
+        Traigent.ai
       </h1>
       <p className="text-2xl md:text-3xl text-slate-200 mb-10 font-medium leading-tight" style={{ textWrap: "balance" }}>
         The most advanced <span style={{ color: BLUE }} className="font-bold">AI Agent Optimization Platform</span> on the market

--- a/src/pages/PitchFull.jsx
+++ b/src/pages/PitchFull.jsx
@@ -931,7 +931,7 @@ export function Slide19EngineerFirst() {
 // ===================================================================
 // 20 — Get Started
 // ===================================================================
-export function Slide20GetStarted() {
+export function Slide20GetStarted({ bookingHref = "https://meetings-eu1.hubspot.com/amir8" } = {}) {
   return (
     <div className="text-center max-w-5xl mx-auto">
       <h2 className="text-5xl md:text-6xl font-bold text-white mb-4">Get Started</h2>
@@ -950,7 +950,7 @@ export function Slide20GetStarted() {
           <h3 className="text-2xl font-bold text-white mb-3">Book a pilot</h3>
           <p className="text-slate-400 mb-5 text-sm">Pick one production agent. 2–4 week engagement. Measurable outcome.</p>
           <a
-            href="https://meetings-eu1.hubspot.com/amir8"
+            href={bookingHref}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-block text-white px-6 py-3 rounded-lg font-medium text-base hover:opacity-90 transition-opacity"

--- a/src/pages/PitchFull.jsx
+++ b/src/pages/PitchFull.jsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { ConvergenceDiagram, KillerStatsGrid, ThreeProductsGrid } from "./pitch/shared";
 import { OnePager2Slide } from "./OnePager2";
+import BrandMark from "../components/BrandMark";
 
 // ===================================================================
 // Brand tokens
@@ -12,8 +13,6 @@ import { OnePager2Slide } from "./OnePager2";
 const BLUE = "#1A6BF5";
 const AMBER = "#f59e0b";
 const VIOLET = "#a78bfa";
-const TRAIGENT_LOGO_URL =
-  "https://qtrypzzcjebvfcihiynt.supabase.co/storage/v1/object/public/base44-prod/public/057ce2_TraigentLogoWhiteCropped.png";
 
 // ===================================================================
 // Reusable mini-components used across multiple slides
@@ -136,11 +135,7 @@ export function SlideHero() {
   ];
   return (
     <div className="text-center max-w-5xl mx-auto">
-      <img
-        src={TRAIGENT_LOGO_URL}
-        alt="Traigent"
-        className="h-16 md:h-20 lg:h-24 w-auto mx-auto mb-6"
-      />
+      <BrandMark size="hero" className="justify-center mb-6" />
       <h1
         className="text-4xl md:text-5xl lg:text-6xl font-bold text-white leading-[1.05] tracking-tight mb-8"
         style={{ fontFamily: "'Inter', sans-serif", letterSpacing: '-0.03em' }}
@@ -1288,11 +1283,7 @@ export function PitchDeck({ slides }) {
           aria-label="Traigent home"
           title="Home"
         >
-          <img
-            src={TRAIGENT_LOGO_URL}
-            alt="Traigent"
-            className="h-7 md:h-8 w-auto"
-          />
+          <BrandMark size="md" />
         </Link>
         <span className="text-slate-500 text-sm font-mono">
           {current + 1} / {total} · {slides[current].title}

--- a/src/pages/PitchShort.jsx
+++ b/src/pages/PitchShort.jsx
@@ -4,7 +4,14 @@
 // rendered through PitchFull's originals with override props for the
 // subtitle / footer; everything else is imported directly. No structural
 // JSX is duplicated from PitchFull.
-import { ArrowRight, Sparkles, Eye } from "lucide-react";
+import { ArrowRight } from "lucide-react";
+import {
+  OptimizationEngineBody,
+  FeedbackLoopConnector,
+  AgentWrapperBody,
+  BenchmarkCardBody,
+  ObservabilityCardBody,
+} from "../components/PlatformShowcase";
 import {
   PitchDeck,
   SlideOnePagerSummary,
@@ -70,8 +77,8 @@ function SlideROIPreviewShort() {
   );
 }
 
-// Slide: Agent Optimization Platform — two-box layout from the homepage,
-// pasted as-is (Optimization Engine + feedback-loop connector + Agent Wrapper).
+// Slide: Agent Optimization Platform — two-box layout pasted as-is from the
+// homepage product section (shared bodies in components/PlatformShowcase).
 function SlidePlatformBoxes() {
   return (
     <div className="w-full">
@@ -79,155 +86,20 @@ function SlidePlatformBoxes() {
         <h2 className="text-3xl md:text-4xl font-bold text-white">Agent Optimization Platform</h2>
       </div>
       <div className="flex flex-col gap-6 items-stretch lg:grid lg:grid-cols-[1fr_180px_1fr] lg:gap-6">
-        {/* Left: Optimization Engine */}
         <div className="flex-1 bg-slate-900/60 border border-slate-700/50 rounded-2xl p-8">
-          <div className="flex items-center gap-3 mb-3">
-            <h3 className="text-lg font-bold text-white">Optimization Engine</h3>
-          </div>
-          <p className="text-slate-400 text-sm mb-6 leading-relaxed">
-            Learns from previous model and configuration combo results and determines the next best combination to test.
-          </p>
-          <svg viewBox="0 0 320 260" className="w-full" xmlns="http://www.w3.org/2000/svg">
-            <defs>
-              <marker id="optArrowSlide" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-                <polygon points="0 0, 8 3, 0 6" fill="#1A6BF5"/>
-              </marker>
-            </defs>
-            <rect x="8" y="50" width="88" height="80" rx="8" fill="#1e293b" stroke="#334155" strokeWidth="1"/>
-            <text x="52" y="68" textAnchor="middle" fill="#64748b" fontSize="8" fontFamily="monospace">Previous Results</text>
-            <line x1="16" y1="74" x2="88" y2="74" stroke="#334155" strokeWidth="0.5"/>
-            <text x="52" y="86" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">gpt-4o / t=0.7</text>
-            <text x="52" y="97" textAnchor="middle" fill="#4ade80" fontSize="7.5" fontFamily="monospace">72% acc · $0.003</text>
-            <text x="52" y="108" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">gpt-4o-mini / t=0.3</text>
-            <text x="52" y="119" textAnchor="middle" fill="#facc15" fontSize="7.5" fontFamily="monospace">61% acc · $0.001</text>
-            <line x1="96" y1="90" x2="118" y2="90" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#optArrowSlide)"/>
-            <rect x="118" y="58" width="76" height="64" rx="10" fill="#1A6BF5" fillOpacity="0.12" stroke="#1A6BF5" strokeWidth="1.5"/>
-            <text x="156" y="88" textAnchor="middle" fill="#93c5fd" fontSize="8.5" fontFamily="monospace">Optimizer</text>
-            <text x="156" y="110" textAnchor="middle" fill="#1A6BF5" fontSize="20">⚙</text>
-            <line x1="194" y1="90" x2="216" y2="90" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#optArrowSlide)"/>
-            <rect x="216" y="55" width="96" height="70" rx="8" fill="#1e293b" stroke="#1A6BF5" strokeWidth="1" strokeDasharray="4,2"/>
-            <text x="264" y="74" textAnchor="middle" fill="#93c5fd" fontSize="8.5" fontFamily="monospace">Next Combo</text>
-            <line x1="224" y1="79" x2="304" y2="79" stroke="#1A6BF5" strokeWidth="0.5" strokeOpacity="0.4"/>
-            <text x="264" y="92" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">o3-mini</text>
-            <text x="264" y="104" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">temp: 0.2</text>
-            <text x="264" y="116" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">top_p: 0.85</text>
-            <rect x="28" y="145" width="280" height="88" rx="4" fill="#0f172a"/>
-            <line x1="36" y1="225" x2="304" y2="225" stroke="#334155" strokeWidth="0.8"/>
-            <line x1="36" y1="148" x2="36" y2="225" stroke="#334155" strokeWidth="0.8"/>
-            <rect x="204" y="148" width="104" height="77" fill="#1e293b" fillOpacity="0.8"/>
-            <circle cx="218" cy="163" r="1.5" fill="#334155"/><circle cx="234" cy="177" r="1.5" fill="#334155"/>
-            <circle cx="248" cy="159" r="1.5" fill="#334155"/><circle cx="263" cy="188" r="1.5" fill="#334155"/>
-            <circle cx="276" cy="171" r="1.5" fill="#334155"/><circle cx="289" cy="165" r="1.5" fill="#334155"/>
-            <circle cx="221" cy="198" r="1.5" fill="#334155"/><circle cx="239" cy="211" r="1.5" fill="#334155"/>
-            <circle cx="255" cy="218" r="1.5" fill="#334155"/><circle cx="268" cy="203" r="1.5" fill="#334155"/>
-            <circle cx="281" cy="191" r="1.5" fill="#334155"/><circle cx="293" cy="213" r="1.5" fill="#334155"/>
-            <circle cx="225" cy="220" r="1.5" fill="#334155"/><circle cx="244" cy="155" r="1.5" fill="#334155"/>
-            <circle cx="259" cy="179" r="1.5" fill="#334155"/><circle cx="273" cy="189" r="1.5" fill="#334155"/>
-            <circle cx="286" cy="221" r="1.5" fill="#334155"/><circle cx="297" cy="170" r="1.5" fill="#334155"/>
-            <circle cx="230" cy="185" r="1.5" fill="#334155"/><circle cx="252" cy="207" r="1.5" fill="#334155"/>
-            <line x1="204" y1="148" x2="204" y2="225" stroke="#1A6BF5" strokeWidth="1" strokeOpacity="0.4" strokeDasharray="3,2"/>
-            <line x1="36" y1="164" x2="204" y2="164" stroke="#4ade80" strokeWidth="0.8" strokeDasharray="3,2" strokeOpacity="0.5"/>
-            <path d="M 50 222 C 72 210, 92 196, 114 181 S 154 169, 174 165 S 192 164, 204 164" stroke="#1A6BF5" strokeWidth="2" fill="none"/>
-            <circle cx="50" cy="222" r="3" fill="#1A6BF5"/>
-            <circle cx="74" cy="209" r="3" fill="#1A6BF5"/>
-            <circle cx="96" cy="195" r="3" fill="#1A6BF5"/>
-            <circle cx="118" cy="181" r="3" fill="#1A6BF5"/>
-            <circle cx="140" cy="171" r="3" fill="#1A6BF5"/>
-            <circle cx="160" cy="166" r="3" fill="#1A6BF5"/>
-            <circle cx="180" cy="164" r="3" fill="#1A6BF5"/>
-            <circle cx="204" cy="164" r="4" fill="#4ade80"/>
-            <text x="172" y="159" textAnchor="middle" fill="#4ade80" fontSize="7" fontFamily="monospace">✓ optimal</text>
-            <text x="30" y="152" fill="#475569" fontSize="7" fontFamily="monospace">KPI ↑</text>
-            <text x="120" y="238" textAnchor="middle" fill="#94a3b8" fontSize="8" fontFamily="monospace">tested (under 10%)</text>
-            <text x="254" y="238" textAnchor="middle" fill="#475569" fontSize="8" fontFamily="monospace">not needed</text>
-          </svg>
-          <p className="text-slate-400 text-sm text-center mt-3">Finds the optimum needing only a fraction of the model and configuration combinations to experiment with</p>
+          <OptimizationEngineBody />
         </div>
-
-        {/* Center: feedback loop connector */}
-        <div className="flex lg:flex-col items-center justify-center gap-3 py-4 lg:py-0 lg:min-w-[180px]">
-          <span className="text-[#1A6BF5] text-base font-semibold font-mono whitespace-nowrap">next combo</span>
-          <svg width="160" height="94" viewBox="0 0 160 94" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-            <line x1="4" y1="14" x2="142" y2="14" stroke="#1A6BF5" strokeWidth="3" strokeLinecap="round"/>
-            <polygon points="140,6 156,14 140,22" fill="#1A6BF5"/>
-            <line x1="18" y1="80" x2="156" y2="80" stroke="#1A6BF5" strokeWidth="3" strokeLinecap="round"/>
-            <polygon points="20,72 4,80 20,88" fill="#1A6BF5"/>
-          </svg>
-          <span className="text-[#1A6BF5] text-base font-semibold font-mono whitespace-nowrap">KPI results</span>
-        </div>
-
-        {/* Right: Agent Wrapper */}
+        <FeedbackLoopConnector />
         <div className="flex-1 bg-slate-900/60 border border-slate-700/50 rounded-2xl p-8">
-          <div className="flex items-center gap-3 mb-3">
-            <h3 className="text-lg font-bold text-white">Agent Wrapper</h3>
-          </div>
-          <p className="text-slate-400 text-sm mb-6 leading-relaxed">
-            Executes a given model and configuration on the benchmark test bed and measures agent KPIs.
-          </p>
-          <svg viewBox="0 0 320 260" className="w-full" xmlns="http://www.w3.org/2000/svg">
-            <defs>
-              <marker id="wrapArrowSlide" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-                <polygon points="0 0, 8 3, 0 6" fill="#475569"/>
-              </marker>
-              <marker id="wrapArrowBlueSlide" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-                <polygon points="0 0, 8 3, 0 6" fill="#1A6BF5"/>
-              </marker>
-            </defs>
-            <rect x="8" y="18" width="304" height="235" rx="12" fill="none" stroke="#334155" strokeWidth="1.5" strokeDasharray="6,3"/>
-            <text x="20" y="32" fill="#475569" fontSize="8.5" fontFamily="monospace">[ Agent Wrapper ]</text>
-            <rect x="14" y="40" width="68" height="26" rx="6" fill="#1e293b" stroke="#1A6BF5" strokeWidth="1" strokeDasharray="3,2"/>
-            <text x="48" y="51" textAnchor="middle" fill="#64748b" fontSize="7.5" fontFamily="monospace">Model</text>
-            <text x="48" y="61" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">o3-mini</text>
-            <rect x="14" y="76" width="68" height="40" rx="6" fill="#1e293b" stroke="#1A6BF5" strokeWidth="1" strokeDasharray="3,2"/>
-            <text x="48" y="89" textAnchor="middle" fill="#64748b" fontSize="7.5" fontFamily="monospace">Config</text>
-            <text x="48" y="101" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">temp: 0.2</text>
-            <text x="48" y="111" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">top_p: 0.85</text>
-            <line x1="82" y1="53" x2="104" y2="70" stroke="#475569" strokeWidth="1.2" markerEnd="url(#wrapArrowSlide)"/>
-            <line x1="82" y1="96" x2="104" y2="84" stroke="#475569" strokeWidth="1.2" markerEnd="url(#wrapArrowSlide)"/>
-            <rect x="104" y="57" width="72" height="48" rx="8" fill="#1A6BF5" fillOpacity="0.12" stroke="#1A6BF5" strokeWidth="1.5"/>
-            <text x="140" y="74" textAnchor="middle" fill="#93c5fd" fontSize="8" fontFamily="monospace">Execute Agent</text>
-            <text x="140" y="95" textAnchor="middle" fill="#1A6BF5" fontSize="16">▶</text>
-            <line x1="140" y1="105" x2="140" y2="147" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#wrapArrowBlueSlide)"/>
-            <rect x="86" y="148" width="116" height="86" rx="8" fill="#1e293b" stroke="#334155" strokeWidth="1"/>
-            <text x="144" y="164" textAnchor="middle" fill="#64748b" fontSize="8" fontFamily="monospace">Benchmark Test Bed</text>
-            <line x1="94" y1="169" x2="194" y2="169" stroke="#334155" strokeWidth="0.5"/>
-            <circle cx="97" cy="184" r="4" fill="#4ade80" fillOpacity="0.85"/>
-            <text x="97" y="187" textAnchor="middle" fill="white" fontSize="6">✓</text>
-            <text x="107" y="187" fill="#94a3b8" fontSize="7.5" fontFamily="monospace"> query_1  pass</text>
-            <circle cx="97" cy="198" r="4" fill="#4ade80" fillOpacity="0.85"/>
-            <text x="97" y="201" textAnchor="middle" fill="white" fontSize="6">✓</text>
-            <text x="107" y="201" fill="#94a3b8" fontSize="7.5" fontFamily="monospace"> query_2  pass</text>
-            <circle cx="97" cy="212" r="4" fill="#1A6BF5" fillOpacity="0.6"/>
-            <text x="97" y="215" textAnchor="middle" fill="white" fontSize="6.5">…</text>
-            <text x="107" y="215" fill="#475569" fontSize="7.5" fontFamily="monospace"> query_3  running</text>
-            <text x="193" y="228" textAnchor="end" fill="#334155" fontSize="7" fontFamily="monospace">N queries total</text>
-            <line x1="202" y1="191" x2="212" y2="191" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#wrapArrowBlueSlide)"/>
-            <rect x="214" y="40" width="90" height="194" rx="8" fill="#1e293b" stroke="#334155" strokeWidth="1"/>
-            <text x="259" y="57" textAnchor="middle" fill="#64748b" fontSize="8.5" fontFamily="monospace">KPIs</text>
-            <line x1="222" y1="62" x2="296" y2="62" stroke="#334155" strokeWidth="0.5"/>
-            <text x="259" y="84" textAnchor="middle" fill="#4ade80" fontSize="8" fontFamily="monospace">accuracy  90%</text>
-            <text x="259" y="106" textAnchor="middle" fill="#facc15" fontSize="8" fontFamily="monospace">cost    $0.0002</text>
-            <text x="259" y="128" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">latency   1.2s</text>
-            <text x="259" y="150" textAnchor="middle" fill="#f472b6" fontSize="8" fontFamily="monospace">safety      ✓</text>
-            <text x="259" y="172" textAnchor="middle" fill="#a78bfa" fontSize="8" fontFamily="monospace">custom KPI  …</text>
-            <line x1="222" y1="190" x2="296" y2="190" stroke="#334155" strokeWidth="0.5"/>
-            <text x="259" y="208" textAnchor="middle" fill="#64748b" fontSize="7.5" fontFamily="monospace">weighted score</text>
-            <text x="259" y="226" textAnchor="middle" fill="#4ade80" fontSize="12" fontFamily="monospace" fontWeight="bold">0.86</text>
-            <line x1="20" y1="241" x2="300" y2="241" stroke="#f59e0b" strokeWidth="0.5" strokeOpacity="0.35" strokeDasharray="2,2"/>
-            <text x="20" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace" fontWeight="bold">+ benchmark insights:</text>
-            <text x="112" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace">⊘ easy</text>
-            <text x="155" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace">⨯ always-fail</text>
-            <text x="218" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace">↻ redundant</text>
-          </svg>
-          <p className="text-slate-400 text-sm text-center mt-3">Automated injection of model and configurations allows Optimizer to run successive tests seamlessly</p>
+          <AgentWrapperBody />
         </div>
       </div>
     </div>
   );
 }
 
-// Slide: Beyond Optimization — two-card layout from the homepage,
-// pasted as-is (Self-Improving Benchmark + Full Observability & Tracing).
+// Slide: Beyond Optimization — two-card layout pasted as-is from the homepage
+// (shared bodies in components/PlatformShowcase).
 function SlideBeyondBoxes() {
   return (
     <div className="w-full">
@@ -235,84 +107,11 @@ function SlideBeyondBoxes() {
         <h2 className="text-3xl md:text-4xl font-bold text-white">Beyond Optimization</h2>
       </div>
       <div className="grid md:grid-cols-2 gap-6 items-stretch">
-        {/* Card 1: Self-Improving Benchmark */}
         <div className="bg-slate-900/60 border border-amber-500/30 rounded-2xl p-8">
-          <div className="flex items-center gap-3 mb-3">
-            <div className="w-10 h-10 rounded-lg bg-amber-500/10 border border-amber-500/30 flex items-center justify-center text-amber-400">
-              <Sparkles className="w-5 h-5" />
-            </div>
-            <h3 className="text-lg font-bold text-white">Self-Improving Benchmark</h3>
-          </div>
-          <p className="text-slate-400 text-sm mb-6 leading-relaxed">
-            Hundreds of runs across the same test bed reveal patterns. Traigent flags them automatically so your benchmark gets sharper — and every future run gets faster and cheaper.
-          </p>
-          <ul className="space-y-4">
-            <li className="flex gap-3">
-              <span className="flex-shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-xs">
-                <span>⊘</span><span>too easy</span>
-              </span>
-              <span className="text-slate-400 text-sm leading-relaxed">Every model & config passes — provides no discrimination. Safe to drop.</span>
-            </li>
-            <li className="flex gap-3">
-              <span className="flex-shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-xs">
-                <span>⨯</span><span>always fails</span>
-              </span>
-              <span className="text-slate-400 text-sm leading-relaxed">Nothing passes — fix the agent itself (code, flow, RAG) before optimization can help.</span>
-            </li>
-            <li className="flex gap-3">
-              <span className="flex-shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-xs">
-                <span>↻</span><span>redundant</span>
-              </span>
-              <span className="text-slate-400 text-sm leading-relaxed">Batches where a small sample carries the same signal — trim them and shorten every wrapper run.</span>
-            </li>
-          </ul>
+          <BenchmarkCardBody />
         </div>
-
-        {/* Card 2: Full Observability & Tracing */}
         <div className="bg-slate-900/60 border border-amber-500/30 rounded-2xl p-8">
-          <div className="flex items-center gap-3 mb-3">
-            <div className="w-10 h-10 rounded-lg bg-amber-500/10 border border-amber-500/30 flex items-center justify-center text-amber-400">
-              <Eye className="w-5 h-5" />
-            </div>
-            <h3 className="text-lg font-bold text-white">Full Observability & Tracing</h3>
-          </div>
-          <p className="text-slate-400 text-sm mb-6 leading-relaxed">
-            Every wrapper run is fully instrumented — spans, tokens, costs, and errors captured end-to-end. Production-grade tracing built in, with no separate observability stack to run.
-          </p>
-          <svg viewBox="0 0 320 200" className="w-full" xmlns="http://www.w3.org/2000/svg">
-            <rect x="4" y="4" width="312" height="192" rx="8" fill="#0f172a" stroke="#334155" strokeWidth="1"/>
-            <text x="14" y="22" fill="#f59e0b" fontSize="9" fontFamily="monospace" fontWeight="bold">Trace</text>
-            <text x="40" y="22" fill="#64748b" fontSize="8.5" fontFamily="monospace">· agent_run_42</text>
-            <text x="306" y="22" textAnchor="end" fill="#4ade80" fontSize="8.5" fontFamily="monospace">1.24s ✓</text>
-            <line x1="14" y1="30" x2="306" y2="30" stroke="#334155" strokeWidth="0.5"/>
-            <text x="14" y="46" fill="#93c5fd" fontSize="8" fontFamily="monospace">▾ agent_run</text>
-            <rect x="170" y="40" width="120" height="8" rx="2" fill="#1A6BF5" fillOpacity="0.45"/>
-            <text x="296" y="46" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">1240ms</text>
-            <text x="22" y="62" fill="#94a3b8" fontSize="8" fontFamily="monospace">├─ retrieve_context</text>
-            <rect x="170" y="56" width="18" height="8" rx="2" fill="#a78bfa" fillOpacity="0.65"/>
-            <text x="296" y="62" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">180ms</text>
-            <text x="36" y="76" fill="#64748b" fontSize="7" fontFamily="monospace">└─ vector_search · top_k=8</text>
-            <rect x="170" y="71" width="13" height="6" rx="1.5" fill="#a78bfa" fillOpacity="0.4"/>
-            <text x="296" y="76" textAnchor="end" fill="#475569" fontSize="6.5" fontFamily="monospace">120ms</text>
-            <text x="22" y="92" fill="#94a3b8" fontSize="8" fontFamily="monospace">├─ llm_call · gpt-4o-mini</text>
-            <rect x="188" y="86" width="74" height="8" rx="2" fill="#60a5fa" fillOpacity="0.65"/>
-            <text x="296" y="92" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">740ms</text>
-            <text x="36" y="106" fill="#475569" fontSize="7" fontFamily="monospace">tokens: 312 in · 89 out</text>
-            <text x="296" y="106" textAnchor="end" fill="#facc15" fontSize="7" fontFamily="monospace">$0.0006</text>
-            <text x="22" y="122" fill="#94a3b8" fontSize="8" fontFamily="monospace">└─ evaluator</text>
-            <rect x="262" y="116" width="32" height="8" rx="2" fill="#4ade80" fillOpacity="0.55"/>
-            <text x="296" y="122" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">320ms</text>
-            <text x="36" y="136" fill="#4ade80" fontSize="7" fontFamily="monospace">score: 0.92 ✓</text>
-            <line x1="14" y1="148" x2="306" y2="148" stroke="#334155" strokeWidth="0.5" strokeDasharray="2,2"/>
-            <text x="14" y="161" fill="#f59e0b" fontSize="7" fontFamily="monospace" fontWeight="bold">Timeline</text>
-            <text x="306" y="161" textAnchor="end" fill="#475569" fontSize="6.5" fontFamily="monospace">0 ──── 1.24s</text>
-            <rect x="14" y="166" width="292" height="22" rx="2" fill="#0a1424"/>
-            <rect x="14" y="169" width="282" height="4" rx="1" fill="#1A6BF5" fillOpacity="0.55"/>
-            <rect x="14" y="175" width="42" height="3.5" rx="1" fill="#a78bfa" fillOpacity="0.7"/>
-            <rect x="56" y="180" width="174" height="3.5" rx="1" fill="#60a5fa" fillOpacity="0.7"/>
-            <rect x="230" y="185" width="72" height="3.5" rx="1" fill="#4ade80" fillOpacity="0.7"/>
-          </svg>
-          <p className="text-slate-400 text-sm text-center mt-3">Inspect any agent execution end-to-end · debug failures · monitor production</p>
+          <ObservabilityCardBody />
         </div>
       </div>
     </div>

--- a/src/pages/PitchShort.jsx
+++ b/src/pages/PitchShort.jsx
@@ -4,7 +4,7 @@
 // rendered through PitchFull's originals with override props for the
 // subtitle / footer; everything else is imported directly. No structural
 // JSX is duplicated from PitchFull.
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, Sparkles, Eye } from "lucide-react";
 import {
   PitchDeck,
   SlideOnePagerSummary,
@@ -42,6 +42,13 @@ function Slide03ExplosionShort() {
 
 // Slide 15: same body as the full deck, with a single centered "Calculate
 // your ROI" link in place of the "Plus engineering recovery" callout.
+// Slide 20: same body as the full deck, but the "Book a pilot" CTA points to
+// traigent.ai's /get-started page instead of the HubSpot meeting scheduler.
+// The /pitch-short-2 deck is shared externally and must keep links on-domain.
+function Slide20GetStartedShort() {
+  return <Slide20GetStarted bookingHref="https://www.traigent.ai/#/get-started" />;
+}
+
 function SlideROIPreviewShort() {
   return (
     <SlideROIPreview
@@ -60,6 +67,255 @@ function SlideROIPreviewShort() {
         </p>
       }
     />
+  );
+}
+
+// Slide: Agent Optimization Platform — two-box layout from the homepage,
+// pasted as-is (Optimization Engine + feedback-loop connector + Agent Wrapper).
+function SlidePlatformBoxes() {
+  return (
+    <div className="w-full">
+      <div className="text-center mb-6">
+        <h2 className="text-3xl md:text-4xl font-bold text-white">Agent Optimization Platform</h2>
+      </div>
+      <div className="flex flex-col gap-6 items-stretch lg:grid lg:grid-cols-[1fr_180px_1fr] lg:gap-6">
+        {/* Left: Optimization Engine */}
+        <div className="flex-1 bg-slate-900/60 border border-slate-700/50 rounded-2xl p-8">
+          <div className="flex items-center gap-3 mb-3">
+            <h3 className="text-lg font-bold text-white">Optimization Engine</h3>
+          </div>
+          <p className="text-slate-400 text-sm mb-6 leading-relaxed">
+            Learns from previous model and configuration combo results and determines the next best combination to test.
+          </p>
+          <svg viewBox="0 0 320 260" className="w-full" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <marker id="optArrowSlide" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                <polygon points="0 0, 8 3, 0 6" fill="#1A6BF5"/>
+              </marker>
+            </defs>
+            <rect x="8" y="50" width="88" height="80" rx="8" fill="#1e293b" stroke="#334155" strokeWidth="1"/>
+            <text x="52" y="68" textAnchor="middle" fill="#64748b" fontSize="8" fontFamily="monospace">Previous Results</text>
+            <line x1="16" y1="74" x2="88" y2="74" stroke="#334155" strokeWidth="0.5"/>
+            <text x="52" y="86" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">gpt-4o / t=0.7</text>
+            <text x="52" y="97" textAnchor="middle" fill="#4ade80" fontSize="7.5" fontFamily="monospace">72% acc · $0.003</text>
+            <text x="52" y="108" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">gpt-4o-mini / t=0.3</text>
+            <text x="52" y="119" textAnchor="middle" fill="#facc15" fontSize="7.5" fontFamily="monospace">61% acc · $0.001</text>
+            <line x1="96" y1="90" x2="118" y2="90" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#optArrowSlide)"/>
+            <rect x="118" y="58" width="76" height="64" rx="10" fill="#1A6BF5" fillOpacity="0.12" stroke="#1A6BF5" strokeWidth="1.5"/>
+            <text x="156" y="88" textAnchor="middle" fill="#93c5fd" fontSize="8.5" fontFamily="monospace">Optimizer</text>
+            <text x="156" y="110" textAnchor="middle" fill="#1A6BF5" fontSize="20">⚙</text>
+            <line x1="194" y1="90" x2="216" y2="90" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#optArrowSlide)"/>
+            <rect x="216" y="55" width="96" height="70" rx="8" fill="#1e293b" stroke="#1A6BF5" strokeWidth="1" strokeDasharray="4,2"/>
+            <text x="264" y="74" textAnchor="middle" fill="#93c5fd" fontSize="8.5" fontFamily="monospace">Next Combo</text>
+            <line x1="224" y1="79" x2="304" y2="79" stroke="#1A6BF5" strokeWidth="0.5" strokeOpacity="0.4"/>
+            <text x="264" y="92" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">o3-mini</text>
+            <text x="264" y="104" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">temp: 0.2</text>
+            <text x="264" y="116" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">top_p: 0.85</text>
+            <rect x="28" y="145" width="280" height="88" rx="4" fill="#0f172a"/>
+            <line x1="36" y1="225" x2="304" y2="225" stroke="#334155" strokeWidth="0.8"/>
+            <line x1="36" y1="148" x2="36" y2="225" stroke="#334155" strokeWidth="0.8"/>
+            <rect x="204" y="148" width="104" height="77" fill="#1e293b" fillOpacity="0.8"/>
+            <circle cx="218" cy="163" r="1.5" fill="#334155"/><circle cx="234" cy="177" r="1.5" fill="#334155"/>
+            <circle cx="248" cy="159" r="1.5" fill="#334155"/><circle cx="263" cy="188" r="1.5" fill="#334155"/>
+            <circle cx="276" cy="171" r="1.5" fill="#334155"/><circle cx="289" cy="165" r="1.5" fill="#334155"/>
+            <circle cx="221" cy="198" r="1.5" fill="#334155"/><circle cx="239" cy="211" r="1.5" fill="#334155"/>
+            <circle cx="255" cy="218" r="1.5" fill="#334155"/><circle cx="268" cy="203" r="1.5" fill="#334155"/>
+            <circle cx="281" cy="191" r="1.5" fill="#334155"/><circle cx="293" cy="213" r="1.5" fill="#334155"/>
+            <circle cx="225" cy="220" r="1.5" fill="#334155"/><circle cx="244" cy="155" r="1.5" fill="#334155"/>
+            <circle cx="259" cy="179" r="1.5" fill="#334155"/><circle cx="273" cy="189" r="1.5" fill="#334155"/>
+            <circle cx="286" cy="221" r="1.5" fill="#334155"/><circle cx="297" cy="170" r="1.5" fill="#334155"/>
+            <circle cx="230" cy="185" r="1.5" fill="#334155"/><circle cx="252" cy="207" r="1.5" fill="#334155"/>
+            <line x1="204" y1="148" x2="204" y2="225" stroke="#1A6BF5" strokeWidth="1" strokeOpacity="0.4" strokeDasharray="3,2"/>
+            <line x1="36" y1="164" x2="204" y2="164" stroke="#4ade80" strokeWidth="0.8" strokeDasharray="3,2" strokeOpacity="0.5"/>
+            <path d="M 50 222 C 72 210, 92 196, 114 181 S 154 169, 174 165 S 192 164, 204 164" stroke="#1A6BF5" strokeWidth="2" fill="none"/>
+            <circle cx="50" cy="222" r="3" fill="#1A6BF5"/>
+            <circle cx="74" cy="209" r="3" fill="#1A6BF5"/>
+            <circle cx="96" cy="195" r="3" fill="#1A6BF5"/>
+            <circle cx="118" cy="181" r="3" fill="#1A6BF5"/>
+            <circle cx="140" cy="171" r="3" fill="#1A6BF5"/>
+            <circle cx="160" cy="166" r="3" fill="#1A6BF5"/>
+            <circle cx="180" cy="164" r="3" fill="#1A6BF5"/>
+            <circle cx="204" cy="164" r="4" fill="#4ade80"/>
+            <text x="172" y="159" textAnchor="middle" fill="#4ade80" fontSize="7" fontFamily="monospace">✓ optimal</text>
+            <text x="30" y="152" fill="#475569" fontSize="7" fontFamily="monospace">KPI ↑</text>
+            <text x="120" y="238" textAnchor="middle" fill="#94a3b8" fontSize="8" fontFamily="monospace">tested (under 10%)</text>
+            <text x="254" y="238" textAnchor="middle" fill="#475569" fontSize="8" fontFamily="monospace">not needed</text>
+          </svg>
+          <p className="text-slate-400 text-sm text-center mt-3">Finds the optimum needing only a fraction of the model and configuration combinations to experiment with</p>
+        </div>
+
+        {/* Center: feedback loop connector */}
+        <div className="flex lg:flex-col items-center justify-center gap-3 py-4 lg:py-0 lg:min-w-[180px]">
+          <span className="text-[#1A6BF5] text-base font-semibold font-mono whitespace-nowrap">next combo</span>
+          <svg width="160" height="94" viewBox="0 0 160 94" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <line x1="4" y1="14" x2="142" y2="14" stroke="#1A6BF5" strokeWidth="3" strokeLinecap="round"/>
+            <polygon points="140,6 156,14 140,22" fill="#1A6BF5"/>
+            <line x1="18" y1="80" x2="156" y2="80" stroke="#1A6BF5" strokeWidth="3" strokeLinecap="round"/>
+            <polygon points="20,72 4,80 20,88" fill="#1A6BF5"/>
+          </svg>
+          <span className="text-[#1A6BF5] text-base font-semibold font-mono whitespace-nowrap">KPI results</span>
+        </div>
+
+        {/* Right: Agent Wrapper */}
+        <div className="flex-1 bg-slate-900/60 border border-slate-700/50 rounded-2xl p-8">
+          <div className="flex items-center gap-3 mb-3">
+            <h3 className="text-lg font-bold text-white">Agent Wrapper</h3>
+          </div>
+          <p className="text-slate-400 text-sm mb-6 leading-relaxed">
+            Executes a given model and configuration on the benchmark test bed and measures agent KPIs.
+          </p>
+          <svg viewBox="0 0 320 260" className="w-full" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <marker id="wrapArrowSlide" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                <polygon points="0 0, 8 3, 0 6" fill="#475569"/>
+              </marker>
+              <marker id="wrapArrowBlueSlide" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                <polygon points="0 0, 8 3, 0 6" fill="#1A6BF5"/>
+              </marker>
+            </defs>
+            <rect x="8" y="18" width="304" height="235" rx="12" fill="none" stroke="#334155" strokeWidth="1.5" strokeDasharray="6,3"/>
+            <text x="20" y="32" fill="#475569" fontSize="8.5" fontFamily="monospace">[ Agent Wrapper ]</text>
+            <rect x="14" y="40" width="68" height="26" rx="6" fill="#1e293b" stroke="#1A6BF5" strokeWidth="1" strokeDasharray="3,2"/>
+            <text x="48" y="51" textAnchor="middle" fill="#64748b" fontSize="7.5" fontFamily="monospace">Model</text>
+            <text x="48" y="61" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">o3-mini</text>
+            <rect x="14" y="76" width="68" height="40" rx="6" fill="#1e293b" stroke="#1A6BF5" strokeWidth="1" strokeDasharray="3,2"/>
+            <text x="48" y="89" textAnchor="middle" fill="#64748b" fontSize="7.5" fontFamily="monospace">Config</text>
+            <text x="48" y="101" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">temp: 0.2</text>
+            <text x="48" y="111" textAnchor="middle" fill="#94a3b8" fontSize="7.5" fontFamily="monospace">top_p: 0.85</text>
+            <line x1="82" y1="53" x2="104" y2="70" stroke="#475569" strokeWidth="1.2" markerEnd="url(#wrapArrowSlide)"/>
+            <line x1="82" y1="96" x2="104" y2="84" stroke="#475569" strokeWidth="1.2" markerEnd="url(#wrapArrowSlide)"/>
+            <rect x="104" y="57" width="72" height="48" rx="8" fill="#1A6BF5" fillOpacity="0.12" stroke="#1A6BF5" strokeWidth="1.5"/>
+            <text x="140" y="74" textAnchor="middle" fill="#93c5fd" fontSize="8" fontFamily="monospace">Execute Agent</text>
+            <text x="140" y="95" textAnchor="middle" fill="#1A6BF5" fontSize="16">▶</text>
+            <line x1="140" y1="105" x2="140" y2="147" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#wrapArrowBlueSlide)"/>
+            <rect x="86" y="148" width="116" height="86" rx="8" fill="#1e293b" stroke="#334155" strokeWidth="1"/>
+            <text x="144" y="164" textAnchor="middle" fill="#64748b" fontSize="8" fontFamily="monospace">Benchmark Test Bed</text>
+            <line x1="94" y1="169" x2="194" y2="169" stroke="#334155" strokeWidth="0.5"/>
+            <circle cx="97" cy="184" r="4" fill="#4ade80" fillOpacity="0.85"/>
+            <text x="97" y="187" textAnchor="middle" fill="white" fontSize="6">✓</text>
+            <text x="107" y="187" fill="#94a3b8" fontSize="7.5" fontFamily="monospace"> query_1  pass</text>
+            <circle cx="97" cy="198" r="4" fill="#4ade80" fillOpacity="0.85"/>
+            <text x="97" y="201" textAnchor="middle" fill="white" fontSize="6">✓</text>
+            <text x="107" y="201" fill="#94a3b8" fontSize="7.5" fontFamily="monospace"> query_2  pass</text>
+            <circle cx="97" cy="212" r="4" fill="#1A6BF5" fillOpacity="0.6"/>
+            <text x="97" y="215" textAnchor="middle" fill="white" fontSize="6.5">…</text>
+            <text x="107" y="215" fill="#475569" fontSize="7.5" fontFamily="monospace"> query_3  running</text>
+            <text x="193" y="228" textAnchor="end" fill="#334155" fontSize="7" fontFamily="monospace">N queries total</text>
+            <line x1="202" y1="191" x2="212" y2="191" stroke="#1A6BF5" strokeWidth="1.5" markerEnd="url(#wrapArrowBlueSlide)"/>
+            <rect x="214" y="40" width="90" height="194" rx="8" fill="#1e293b" stroke="#334155" strokeWidth="1"/>
+            <text x="259" y="57" textAnchor="middle" fill="#64748b" fontSize="8.5" fontFamily="monospace">KPIs</text>
+            <line x1="222" y1="62" x2="296" y2="62" stroke="#334155" strokeWidth="0.5"/>
+            <text x="259" y="84" textAnchor="middle" fill="#4ade80" fontSize="8" fontFamily="monospace">accuracy  90%</text>
+            <text x="259" y="106" textAnchor="middle" fill="#facc15" fontSize="8" fontFamily="monospace">cost    $0.0002</text>
+            <text x="259" y="128" textAnchor="middle" fill="#60a5fa" fontSize="8" fontFamily="monospace">latency   1.2s</text>
+            <text x="259" y="150" textAnchor="middle" fill="#f472b6" fontSize="8" fontFamily="monospace">safety      ✓</text>
+            <text x="259" y="172" textAnchor="middle" fill="#a78bfa" fontSize="8" fontFamily="monospace">custom KPI  …</text>
+            <line x1="222" y1="190" x2="296" y2="190" stroke="#334155" strokeWidth="0.5"/>
+            <text x="259" y="208" textAnchor="middle" fill="#64748b" fontSize="7.5" fontFamily="monospace">weighted score</text>
+            <text x="259" y="226" textAnchor="middle" fill="#4ade80" fontSize="12" fontFamily="monospace" fontWeight="bold">0.86</text>
+            <line x1="20" y1="241" x2="300" y2="241" stroke="#f59e0b" strokeWidth="0.5" strokeOpacity="0.35" strokeDasharray="2,2"/>
+            <text x="20" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace" fontWeight="bold">+ benchmark insights:</text>
+            <text x="112" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace">⊘ easy</text>
+            <text x="155" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace">⨯ always-fail</text>
+            <text x="218" y="250" fill="#f59e0b" fontSize="7" fontFamily="monospace">↻ redundant</text>
+          </svg>
+          <p className="text-slate-400 text-sm text-center mt-3">Automated injection of model and configurations allows Optimizer to run successive tests seamlessly</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Slide: Beyond Optimization — two-card layout from the homepage,
+// pasted as-is (Self-Improving Benchmark + Full Observability & Tracing).
+function SlideBeyondBoxes() {
+  return (
+    <div className="w-full">
+      <div className="text-center mb-6">
+        <h2 className="text-3xl md:text-4xl font-bold text-white">Beyond Optimization</h2>
+      </div>
+      <div className="grid md:grid-cols-2 gap-6 items-stretch">
+        {/* Card 1: Self-Improving Benchmark */}
+        <div className="bg-slate-900/60 border border-amber-500/30 rounded-2xl p-8">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="w-10 h-10 rounded-lg bg-amber-500/10 border border-amber-500/30 flex items-center justify-center text-amber-400">
+              <Sparkles className="w-5 h-5" />
+            </div>
+            <h3 className="text-lg font-bold text-white">Self-Improving Benchmark</h3>
+          </div>
+          <p className="text-slate-400 text-sm mb-6 leading-relaxed">
+            Hundreds of runs across the same test bed reveal patterns. Traigent flags them automatically so your benchmark gets sharper — and every future run gets faster and cheaper.
+          </p>
+          <ul className="space-y-4">
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-xs">
+                <span>⊘</span><span>too easy</span>
+              </span>
+              <span className="text-slate-400 text-sm leading-relaxed">Every model & config passes — provides no discrimination. Safe to drop.</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-xs">
+                <span>⨯</span><span>always fails</span>
+              </span>
+              <span className="text-slate-400 text-sm leading-relaxed">Nothing passes — fix the agent itself (code, flow, RAG) before optimization can help.</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-400 font-mono text-xs">
+                <span>↻</span><span>redundant</span>
+              </span>
+              <span className="text-slate-400 text-sm leading-relaxed">Batches where a small sample carries the same signal — trim them and shorten every wrapper run.</span>
+            </li>
+          </ul>
+        </div>
+
+        {/* Card 2: Full Observability & Tracing */}
+        <div className="bg-slate-900/60 border border-amber-500/30 rounded-2xl p-8">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="w-10 h-10 rounded-lg bg-amber-500/10 border border-amber-500/30 flex items-center justify-center text-amber-400">
+              <Eye className="w-5 h-5" />
+            </div>
+            <h3 className="text-lg font-bold text-white">Full Observability & Tracing</h3>
+          </div>
+          <p className="text-slate-400 text-sm mb-6 leading-relaxed">
+            Every wrapper run is fully instrumented — spans, tokens, costs, and errors captured end-to-end. Production-grade tracing built in, with no separate observability stack to run.
+          </p>
+          <svg viewBox="0 0 320 200" className="w-full" xmlns="http://www.w3.org/2000/svg">
+            <rect x="4" y="4" width="312" height="192" rx="8" fill="#0f172a" stroke="#334155" strokeWidth="1"/>
+            <text x="14" y="22" fill="#f59e0b" fontSize="9" fontFamily="monospace" fontWeight="bold">Trace</text>
+            <text x="40" y="22" fill="#64748b" fontSize="8.5" fontFamily="monospace">· agent_run_42</text>
+            <text x="306" y="22" textAnchor="end" fill="#4ade80" fontSize="8.5" fontFamily="monospace">1.24s ✓</text>
+            <line x1="14" y1="30" x2="306" y2="30" stroke="#334155" strokeWidth="0.5"/>
+            <text x="14" y="46" fill="#93c5fd" fontSize="8" fontFamily="monospace">▾ agent_run</text>
+            <rect x="170" y="40" width="120" height="8" rx="2" fill="#1A6BF5" fillOpacity="0.45"/>
+            <text x="296" y="46" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">1240ms</text>
+            <text x="22" y="62" fill="#94a3b8" fontSize="8" fontFamily="monospace">├─ retrieve_context</text>
+            <rect x="170" y="56" width="18" height="8" rx="2" fill="#a78bfa" fillOpacity="0.65"/>
+            <text x="296" y="62" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">180ms</text>
+            <text x="36" y="76" fill="#64748b" fontSize="7" fontFamily="monospace">└─ vector_search · top_k=8</text>
+            <rect x="170" y="71" width="13" height="6" rx="1.5" fill="#a78bfa" fillOpacity="0.4"/>
+            <text x="296" y="76" textAnchor="end" fill="#475569" fontSize="6.5" fontFamily="monospace">120ms</text>
+            <text x="22" y="92" fill="#94a3b8" fontSize="8" fontFamily="monospace">├─ llm_call · gpt-4o-mini</text>
+            <rect x="188" y="86" width="74" height="8" rx="2" fill="#60a5fa" fillOpacity="0.65"/>
+            <text x="296" y="92" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">740ms</text>
+            <text x="36" y="106" fill="#475569" fontSize="7" fontFamily="monospace">tokens: 312 in · 89 out</text>
+            <text x="296" y="106" textAnchor="end" fill="#facc15" fontSize="7" fontFamily="monospace">$0.0006</text>
+            <text x="22" y="122" fill="#94a3b8" fontSize="8" fontFamily="monospace">└─ evaluator</text>
+            <rect x="262" y="116" width="32" height="8" rx="2" fill="#4ade80" fillOpacity="0.55"/>
+            <text x="296" y="122" textAnchor="end" fill="#64748b" fontSize="7" fontFamily="monospace">320ms</text>
+            <text x="36" y="136" fill="#4ade80" fontSize="7" fontFamily="monospace">score: 0.92 ✓</text>
+            <line x1="14" y1="148" x2="306" y2="148" stroke="#334155" strokeWidth="0.5" strokeDasharray="2,2"/>
+            <text x="14" y="161" fill="#f59e0b" fontSize="7" fontFamily="monospace" fontWeight="bold">Timeline</text>
+            <text x="306" y="161" textAnchor="end" fill="#475569" fontSize="6.5" fontFamily="monospace">0 ──── 1.24s</text>
+            <rect x="14" y="166" width="292" height="22" rx="2" fill="#0a1424"/>
+            <rect x="14" y="169" width="282" height="4" rx="1" fill="#1A6BF5" fillOpacity="0.55"/>
+            <rect x="14" y="175" width="42" height="3.5" rx="1" fill="#a78bfa" fillOpacity="0.7"/>
+            <rect x="56" y="180" width="174" height="3.5" rx="1" fill="#60a5fa" fillOpacity="0.7"/>
+            <rect x="230" y="185" width="72" height="3.5" rx="1" fill="#4ade80" fillOpacity="0.7"/>
+          </svg>
+          <p className="text-slate-400 text-sm text-center mt-3">Inspect any agent execution end-to-end · debug failures · monitor production</p>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -87,8 +343,11 @@ export const SHORT_SLIDES = [
   // ----- PROOF -----
   { title: "Customers", section: "Proof", component: Slide17Customers },
   // ----- CTA -----
-  { title: "Get Started", section: "CTA", component: Slide20GetStarted },
+  { title: "Get Started", section: "CTA", component: Slide20GetStartedShort },
   { title: "Better Agents. Faster. Lower Spend. Higher Confidence.", section: "CTA", component: Slide21Closing },
+  // ----- APPENDIX: homepage-style detail slides -----
+  { title: "Agent Optimization Platform — Components", section: "Appendix", component: SlidePlatformBoxes },
+  { title: "Beyond Optimization — Capabilities", section: "Appendix", component: SlideBeyondBoxes },
 ];
 
 export default function PitchShort() {

--- a/src/pages/PitchShort2.jsx
+++ b/src/pages/PitchShort2.jsx
@@ -5,6 +5,7 @@
 import { Helmet } from "react-helmet-async";
 import { SHORT_SLIDES } from "./PitchShort";
 import { OnePager2Slide } from "./OnePager2";
+import BrandMark from "../components/BrandMark";
 
 // Slide 1 in /pitch-short uses SlideOnePagerSummary which wraps OnePager2Slide
 // with deck-specific negative margins. In scroll mode there's no deck padding
@@ -45,11 +46,10 @@ export default function PitchShort2() {
                   href="https://www.traigent.ai/"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="absolute top-4 left-4 z-10 flex items-center gap-2 hover:opacity-80 transition-opacity"
+                  className="absolute top-4 left-4 z-10 hover:opacity-80 transition-opacity"
                   aria-label="Traigent.ai"
                 >
-                  <img src="/images/traigent-logo-icon.png" alt="" aria-hidden="true" className="h-6 w-auto" />
-                  <span className="text-white text-base md:text-lg font-bold tracking-tight">Traigent.ai</span>
+                  <BrandMark size="md" />
                 </a>
                 <div className="flex items-center justify-center">
                   <Slide />

--- a/src/pages/ValueProposition.jsx
+++ b/src/pages/ValueProposition.jsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
+import BrandMark from "../components/BrandMark";
 
 // ============================================================================
 // V2's 6 truths — logical chain that leads to the Traigent Solution.
@@ -473,11 +474,7 @@ export default function ValueProposition() {
       <header className="bg-gradient-to-br from-slate-950 to-indigo-950 py-12 border-b border-slate-800">
         <div className="max-w-5xl mx-auto px-6">
           <FadeInView>
-            <img
-              src="https://qtrypzzcjebvfcihiynt.supabase.co/storage/v1/object/public/base44-prod/public/057ce2_TraigentLogoWhiteCropped.png"
-              alt="Traigent Logo"
-              className="h-14 mb-6"
-            />
+            <BrandMark size="lg" className="mb-6" />
             <h2 className="text-3xl md:text-4xl font-bold mb-3">
               The First <span className="text-indigo-400">AI Agents Continuous Optimization</span> Infrastructure
             </h2>


### PR DESCRIPTION
## Summary
Introduces a single `BrandMark` component that renders the slide-chrome look (icon + **Traigent.ai** wordmark) at four preset sizes (`sm`/`md`/`lg`/`hero`). Every standalone Traigent brand mark on the site now uses it, so the wordmark reads consistently as "Traigent.ai" — matching the `/pitch-short-2` slide frame the user pointed at.

**Replaced:**
- TopNav desktop logo + mobile drawer logo
- PitchFull deck-shell top-left logo + slide-1 hero logo
- OnePager (`/one-pager`) and OnePager2 (`/one-pager-2`) headers
- `/pitch-short-2` slide-frame chrome (consolidated onto the same component)
- `/pitch` slide-1 hero h1 text (Traigent → Traigent.ai)
- Investors page (3 spots: password gate, two headers)
- ValueProposition page header

Removed unused `TRAIGENT_LOGO_URL` / `LOGO_SRC` constants now that the Supabase wordmark PNG is no longer referenced from the React app. (Static `investors.html` export still references it, intentionally left alone.)

## Test plan
- [ ] Sticky top nav reads "Traigent.ai" on every page (desktop + mobile drawer)
- [ ] `/pitch-full` deck shell top-left and slide 1 hero both render BrandMark
- [ ] `/pitch-short` and `/pitch-short-2` slide frames unchanged visually
- [ ] `/one-pager` and `/one-pager-2` headers show the new mark
- [ ] `/pitch` slide-1 h1 reads "Traigent.ai"
- [ ] `/value-proposition` header shows the new mark
- [ ] Investors gate + headers show the new mark
- [ ] No leftover imports of `LOGO_SRC` or `TRAIGENT_LOGO_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)