### PR TITLE
feat(nav): right-click presentations menu behind the hidden ▸

### DIFF
--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -16,7 +16,7 @@ const PITCH_DECK_OPTIONS = [
   {
     label: "Extended product presentation",
     desc: "Full pitch deck — product, no investor section",
-    href: "/#/pitch-short-2?exclude=24-25",
+    href: "/#/pitch-short-2?exclude=24-26",
   },
   {
     label: "Short summary",
@@ -25,8 +25,8 @@ const PITCH_DECK_OPTIONS = [
   },
   {
     label: "Market opportunity",
-    desc: "Slides 24–25 — for partners + investors",
-    href: "/#/pitch-short-2?range=24-25",
+    desc: "Slides 24–26 — for partners + investors",
+    href: "/#/pitch-short-2?range=24-26",
   },
 ];
 

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { ChevronDown, Github, Menu, X } from "lucide-react";
 import StartNowModal from "./StartNowModal";
@@ -8,6 +8,27 @@ import { trackEvent } from "../lib/analytics";
 const PORTAL_URL = "https://portal.traigent.ai";
 const DEMO_URL = "https://meetings-eu1.hubspot.com/amir8";
 const GITHUB_URL = "https://github.com/Traigent/Traigent";
+
+// Hidden access point: presentations menu behind the obscure ▸ glyph in the
+// far-right of the nav. Each item opens the scroll-mode deck in a new tab
+// with a different ?range= filter (see PitchShort2.jsx).
+const PITCH_DECK_OPTIONS = [
+  {
+    label: "Extended product presentation",
+    desc: "Full pitch deck — product, no investor section",
+    href: "/#/pitch-short-2?exclude=24-25",
+  },
+  {
+    label: "Short summary",
+    desc: "Slides 1–5 — the headline arc",
+    href: "/#/pitch-short-2?range=1-5",
+  },
+  {
+    label: "Market opportunity",
+    desc: "Slides 24–25 — for partners + investors",
+    href: "/#/pitch-short-2?range=24-25",
+  },
+];
 
 const productItems = [
   { label: "Optimization Engine", scrollId: "optimization", desc: "Picks next best config from run history" },
@@ -147,8 +168,29 @@ export default function TopNav() {
   const [openMenu, setOpenMenu] = useState(null);
   const [showStartNow, setShowStartNow] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [pitchMenuOpen, setPitchMenuOpen] = useState(false);
+  const pitchMenuRef = useRef(null);
   const navigate = useNavigate();
   const location = useLocation();
+
+  // Close the pitch-deck dropdown on outside-click or Escape.
+  useEffect(() => {
+    if (!pitchMenuOpen) return;
+    const onDocClick = (e) => {
+      if (pitchMenuRef.current && !pitchMenuRef.current.contains(e.target)) {
+        setPitchMenuOpen(false);
+      }
+    };
+    const onKey = (e) => {
+      if (e.key === "Escape") setPitchMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [pitchMenuOpen]);
 
   // Click handler for in-page anchor scrolling.
   // If we're on the homepage, scrollIntoView directly.
@@ -285,16 +327,49 @@ export default function TopNav() {
               >
                 Book a demo
               </a>
-              {/* Hidden access to the scroll-mode pitch deck. Intentionally low
-                  contrast and unlabeled — visible only if you scan for it. */}
-              <Link
-                to="/pitch-short-2"
-                aria-label="Pitch deck"
-                title="Pitch deck"
-                className="text-slate-700 hover:text-slate-200 transition-colors text-base leading-none select-none px-1"
-              >
-                ▸
-              </Link>
+              {/* Hidden access to the presentations menu. The ▸ glyph is the
+                  trigger; right-click toggles a small dropdown of decks, each
+                  opening in a new tab. Left-click is intentionally a no-op
+                  so the surface stays obscure. */}
+              <div className="relative" ref={pitchMenuRef}>
+                <button
+                  type="button"
+                  onClick={(e) => e.preventDefault()}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    setPitchMenuOpen((v) => !v);
+                  }}
+                  aria-label="Presentations menu"
+                  aria-haspopup="menu"
+                  aria-expanded={pitchMenuOpen}
+                  title="Presentations"
+                  className="text-slate-700 hover:text-slate-200 transition-colors text-base leading-none select-none px-1"
+                >
+                  ▸
+                </button>
+                {pitchMenuOpen && (
+                  <div
+                    role="menu"
+                    aria-label="Presentations"
+                    className="absolute top-full right-0 mt-2 w-72 bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-2 z-[60]"
+                  >
+                    {PITCH_DECK_OPTIONS.map((item) => (
+                      <a
+                        key={item.href}
+                        href={item.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        role="menuitem"
+                        onClick={() => setPitchMenuOpen(false)}
+                        className="block px-3 py-2 rounded-lg hover:bg-slate-800 transition-colors"
+                      >
+                        <div className="text-sm text-white font-medium">{item.label}</div>
+                        <div className="text-xs text-slate-400 mt-0.5">{item.desc}</div>
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
 
             {/* Mobile: hamburger only. Drawer below carries all the nav. */}

--- a/src/pages/PitchShort2.jsx
+++ b/src/pages/PitchShort2.jsx
@@ -1,8 +1,13 @@
 // /pitch-short-2 - same slides as /pitch-short, but rendered as a vertical
 // scrollable page. Each slide is a fixed 1280x720 canvas scaled down to fit
 // the viewport, which keeps it readable on iPhone landscape without clipping.
-import { useEffect, useState } from "react";
+//
+// Subset filtering: `?range=N-M` (1-based, inclusive) renders only that slice.
+// Used by the hidden presentations menu in the top nav to share narrowly-
+// targeted versions of the deck (short summary, market opportunity, etc.).
+import { useEffect, useMemo, useState } from "react";
 import { Helmet } from "react-helmet-async";
+import { useSearchParams } from "react-router-dom";
 import { SHORT_SLIDES } from "./PitchShort";
 import { OnePager2Slide } from "./OnePager2";
 import BrandMark from "../components/BrandMark";
@@ -121,9 +126,52 @@ function SlideCanvas({ slide, index, total, scale }) {
   );
 }
 
+// Parse a "N-M" string into a [startIdx, endIdx) zero-based half-open
+// interval. Returns null when malformed or out of bounds against `total`.
+function parseRange(s, total) {
+  if (!s) return null;
+  const m = /^\s*(\d+)\s*-\s*(\d+)\s*$/.exec(s);
+  if (!m) return null;
+  const start = parseInt(m[1], 10) - 1;
+  const end = parseInt(m[2], 10);
+  if (
+    Number.isNaN(start) ||
+    Number.isNaN(end) ||
+    start < 0 ||
+    end <= start ||
+    start >= total
+  ) {
+    return null;
+  }
+  return [start, Math.min(end, total)];
+}
+
+// Filter SCROLL_SLIDES per query params:
+//   ?range=N-M    → keep only slides N..M (1-based, inclusive both ends)
+//   ?exclude=N-M  → keep everything EXCEPT slides N..M
+// When both are set, `range` wins. Malformed values fall back to the full deck.
+function resolveSlides(rangeParam, excludeParam, allSlides) {
+  const total = allSlides.length;
+  const range = parseRange(rangeParam, total);
+  if (range) return allSlides.slice(range[0], range[1]);
+  const exclude = parseRange(excludeParam, total);
+  if (exclude) return allSlides.filter((_, i) => i < exclude[0] || i >= exclude[1]);
+  return allSlides;
+}
+
 export default function PitchShort2() {
   const scale = useViewportScale();
   useRemoveChatWidget();
+  const [searchParams] = useSearchParams();
+  const slidesToRender = useMemo(
+    () =>
+      resolveSlides(
+        searchParams.get("range"),
+        searchParams.get("exclude"),
+        SCROLL_SLIDES,
+      ),
+    [searchParams],
+  );
 
   return (
     <>
@@ -148,12 +196,12 @@ export default function PitchShort2() {
         }
       `}</style>
       <div className="bg-[#080808] text-white">
-        {SCROLL_SLIDES.map((slide, i) => (
+        {slidesToRender.map((slide, i) => (
           <SlideCanvas
             key={`${i}-${slide.title}`}
             slide={slide}
             index={i}
-            total={SCROLL_SLIDES.length}
+            total={slidesToRender.length}
             scale={scale}
           />
         ))}


### PR DESCRIPTION
## Summary
- Right-clicking the hidden ▸ in the top-right desktop nav opens a 3-item dropdown of presentations. Left-click is a no-op so the surface stays obscure.
- Three menu items, each opening in a new tab:
  - **Extended product presentation** → `/pitch-short-2?exclude=24-26` (full deck minus investor section)
  - **Short summary** → `/pitch-short-2?range=1-5` (slides 1–5)
  - **Market opportunity** → `/pitch-short-2?range=24-26` (slides 24–26, for partners + investors)
- `PitchShort2` grows two new query-string filters:
  - `?range=N-M` — keep only slides N..M (1-based, inclusive)
  - `?exclude=N-M` — keep everything EXCEPT slides N..M
- Bare `/pitch-short-2` still renders the full deck (backward compatible).
- Slides scale with `useViewportScale`, so subsets render correctly on PC and iPhone landscape.

## Test plan
- Build passes (npx vite build)
- Verified locally — three menu items render correct slide subsets
- Top-right ▸ visible-but-obscure (text-slate-700)
- Left-click does nothing; right-click opens dropdown
- Escape / outside-click closes the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)