### PR TITLE
feat(decks): Optimization in Action live-demo slide + readable preset URLs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ export default function App() {
       <Route path="pitch-full" element={<PitchFull />} />
       <Route path="pitch-short" element={<PitchShort />} />
       <Route path="pitch-short-2" element={<PitchShort2 />} />
+      <Route path="pitch-short-2/:preset" element={<PitchShort2 />} />
       <Route path="one-pager" element={<OnePager />} />
       <Route path="one-pager-2" element={<OnePager2 />} />
 

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -15,18 +15,18 @@ const GITHUB_URL = "https://github.com/Traigent/Traigent";
 const PITCH_DECK_OPTIONS = [
   {
     label: "Extended product presentation",
-    desc: "Full pitch deck — product, no investor section",
-    href: "/#/pitch-short-2?exclude=24-26",
+    desc: "Full product deck + live demo (no investor section)",
+    href: "/#/pitch-short-2/extended-product-presentation",
   },
   {
     label: "Short summary",
-    desc: "Slides 1–5 — the headline arc",
-    href: "/#/pitch-short-2?range=1-5",
+    desc: "Slides 1–5 + live demo — the headline arc",
+    href: "/#/pitch-short-2/short-summary",
   },
   {
     label: "Market opportunity",
-    desc: "Slides 24–26 — for partners + investors",
-    href: "/#/pitch-short-2?range=24-26",
+    desc: "Investor section + live demo",
+    href: "/#/pitch-short-2/market-opportunity",
   },
 ];
 

--- a/src/pages/PitchShort.jsx
+++ b/src/pages/PitchShort.jsx
@@ -4,7 +4,7 @@
 // rendered through PitchFull's originals with override props for the
 // subtitle / footer; everything else is imported directly. No structural
 // JSX is duplicated from PitchFull.
-import { ArrowRight, ArrowDown, ArrowUp, ChevronsDown, DollarSign, Check, Clock, ShieldCheck, TrendingDown, TrendingUp } from "lucide-react";
+import { ArrowRight, ArrowDown, ArrowUp, ChevronsDown, DollarSign, Check, Clock, ShieldCheck, TrendingDown, TrendingUp, X } from "lucide-react";
 
 // Shared optimizer ring — clockwise Learn → Deduce → Test → Repeat loop.
 // Used by slide 1, slide 2 (BEFORE/TRAIGENT/AFTER middle panel), and slide 24
@@ -44,6 +44,7 @@ import {
   ObservabilityCardBody,
 } from "../components/PlatformShowcase";
 import { ConvergenceDiagram, KillerStatsGrid } from "./pitch/shared";
+import SlideOptimizationInActionDemo from "./pitch/SlideOptimizationInActionDemo";
 import {
   PitchDeck,
   SlideOnePagerSummary,
@@ -373,6 +374,93 @@ export function SlideParetoFrontier() {
   );
 }
 
+
+// Slide: Sweep the eval + observability pack. Follow-up to slide 24.
+// Langfuse, Arize, LangSmith, Braintrust, Galileo, Helicone all rode the
+// previous wave (eval + observability) and raised hundreds of millions —
+// but none of them solve OPTIMIZATION, which slide 24's market wave is
+// making urgent. Traigent has all three pillars. We sweep the pack.
+function SlideSweepThePack() {
+  const competitors = [
+    { name: "Langfuse",   note: "Open-source, AWS partner" },
+    { name: "Arize AI",   note: "$131M raised" },
+    { name: "LangSmith",  note: "LangChain product" },
+    { name: "Braintrust", note: "$80M raised · $800M val" },
+    { name: "Galileo",    note: "Enterprise direct" },
+    { name: "Helicone",   note: "Acquired by Mintlify · maintenance mode" },
+  ];
+  const CheckCell = () => (
+    <td className="py-2.5 text-center">
+      <Check className="w-6 h-6 inline" strokeWidth={3} style={{ color: "#4ade80" }} />
+    </td>
+  );
+  const XCell = () => (
+    <td className="py-2.5 text-center">
+      <X className="w-6 h-6 inline" strokeWidth={3} style={{ color: "#f87171" }} />
+    </td>
+  );
+  return (
+    <div className="w-full max-w-[1180px] mx-auto text-center self-stretch flex flex-col min-h-[600px]">
+      {/* Title — tightened to fit within slide canvas */}
+      <div className="mb-2">
+        <h1 className="text-3xl md:text-4xl font-extrabold text-white leading-tight tracking-tight mb-1.5">
+          Why partner with <span style={{ color: "#4D8EF8" }}>Traigent.ai</span>?
+        </h1>
+        <h2 className="text-xl md:text-2xl font-bold text-white leading-tight tracking-tight mb-1">
+          Sweep the <span style={{ color: "#4D8EF8" }}>Eval + Observability</span> Pack
+        </h2>
+        <p className="text-sm md:text-base text-slate-300 leading-snug">
+          Langfuse and similar <span className="font-bold text-white">burst with success</span> on eval + observability &mdash; $1B+ valuations.
+          <br />
+          They raised hundreds of millions but never built the most important pillar: <span className="font-bold text-[#f59e0b]">optimization</span>.
+        </p>
+      </div>
+
+      {/* Capability matrix */}
+      <div className="bg-slate-900/70 border border-slate-700/60 rounded-xl p-3 flex-1 flex flex-col">
+        <table className="w-full text-left text-[14px] flex-1">
+          <thead>
+            <tr className="text-[11px] font-mono uppercase tracking-widest text-slate-400 border-b border-slate-700">
+              <th className="py-1.5">Vendor</th>
+              <th className="py-1.5 text-center">Observability</th>
+              <th className="py-1.5 text-center">Evaluation</th>
+              <th className="py-1.5 text-center" style={{ color: "#f59e0b" }}>Optimization</th>
+              <th className="py-1.5 text-right text-slate-500">Context</th>
+            </tr>
+          </thead>
+          <tbody>
+            {competitors.map((c) => (
+              <tr key={c.name} className="border-b border-slate-800/70">
+                <td className="py-1.5 font-semibold text-white">{c.name}</td>
+                <CheckCell />
+                <CheckCell />
+                <XCell />
+                <td className="py-1.5 text-right text-slate-400 text-[12px]">{c.note}</td>
+              </tr>
+            ))}
+            {/* Traigent — highlighted row */}
+            <tr className="bg-blue-500/10">
+              <td className="py-2 font-bold text-[16px]" style={{ color: "#4D8EF8" }}>Traigent.ai</td>
+              <CheckCell />
+              <CheckCell />
+              <td className="py-2 text-center">
+                <Check className="w-7 h-7 inline" strokeWidth={3.5} style={{ color: "#4ade80" }} />
+              </td>
+              <td className="py-2 text-right font-bold text-white text-[12px]">3 platforms in 1</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* Punchline */}
+      <div className="mt-2 bg-slate-950 border-2 rounded-xl p-2.5 text-center" style={{ borderColor: "#4D8EF8" }}>
+        <p className="text-base md:text-lg text-slate-200 leading-snug">
+          <span className="font-bold" style={{ color: "#4D8EF8" }}>Traigent</span> has everything they have <span className="font-bold text-[#f59e0b]">PLUS the optimization layer the market is now demanding</span>. The pack gets swept.
+        </p>
+      </div>
+    </div>
+  );
+}
 
 // Slide: Market & Revenue — headline numbers from the May 2026 partner brief.
 // Top section: 3 stat tiles (TAM today, addressable LLM bill 2026, 2030).
@@ -749,8 +837,12 @@ export const SHORT_SLIDES = [
   { title: "How we converge rapidly", section: "Appendix", component: SlideHowWeConverge },
   // ----- MARKET OPPORTUNITY (for channel partners + investors) -----
   { title: "Market Opportunity — Wave / Pain / Play", section: "Appendix", component: SlideMarketOpportunity },
+  // ----- SWEEP THE EVAL + OBSERVABILITY PACK (follow-up to slide 24) -----
+  { title: "Sweep the Eval + Observability Pack", section: "Appendix", component: SlideSweepThePack },
   // ----- MARKET & REVENUE (the numbers from the partner brief) -----
   { title: "Market & Revenue — Non-Vendor Agents", section: "Appendix", component: SlideMarketAndRevenue },
+  // ----- LIVE DEMO — appears as last slide of every filtered deck via URL ranges -----
+  { title: "Optimization in Action (Video Demo)", section: "Demo", component: SlideOptimizationInActionDemo },
 ];
 
 export default function PitchShort() {

--- a/src/pages/PitchShort2.jsx
+++ b/src/pages/PitchShort2.jsx
@@ -7,10 +7,20 @@
 // targeted versions of the deck (short summary, market opportunity, etc.).
 import { useEffect, useMemo, useState } from "react";
 import { Helmet } from "react-helmet-async";
-import { useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import { SHORT_SLIDES } from "./PitchShort";
 import { OnePager2Slide } from "./OnePager2";
 import BrandMark from "../components/BrandMark";
+
+// Named presets — URLs like /pitch-short-2/extended-product-presentation map
+// onto specific range/exclude filters here, so each deck has a readable URL
+// matching its menu label. Update both this map and src/components/TopNav.jsx
+// PITCH_DECK_OPTIONS when adding a new preset.
+const PRESETS = {
+  "extended-product-presentation": { exclude: "24-26" },
+  "short-summary":                 { range:   "1-5,27" },
+  "market-opportunity":            { range:   "24-27" },
+};
 
 const SLIDE_W = 1280;
 const SLIDE_H = 720;
@@ -126,52 +136,76 @@ function SlideCanvas({ slide, index, total, scale }) {
   );
 }
 
-// Parse a "N-M" string into a [startIdx, endIdx) zero-based half-open
-// interval. Returns null when malformed or out of bounds against `total`.
-function parseRange(s, total) {
+// Parse a comma-separated list like "1-5,7,9-12" into an array of
+// [startIdx, endIdx) zero-based half-open intervals. Single numbers like
+// "27" become [26, 27). Malformed parts are skipped; returns null if nothing
+// parses.
+function parseRangeList(s, total) {
   if (!s) return null;
-  const m = /^\s*(\d+)\s*-\s*(\d+)\s*$/.exec(s);
-  if (!m) return null;
-  const start = parseInt(m[1], 10) - 1;
-  const end = parseInt(m[2], 10);
-  if (
-    Number.isNaN(start) ||
-    Number.isNaN(end) ||
-    start < 0 ||
-    end <= start ||
-    start >= total
-  ) {
-    return null;
+  const out = [];
+  for (const part of s.split(",").map((p) => p.trim()).filter(Boolean)) {
+    const range = /^\s*(\d+)\s*-\s*(\d+)\s*$/.exec(part);
+    const single = /^\s*(\d+)\s*$/.exec(part);
+    let start;
+    let end;
+    if (range) {
+      start = parseInt(range[1], 10) - 1;
+      end = parseInt(range[2], 10);
+    } else if (single) {
+      start = parseInt(single[1], 10) - 1;
+      end = start + 1;
+    } else {
+      continue;
+    }
+    if (Number.isNaN(start) || Number.isNaN(end)) continue;
+    if (start < 0 || end <= start || start >= total) continue;
+    out.push([start, Math.min(end, total)]);
   }
-  return [start, Math.min(end, total)];
+  return out.length ? out : null;
 }
 
-// Filter SCROLL_SLIDES per query params:
-//   ?range=N-M    → keep only slides N..M (1-based, inclusive both ends)
-//   ?exclude=N-M  → keep everything EXCEPT slides N..M
-// When both are set, `range` wins. Malformed values fall back to the full deck.
+// Filter SCROLL_SLIDES per query params (1-based, inclusive both ends):
+//   ?range=1-5,28   → keep only slides 1..5 and slide 28 (in that order)
+//   ?exclude=25-27  → keep everything EXCEPT slides 25..27
+// `range` wins when both are set. Malformed values fall back to the full deck.
 function resolveSlides(rangeParam, excludeParam, allSlides) {
   const total = allSlides.length;
-  const range = parseRange(rangeParam, total);
-  if (range) return allSlides.slice(range[0], range[1]);
-  const exclude = parseRange(excludeParam, total);
-  if (exclude) return allSlides.filter((_, i) => i < exclude[0] || i >= exclude[1]);
+  const ranges = parseRangeList(rangeParam, total);
+  if (ranges) {
+    const out = [];
+    for (const [s, e] of ranges) {
+      for (let i = s; i < e; i++) out.push(allSlides[i]);
+    }
+    return out;
+  }
+  const excludes = parseRangeList(excludeParam, total);
+  if (excludes) {
+    return allSlides.filter(
+      (_, i) => !excludes.some(([s, e]) => i >= s && i < e),
+    );
+  }
   return allSlides;
 }
 
 export default function PitchShort2() {
   const scale = useViewportScale();
   useRemoveChatWidget();
+  const { preset } = useParams();
   const [searchParams] = useSearchParams();
-  const slidesToRender = useMemo(
-    () =>
-      resolveSlides(
-        searchParams.get("range"),
-        searchParams.get("exclude"),
-        SCROLL_SLIDES,
-      ),
-    [searchParams],
-  );
+  const slidesToRender = useMemo(() => {
+    // Named preset on the URL path (e.g. /pitch-short-2/short-summary) wins
+    // over raw ?range= / ?exclude= query params. Unknown preset names fall
+    // through to whatever the query params (or full deck) say.
+    if (preset && PRESETS[preset]) {
+      const { range, exclude } = PRESETS[preset];
+      return resolveSlides(range, exclude, SCROLL_SLIDES);
+    }
+    return resolveSlides(
+      searchParams.get("range"),
+      searchParams.get("exclude"),
+      SCROLL_SLIDES,
+    );
+  }, [preset, searchParams]);
 
   return (
     <>

--- a/src/pages/pitch/SlideOptimizationInActionDemo.jsx
+++ b/src/pages/pitch/SlideOptimizationInActionDemo.jsx
@@ -1,0 +1,27 @@
+// Slide: Optimization in Action — live demo.
+// Embeds the same OptimizationTable used on /optimization-in-action (autoplay
+// mode), wrapped in a slide-sized title + description shell so it fits the
+// PitchShort canvas (1280×720 with px-10 pt-16 pb-12 wrapper). Shown right
+// after "Two Components, One Loop" so the audience sees the concept and then
+// watches it actually happen.
+import OptimizationTable from "../../components/OptimizationTable";
+
+export default function SlideOptimizationInActionDemo() {
+  return (
+    <div className="w-full h-full flex flex-col items-center justify-start">
+      <div className="text-center mb-5">
+        <h2 className="text-4xl font-bold text-white mb-2">
+          Optimization in Action <span className="text-slate-400 font-medium">(Video Demo)</span>
+        </h2>
+        <p className="text-base text-slate-400 max-w-3xl mx-auto leading-snug">
+          Watch Traigent sweep hundreds of model and configuration combinations
+          and converge on the optimum — accuracy, cost, latency, or any KPI you
+          pick.
+        </p>
+      </div>
+      <div className="flex-1 w-full max-w-[1080px] rounded-xl overflow-hidden border border-slate-700/50 shadow-xl">
+        <OptimizationTable autoPlay={true} embedded={true} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds **Optimization in Action (Video Demo)** slide — embeds the autoplaying \`OptimizationTable\` used on \`/optimization-in-action\`.
- Demo slide is the last slide of every filtered deck.
- **Readable preset URLs** replace opaque query strings:
  - \`/#/pitch-short-2/extended-product-presentation\` → 24 slides (full product + demo, no investor section)
  - \`/#/pitch-short-2/short-summary\` → 6 slides (1–5 + demo)
  - \`/#/pitch-short-2/market-opportunity\` → 4 slides (24–26 + demo)
- Query-string \`?range=\` / \`?exclude=\` continue to work as fallback.
- Also brings in the previously-pending \`SlideSweepThePack\` slide (between Market Opportunity and Market & Revenue) so production matches local. Production HEAD had 25 slides; this lands at 27.

## Test plan
- Build passes (\`npx vite build\`)
- Right-click ▸ menu shows the three items with new URLs
- Each preset URL renders the correct slide count + final slide = demo
- Bare \`/pitch-short-2\` still renders the full deck
- iPhone landscape renders subsets without clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)