### PR TITLE
ship: BEFORE / TRAIGENT / AFTER graphic + iPhone-fit /pitch-short-2

### DIFF
--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -8,6 +8,7 @@ import {
   BenchmarkCardBody,
   ObservabilityCardBody,
 } from "../components/PlatformShowcase";
+import { SlideParetoFrontier } from "./PitchShort";
 import { Link } from "react-router-dom";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
@@ -250,7 +251,7 @@ export default function Homepage() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.3 }}
-              className="mt-6 md:mt-8 mb-20 md:mb-28 scroll-mt-20"
+              className="mt-6 md:mt-8 mb-6 md:mb-8 scroll-mt-20"
             >
               <p className="text-center text-sm md:text-base text-slate-300 uppercase tracking-widest font-bold mb-8">Customers</p>
               <div className="relative overflow-hidden">
@@ -281,6 +282,15 @@ export default function Homepage() {
             </motion.div>
           </div>
 
+        </div>
+      </section>
+
+      {/* How It Works — three-panel BEFORE / TRAIGENT / AFTER story.
+          Component is shared with /pitch-short(-2) slide 21 so the visual
+          stays identical between the homepage and the deck. */}
+      <section className="pt-2 md:pt-4 pb-16 md:pb-20 bg-[#080808]">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <SlideParetoFrontier />
         </div>
       </section>
 

--- a/src/pages/PitchShort.jsx
+++ b/src/pages/PitchShort.jsx
@@ -4,7 +4,7 @@
 // rendered through PitchFull's originals with override props for the
 // subtitle / footer; everything else is imported directly. No structural
 // JSX is duplicated from PitchFull.
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, DollarSign, Check, Clock, ShieldCheck } from "lucide-react";
 import {
   OptimizationEngineBody,
   FeedbackLoopConnector,
@@ -118,9 +118,233 @@ function SlideBeyondBoxes() {
   );
 }
 
+// Slide: BEFORE → OPTIMIZER → AFTER three-panel story.
+// LEFT  = the 25+ knob configuration space (dimensionality of the problem).
+// MIDDLE = the autonomous Test/Measure/Tune/Repeat loop.
+// RIGHT = the business outcomes (cost, accuracy, time).
+// Per-category color palette for the knob bars.
+const KNOB_COLOR = {
+  model: { bar: "#4D8EF8", dot: "#1A6BF5", track: "rgba(77,142,248,0.18)" }, // blue   — model selection
+  llm:   { bar: "#f59e0b", dot: "#b45309", track: "rgba(245,158,11,0.18)" }, // amber  — LLM inference
+  agent: { bar: "#a78bfa", dot: "#7c3aed", track: "rgba(167,139,250,0.18)" }, // violet — agent orchestration
+};
+
+function KnobRow({ name, fill, value, category = "model" }) {
+  const c = KNOB_COLOR[category];
+  return (
+    <div>
+      <div className="flex items-center justify-between text-[12px] mb-1">
+        <span className="text-slate-200 font-semibold">{name}</span>
+        <span className="text-slate-400 font-mono">{value}</span>
+      </div>
+      <div className="relative h-1.5 rounded-full" style={{ backgroundColor: c.track }}>
+        <div
+          className="absolute inset-y-0 left-0 rounded-full"
+          style={{ width: `${fill}%`, backgroundColor: c.bar }}
+        />
+        <div
+          className="absolute top-1/2 w-3 h-3 rounded-full bg-white -translate-y-1/2"
+          style={{ left: `calc(${fill}% - 6px)`, border: `2px solid ${c.dot}` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CategoryLegendDot({ category, label }) {
+  const c = KNOB_COLOR[category];
+  return (
+    <span className="inline-flex items-center gap-1.5 text-[11px] font-mono uppercase tracking-wider">
+      <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: c.bar }} />
+      <span className="text-slate-300">{label}</span>
+    </span>
+  );
+}
+
+function OutcomeCard({ icon: Icon, iconColor, iconBg, title, body }) {
+  return (
+    <div className="bg-slate-950/60 border border-slate-700/60 rounded-lg p-3">
+      <div className="flex items-center gap-2 mb-1">
+        <div className="w-7 h-7 rounded-md flex items-center justify-center" style={{ backgroundColor: iconBg, color: iconColor }}>
+          <Icon className="w-4 h-4" strokeWidth={2.5} />
+        </div>
+        <h4 className="text-[15px] font-bold text-white">{title}</h4>
+      </div>
+      <p className="text-[12px] text-slate-400 leading-snug">{body}</p>
+    </div>
+  );
+}
+
+export function SlideParetoFrontier() {
+  // Knobs grouped by category — Model / LLM / Agent. Each column keeps its
+  // categories contiguous so the colors read as bands top-to-bottom.
+  const knobsLeft = [
+    // Model
+    { name: 'Model',       fill: 65, value: '7 candidates', category: 'model' },
+    { name: 'Routing',     fill: 45, value: '5',            category: 'model' },
+    // LLM (per-call inference)
+    { name: 'Prompt',      fill: 90, value: '18 variants',  category: 'llm' },
+    { name: 'Reasoning',   fill: 60, value: 'low/med/high', category: 'llm' },
+    { name: 'Context',     fill: 70, value: '32k',          category: 'llm' },
+    { name: 'CoT / SC',    fill: 50, value: '4',            category: 'llm' },
+    { name: 'Caching',     fill: 75, value: 'on / off',     category: 'llm' },
+  ];
+  const knobsRight = [
+    // LLM continued
+    { name: 'Few-shot',     fill: 70, value: '0–32 ex',       category: 'llm' },
+    { name: 'Output schema',fill: 50, value: 'free/JSON/fn',  category: 'llm' },
+    // Agent (orchestration)
+    { name: 'Tools',        fill: 50, value: '9',             category: 'agent' },
+    { name: 'RAG strategy', fill: 80, value: '12',            category: 'agent' },
+    { name: 'Re-ranker',    fill: 55, value: '5',             category: 'agent' },
+    { name: 'Chunking',     fill: 40, value: '4 sizes',       category: 'agent' },
+    { name: 'Guardrails',   fill: 60, value: '6',             category: 'agent' },
+  ];
+  return (
+    <div className="w-full max-w-[1240px] mx-auto">
+      <div className="text-center mb-3">
+        <p className="text-[18px] md:text-[22px] font-bold text-amber-400 mb-1.5 tracking-tight">
+          Literally millions of configuration options to contemplate.
+        </p>
+        <h2 className="text-3xl md:text-4xl font-bold text-white mb-1">
+          Agent performance is a <span className="text-[#4D8EF8]">25+ knob</span> optimization problem
+        </h2>
+        <p className="text-base md:text-lg text-slate-400">
+          Traigent intelligently finds the <span className="font-bold text-[#f59e0b]">lowest-cost</span>, <span className="font-bold text-[#4D8EF8]">highest-quality</span> setup for each AI agent, rapidly.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-[1fr_28px_1fr_28px_1fr] items-stretch gap-0">
+        {/* LEFT: 25+ knobs */}
+        <div className="bg-slate-900/70 border border-slate-700/60 rounded-xl p-4">
+          <div className="text-[10px] font-mono uppercase tracking-widest text-amber-400 mb-1">Before Traigent</div>
+          <h3 className="text-[20px] font-bold text-white leading-tight mb-1">25+ configuration knobs</h3>
+          <p className="text-[12px] text-slate-400 leading-snug mb-2">
+            Too many choices to test manually, and every workload behaves differently.
+          </p>
+          <div className="flex items-center justify-center gap-3 mb-3">
+            <CategoryLegendDot category="model" label="Model" />
+            <CategoryLegendDot category="llm"   label="LLM" />
+            <CategoryLegendDot category="agent" label="Agent" />
+          </div>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-2.5">
+            {[...knobsLeft, ...knobsRight].map((k, i) => (
+              <KnobRow key={i} {...k} />
+            ))}
+          </div>
+          <div className="text-[11px] text-slate-500 mt-3 italic text-center">…and 11 more knobs (eval threshold, concurrency, streaming, …)</div>
+        </div>
+
+        {/* Arrow */}
+        <div className="flex items-center justify-center">
+          <ArrowRight className="w-7 h-7" style={{ color: '#1A6BF5' }} />
+        </div>
+
+        {/* MIDDLE: Optimizer */}
+        <div className="bg-slate-900/70 border-2 rounded-xl p-4 flex flex-col" style={{ borderColor: '#1A6BF5' }}>
+          <div className="text-[10px] font-mono uppercase tracking-widest mb-1" style={{ color: '#4D8EF8' }}>Traigent</div>
+          <h3 className="text-[20px] font-bold text-white leading-tight mb-1">Automatic Optimization</h3>
+          <p className="text-[12px] text-slate-400 leading-snug mb-2">
+            Contemplates 1,000s of options. Converges on <span className="text-white font-semibold">THE</span> optimum. Re-runs every time conditions change.
+          </p>
+
+          {/* Loop SVG */}
+          <div className="flex-1 flex items-center justify-center">
+            <svg viewBox="0 0 240 240" className="w-full max-w-[240px]" xmlns="http://www.w3.org/2000/svg">
+              <defs>
+                <linearGradient id="ringGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stopColor="#4D8EF8"/>
+                  <stop offset="100%" stopColor="#1A6BF5"/>
+                </linearGradient>
+              </defs>
+              {/* Background full ring */}
+              <circle cx="120" cy="120" r="82" fill="none" stroke="#1e293b" strokeWidth="14"/>
+              {/* Clockwise progress arc — starts at 12 o'clock, sweeps 270° clockwise,
+                  ends at 9 o'clock. Path "A 82 82 0 1 1 ..." uses sweep-flag=1 (clockwise). */}
+              <path
+                d="M 120 38 A 82 82 0 1 1 38 120"
+                fill="none"
+                stroke="url(#ringGrad)"
+                strokeWidth="14"
+                strokeLinecap="round"
+              />
+              {/* Arrowhead at 9 o'clock pointing UP — the tangent direction of
+                  clockwise motion at the left side of the circle. */}
+              <polygon points="38,96 22,128 54,128" fill="#1A6BF5"/>
+
+              <circle cx="120" cy="120" r="58" fill="#020617" stroke="#334155" strokeWidth="1"/>
+              <text x="120" y="110" textAnchor="middle" fill="#cbd5e1" fontSize="13" fontFamily="ui-sans-serif, system-ui" fontWeight="700">LEARN</text>
+              <text x="120" y="127" textAnchor="middle" fill="#cbd5e1" fontSize="13" fontFamily="ui-sans-serif, system-ui" fontWeight="700">DEDUCE</text>
+              <text x="120" y="144" textAnchor="middle" fill="#cbd5e1" fontSize="13" fontFamily="ui-sans-serif, system-ui" fontWeight="700">TEST</text>
+            </svg>
+          </div>
+
+          {/* Bottom step pills */}
+          <div className="grid grid-cols-4 gap-1.5 mt-2">
+            {['Learn', 'Deduce', 'Test', 'Repeat'].map((label) => (
+              <div
+                key={label}
+                className="text-[11px] font-mono text-center py-1 rounded border border-slate-700 text-slate-300"
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Arrow */}
+        <div className="flex items-center justify-center">
+          <ArrowRight className="w-7 h-7" style={{ color: '#1A6BF5' }} />
+        </div>
+
+        {/* RIGHT: Outcomes */}
+        <div className="bg-slate-950 border border-slate-700/60 rounded-xl p-4">
+          <div className="text-[10px] font-mono uppercase tracking-widest mb-1" style={{ color: '#4D8EF8' }}>After Traigent</div>
+          <h3 className="text-[20px] font-bold text-white leading-tight mb-1">Best agent config</h3>
+          <p className="text-[12px] text-slate-400 leading-snug mb-3">
+            Rapidly finds <span className="text-white font-semibold">THE</span> optimal business option — vs. weeks of laborious guesswork.
+          </p>
+          <div className="space-y-2.5">
+            <OutcomeCard
+              icon={DollarSign}
+              iconColor="#f59e0b"
+              iconBg="rgba(245,158,11,0.15)"
+              title="Lower LLM cost"
+              body="Finds cheaper combination that still hits accuracy."
+            />
+            <OutcomeCard
+              icon={Check}
+              iconColor="#4D8EF8"
+              iconBg="rgba(77,142,248,0.15)"
+              title="Higher accuracy"
+              body="Scores output quality against the benchmark."
+            />
+            <OutcomeCard
+              icon={Clock}
+              iconColor="#cbd5e1"
+              iconBg="rgba(148,163,184,0.15)"
+              title="Weeks saved"
+              body="Replaces exhaustive trial-and-error with automated deductive optimization."
+            />
+            <OutcomeCard
+              icon={ShieldCheck}
+              iconColor="#a78bfa"
+              iconBg="rgba(167,139,250,0.15)"
+              title="100% Confidence"
+              body="You know it's THE optimum."
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export const SHORT_SLIDES = [
   // ----- ONE-PAGER SUMMARY (opener) -----
   { title: "One-Pager Summary", section: "Traigent intro", component: SlideOnePagerSummary },
+  // ----- BEFORE / TRAIGENT / AFTER — promoted to slide 2 as the visual hook -----
+  { title: "25+ Knob Problem — Before / Traigent / After", section: "Traigent intro", component: SlideParetoFrontier },
   // ----- PROBLEM -----
   { title: "The Configuration Explosion", section: "Problem", component: Slide03ExplosionShort },
   // ----- SOLUTION -----

--- a/src/pages/PitchShort2.jsx
+++ b/src/pages/PitchShort2.jsx
@@ -1,15 +1,61 @@
-// /pitch-short-2 — same slides as /pitch-short, but rendered as a vertical
-// scrollable page (one slide per viewport-height section). No top bar, no
-// bottom nav, no keyboard handlers, no animated transitions. Designed for
-// recipients who prefer scrolling over slide-by-slide presentation chrome.
+// /pitch-short-2 - same slides as /pitch-short, but rendered as a vertical
+// scrollable page. Each slide is a fixed 1280x720 canvas scaled down to fit
+// the viewport, which keeps it readable on iPhone landscape without clipping.
+import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { SHORT_SLIDES } from "./PitchShort";
 import { OnePager2Slide } from "./OnePager2";
 import BrandMark from "../components/BrandMark";
 
-// Slide 1 in /pitch-short uses SlideOnePagerSummary which wraps OnePager2Slide
-// with deck-specific negative margins. In scroll mode there's no deck padding
-// to cancel, so render OnePager2Slide directly here.
+const SLIDE_W = 1280;
+const SLIDE_H = 720;
+const VIEWPORT_MARGIN = 16;
+
+function getScale() {
+  if (typeof window === "undefined") return 1;
+  const availableW = Math.max(320, window.innerWidth - VIEWPORT_MARGIN);
+  const availableH = Math.max(240, window.innerHeight - VIEWPORT_MARGIN);
+  return Math.min(1, availableW / SLIDE_W, availableH / SLIDE_H);
+}
+
+function useViewportScale() {
+  const [scale, setScale] = useState(getScale);
+
+  useEffect(() => {
+    const update = () => setScale(getScale());
+    window.addEventListener("resize", update);
+    window.addEventListener("orientationchange", update);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("orientationchange", update);
+    };
+  }, []);
+
+  return scale;
+}
+
+function useRemoveChatWidget() {
+  useEffect(() => {
+    const removeChat = () => {
+      window.HubSpotConversations?.widget?.remove?.();
+      document.querySelectorAll(
+        [
+          "#hubspot-messages-iframe-container",
+          "#hubspot-conversations-iframe",
+          ".hs-shadow-container",
+          "iframe[src*='conversations-visitor']",
+        ].join(",")
+      ).forEach((node) => node.remove());
+    };
+
+    removeChat();
+    const observer = new MutationObserver(removeChat);
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, []);
+}
+
 function ScrollOnePagerOpener() {
   return <OnePager2Slide showHeader={false} showFooter={false} />;
 }
@@ -18,49 +64,93 @@ const SCROLL_SLIDES = SHORT_SLIDES.map((s, i) =>
   i === 0 ? { ...s, component: ScrollOnePagerOpener } : s
 );
 
+function SlideCanvas({ slide, index, total, scale }) {
+  const Slide = slide.component;
+
+  return (
+    <section
+      className="min-h-[100svh] flex items-center justify-center bg-[#080808] border-b border-slate-900/70 last:border-b-0"
+      style={{ padding: `${VIEWPORT_MARGIN / 2}px` }}
+    >
+      <div
+        className="relative shrink-0"
+        style={{
+          width: SLIDE_W * scale,
+          height: SLIDE_H * scale,
+        }}
+      >
+        <div
+          className="pitch-short-2-slide relative bg-[#080808] text-white overflow-hidden border border-slate-600"
+          style={{
+            width: SLIDE_W,
+            height: SLIDE_H,
+            transform: `scale(${scale})`,
+            transformOrigin: "top left",
+          }}
+        >
+          <a
+            href="https://www.traigent.ai/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="absolute top-4 left-4 z-10 hover:opacity-80 transition-opacity"
+            aria-label="Traigent.ai"
+          >
+            <BrandMark size="md" />
+          </a>
+
+          <div
+            className={`h-full w-full flex items-center justify-center ${
+              index === 0 ? "" : "px-10 pt-16 pb-12"
+            }`}
+          >
+            <Slide />
+          </div>
+
+          <span className="absolute bottom-3 right-4 text-slate-500 text-sm font-mono">
+            {index + 1} / {total}
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export default function PitchShort2() {
+  const scale = useViewportScale();
+  useRemoveChatWidget();
+
   return (
     <>
       <Helmet>
-        <title>Traigent — Pitch (Scroll)</title>
+        <title>Traigent - Pitch (Scroll)</title>
       </Helmet>
-      {/* Suppress HubSpot chat widget + cookie banner. NOTE: do NOT include
-          `.hs-messages-mobile` — that selector matches React's own root in
-          some dev builds and blanks the entire page on mobile. */}
       <style>{`
         #hubspot-messages-iframe-container,
+        #hubspot-conversations-iframe,
+        .hs-shadow-container,
+        iframe[src*="conversations-visitor"],
         .hs-banner-iframe,
         #hs-eu-cookie-confirmation,
         #hs-eu-cookie-confirmation-inner { display: none !important; }
+        @supports (height: 100svh) {
+          html, body, #root { min-height: 100svh; }
+        }
+        .pitch-short-2-slide div[class*="lg:grid-cols"] {
+          display: grid !important;
+          grid-template-columns: minmax(0, 1fr) 180px minmax(0, 1fr) !important;
+          gap: 1.5rem !important;
+        }
       `}</style>
       <div className="bg-[#080808] text-white">
-        {SCROLL_SLIDES.map((slide, i) => {
-          const Slide = slide.component;
-          return (
-            <section
-              key={`${i}-${slide.title}`}
-              className="min-h-screen flex items-center justify-center bg-[#080808] border-b border-slate-900/60 last:border-b-0 px-4 md:px-12 py-12"
-            >
-              <div className="relative w-full max-w-[1280px] mx-auto border border-slate-600 rounded-lg pt-16 pb-12 px-4 md:px-10 min-h-[500px] md:min-h-[700px]">
-                <a
-                  href="https://www.traigent.ai/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="absolute top-4 left-4 z-10 hover:opacity-80 transition-opacity"
-                  aria-label="Traigent.ai"
-                >
-                  <BrandMark size="md" />
-                </a>
-                <div className="flex items-center justify-center">
-                  <Slide />
-                </div>
-                <span className="absolute bottom-3 right-4 text-slate-500 text-xs md:text-sm font-mono">
-                  {i + 1} / {SCROLL_SLIDES.length}
-                </span>
-              </div>
-            </section>
-          );
-        })}
+        {SCROLL_SLIDES.map((slide, i) => (
+          <SlideCanvas
+            key={`${i}-${slide.title}`}
+            slide={slide}
+            index={i}
+            total={SCROLL_SLIDES.length}
+            scale={scale}
+          />
+        ))}
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- **New homepage graphic** between Customers and "Agent Optimization Platform" — the three-panel **BEFORE / TRAIGENT / AFTER** story (color-coded knob categories on the left, clockwise Learn → Deduce → Test → Repeat optimizer in the middle, four outcome cards on the right).
- **Promoted to slot 2** of `/pitch-short` and `/pitch-short-2` (right after the One-Pager opener). Same `SlideParetoFrontier` component drives both the homepage section and slide 2 — single source of truth.
- **/pitch-short-2 viewport scaling**: deck now renders as a fixed 1280×720 canvas scaled to fit, fixing the iPhone-landscape clipping issue.
- Customers section margin tightened so the new graphic reads as the natural follow-on to the customer marquee.

## Knob list (Before panel)
14 of "25+" knobs shown, color-coded by category:
- **Model** (blue): Model, Routing
- **LLM** (amber): Prompt, Reasoning, Context, CoT/SC, Caching, Few-shot, Output schema
- **Agent** (violet): Tools, RAG strategy, Re-ranker, Chunking, Guardrails

## Outcomes (After panel)
- Lower LLM cost (amber)
- Higher accuracy (blue)
- Weeks saved (slate)
- 100% Confidence (violet) — "You know it's THE optimum."

## Test plan
- [ ] Homepage: graphic appears between Customers logos and "Agent Optimization Platform" section, with kicker "Literally millions of configuration options to contemplate." at top
- [ ] `/pitch-short` and `/pitch-short-2` slot 2 is the same graphic
- [ ] `/pitch-short-2` on iPhone-landscape: each slide canvas scales to fit, no clipping
- [ ] Knob bars and dots render in their category color (blue/amber/violet)
- [ ] Optimizer ring sweeps clockwise; arrow points up at 9 o'clock
- [ ] 4 outcome cards visible in the After panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)