### PR TITLE
ship: parallel imperative voice on Traigent-benefits bullets

### DIFF
--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -206,20 +206,20 @@ export default function Homepage() {
                 <ul className="space-y-3">
                   {[
                     {
-                      content: <><span className="text-white font-semibold">Reduces engineering costs.</span></>,
+                      content: <><span className="text-white font-semibold">Reduce engineering costs.</span></>,
                       to: "/ttm",
                       linkLabel: "TTM calc",
                     },
                     {
-                      content: <><span className="text-white font-semibold">Saves LLM costs</span> over the lifecycle.</>,
+                      content: <><span className="text-white font-semibold">Save LLM costs</span> over the lifecycle.</>,
                       to: "/roi",
                       linkLabel: "ROI calc",
                     },
                     {
-                      content: <><span className="text-white font-semibold">Shortens time to market.</span></>,
+                      content: <><span className="text-white font-semibold">Shorten time to market.</span></>,
                     },
                     {
-                      content: <><span className="text-white font-semibold">Increases confidence</span> significantly.</>,
+                      content: <>Ship with <span className="text-white font-semibold">100% confidence</span>.</>,
                     },
                   ].map((b, i) => (
                     <li key={i} className="flex items-start gap-2.5 text-slate-300 leading-snug">


### PR DESCRIPTION
## Summary
Right-hand "TRAIGENT BENEFITS" card on the homepage now reads as four parallel imperatives:
- **Reduce** engineering costs.
- **Save** LLM costs over the lifecycle.
- **Shorten** time to market.
- Ship with **100% confidence**.

Replaces the mixed-voice "Reduces / Saves / Shortens / Increases confidence significantly" copy. Last bullet also picks up the **100% Confidence** phrase from the new outcomes card in the slide-2 graphic, so the homepage and the BEFORE/TRAIGENT/AFTER visual now use the same words.

Layout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)