### PR TITLE
feat(calculators): bidirectional link between Knob Explorer + TTM + ROI

### DIFF
--- a/src/lib/useCustomSearchSpace.js
+++ b/src/lib/useCustomSearchSpace.js
@@ -1,0 +1,26 @@
+// useCustomSearchSpace — when set, the TTM and ROI calculators use this
+// configuration instead of their built-in sliders. Written by the Knob
+// Explorer's "Apply to TTM/ROI" buttons; read by both calculators.
+//
+// Shape: { configs: number, source: "knob-explorer", appliedAt: ISO-string } | null
+//
+// Sits on top of useSharedSetting so the value persists across reloads and
+// syncs between tabs (storage event).
+import { useSharedSetting } from "./useSharedSetting";
+
+const KEY = "traigent_custom_search_space";
+
+export function useCustomSearchSpace() {
+  const [value, setValue] = useSharedSetting(KEY, null);
+  function apply(configs) {
+    setValue({
+      configs,
+      source: "knob-explorer",
+      appliedAt: new Date().toISOString(),
+    });
+  }
+  function reset() {
+    setValue(null);
+  }
+  return [value, apply, reset];
+}

--- a/src/pages/KnobExplorer.jsx
+++ b/src/pages/KnobExplorer.jsx
@@ -6,10 +6,12 @@
 //
 // Reachable via the hidden ▸ menu in TopNav.
 import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { motion } from "framer-motion";
-import { ArrowLeft, ChevronDown, ChevronUp, Sparkles } from "lucide-react";
+import { ArrowLeft, ArrowRight, ChevronDown, ChevronUp, Clock, DollarSign, Sparkles } from "lucide-react";
+import { useSharedSetting } from "../lib/useSharedSetting";
+import { useCustomSearchSpace } from "../lib/useCustomSearchSpace";
 
 // =============================================================================
 // Knob catalog — generic across agent types (not text-to-SQL specific).
@@ -544,12 +546,25 @@ function sortKnobsByImpact(knobs, metric) {
 }
 
 export default function KnobExplorer() {
-  const [selectedModels, setSelectedModels] = useState([]);
+  // Persist selections + sort preference across reloads / tabs so the user
+  // can leave the page and come back to the same configuration.
+  const [selectedModels, setSelectedModels] = useSharedSetting(
+    "traigent_knob_explorer_models",
+    [],
+  );
   // knobValues maps knob-id (or `${modelId}.${knobId}` for specific) → array of selected values.
   // Presence in the map (with at least one value) = "enabled".
-  const [knobValues, setKnobValues] = useState({});
+  const [knobValues, setKnobValues] = useSharedSetting(
+    "traigent_knob_explorer_knob_values",
+    {},
+  );
   // Which impact metric to rank knobs by. Doesn't affect the Models section.
-  const [sortBy, setSortBy] = useState("a");
+  const [sortBy, setSortBy] = useSharedSetting("traigent_knob_explorer_sort_by", "a");
+  // Bidirectional link with the TTM + ROI calculators.
+  const [, applySearchSpace] = useCustomSearchSpace();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const cameFrom = searchParams.get("from"); // "ttm" | "roi" | null
   // Set of vendor names currently expanded in the Models section. Lifted here
   // so the grid wrapper can apply col-span-full to expanded cells.
   const [expandedVendors, setExpandedVendors] = useState(new Set());
@@ -637,6 +652,31 @@ export default function KnobExplorer() {
               Back to traigent.ai
             </Link>
 
+            {/* Return banner — when arriving from /ttm or /roi via "Configure
+                custom search space", offer one-click return that also writes
+                the current combinatorics to the shared setting so the calc
+                picks it up. */}
+            {cameFrom && (
+              <button
+                type="button"
+                onClick={() => {
+                  applySearchSpace(total);
+                  navigate(`/${cameFrom}`);
+                }}
+                className="w-full mb-5 flex items-center justify-between gap-3 px-4 py-3 rounded-xl bg-blue-500/10 border border-blue-500/40 text-blue-200 hover:bg-blue-500/20 transition-colors text-left"
+              >
+                <span className="flex items-center gap-2">
+                  <ArrowLeft className="w-4 h-4" />
+                  Return to{" "}
+                  <span className="font-semibold uppercase">{cameFrom}</span>{" "}
+                  calculator with this search space
+                </span>
+                <span className="font-mono text-xs text-blue-300">
+                  {total.toLocaleString()} configs →
+                </span>
+              </button>
+            )}
+
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-500/10 border border-blue-500/30 text-xs font-mono tracking-wider mb-3 text-[#4D8EF8]">
               <Sparkles className="w-3.5 h-3.5" />
               KNOB EXPLORER
@@ -705,6 +745,42 @@ export default function KnobExplorer() {
                       {enabledSpecificCount} model-specific
                     </span>
                   </div>
+                </div>
+
+                {/* Apply buttons — write the current combinatorics to the shared
+                    setting (TTM + ROI both pick it up automatically) and jump
+                    to the chosen calculator. */}
+                <div className="mt-4 pt-3 border-t border-slate-700/60 flex items-center gap-2 flex-wrap">
+                  <span className="text-[10px] font-mono uppercase tracking-widest text-slate-500 mr-1">
+                    Apply to →
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      applySearchSpace(total);
+                      navigate("/ttm");
+                    }}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-500/15 text-blue-200 border border-blue-500/40 hover:bg-blue-500/25 transition-colors text-xs font-medium"
+                  >
+                    <Clock className="w-3.5 h-3.5" />
+                    TTM calculator
+                    <ArrowRight className="w-3.5 h-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      applySearchSpace(total);
+                      navigate("/roi");
+                    }}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-500/15 text-blue-200 border border-blue-500/40 hover:bg-blue-500/25 transition-colors text-xs font-medium"
+                  >
+                    <DollarSign className="w-3.5 h-3.5" />
+                    ROI calculator
+                    <ArrowRight className="w-3.5 h-3.5" />
+                  </button>
+                  <span className="text-[10px] text-slate-500">
+                    (updates both; opens only the one clicked)
+                  </span>
                 </div>
               </div>
             </div>

--- a/src/pages/ROICalculator.jsx
+++ b/src/pages/ROICalculator.jsx
@@ -1,10 +1,11 @@
 ﻿import { useState, useMemo } from "react";
 import { motion } from "framer-motion";
-import { ArrowRight, TrendingDown, Clock, DollarSign, Github } from "lucide-react";
+import { ArrowRight, TrendingDown, Clock, DollarSign, Github, Sparkles, RotateCcw } from "lucide-react";
 import { Helmet } from "react-helmet-async";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { trackEvent } from "../lib/analytics";
 import { useSharedSetting } from "../lib/useSharedSetting";
+import { useCustomSearchSpace } from "../lib/useCustomSearchSpace";
 import StartNowModal from "../components/StartNowModal";
 import CalculatorTopBar from "../components/CalculatorTopBar";
 
@@ -91,6 +92,11 @@ export default function ROICalculator() {
   // dial in their own % rather than commit to one of the three published ranges.
   const [savingsScenario, setSavingsScenario] = useState("conservative");
   const [customSavingsPct, setCustomSavingsPct] = useState(15);
+  // Custom search space from the Knob Explorer. The engineering-savings math
+  // (lines below) already picks up TTM's republished `manual_hours_per_pass`
+  // automatically — this state is read only to render an orientation banner.
+  const [customSpace, , resetCustomSpace] = useCustomSearchSpace();
+  const navigate = useNavigate();
 
   function resetToDefaults() {
     setMonthlySpend(DEFAULT_MONTHLY_SPEND);
@@ -186,6 +192,53 @@ export default function ROICalculator() {
               Plug in your numbers. Pick a tier. Calculate your 12-month savings.
             </p>
           </motion.div>
+
+          {/* Custom search-space orientation banner — appears when the user
+              applied a search space from the Knob Explorer. The engineering
+              math below picks up TTM's republished per-pass hours automatically;
+              this banner just keeps the user oriented. */}
+          {customSpace && (
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.4 }}
+              className="mb-10 bg-blue-500/10 border border-blue-500/40 rounded-2xl px-5 py-4 flex items-center justify-between gap-4 flex-wrap"
+            >
+              <div className="flex items-center gap-3">
+                <Sparkles className="w-5 h-5 text-blue-300 flex-shrink-0" />
+                <div>
+                  <div className="text-xs font-mono uppercase tracking-widest text-blue-300 font-semibold mb-0.5">
+                    Custom search space active
+                  </div>
+                  <div className="text-sm text-slate-300">
+                    Engineering-savings math derives from{" "}
+                    <span className="font-mono font-semibold text-white">
+                      {customSpace.configs.toLocaleString()}
+                    </span>{" "}
+                    configurations · via TTM Calculator
+                  </div>
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => navigate("/knob-explorer?from=roi")}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-500/20 text-blue-200 border border-blue-500/40 hover:bg-blue-500/30 transition-colors text-xs font-medium"
+                >
+                  Edit
+                  <ArrowRight className="w-3.5 h-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => resetCustomSpace()}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-800/60 text-slate-300 border border-slate-700 hover:bg-slate-800 transition-colors text-xs"
+                >
+                  <RotateCcw className="w-3.5 h-3.5" />
+                  Reset
+                </button>
+              </div>
+            </motion.div>
+          )}
 
           {/* Inputs */}
           <motion.div

--- a/src/pages/TTMCalculator.jsx
+++ b/src/pages/TTMCalculator.jsx
@@ -1,10 +1,11 @@
 import { useState, useMemo, useEffect } from "react";
 import { motion } from "framer-motion";
-import { ArrowRight, Clock, Zap, Layers, FileText, SlidersHorizontal } from "lucide-react";
+import { ArrowRight, Clock, Zap, Layers, FileText, SlidersHorizontal, Sparkles, RotateCcw } from "lucide-react";
 import { Helmet } from "react-helmet-async";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { trackEvent } from "../lib/analytics";
 import { useSharedSetting } from "../lib/useSharedSetting";
+import { useCustomSearchSpace } from "../lib/useCustomSearchSpace";
 import CalculatorTopBar from "../components/CalculatorTopBar";
 
 const BLUE = "#1A6BF5";
@@ -184,6 +185,10 @@ export default function TTMCalculator() {
   // fraction. This slider lets the user reflect that reality and surfaces the
   // confidence they're sacrificing in return.
   const [manualCoveragePct, setManualCoveragePct] = useState(20);
+  // Custom search space from the Knob Explorer. When set, overrides the
+  // 6-slider product below and the slider UI hides behind a summary card.
+  const [customSpace, , resetCustomSpace] = useCustomSearchSpace();
+  const navigate = useNavigate();
 
   function resetToDefaults() {
     setModels(6);
@@ -199,7 +204,12 @@ export default function TTMCalculator() {
   }
 
   const r = useMemo(() => {
-    const totalConfigs = models * prompts * maxTokensVariants * fewShots * selfConsistency * otherDims;
+    // Knob Explorer's "Apply to TTM" writes a configs number to the shared
+    // setting. When present, it overrides the 6-slider product. All downstream
+    // numbers (engineer hours, weeks, dollars) flow from totalConfigs and pick
+    // up the override automatically.
+    const sliderConfigs = models * prompts * maxTokensVariants * fewShots * selfConsistency * otherDims;
+    const totalConfigs = customSpace?.configs ?? sliderConfigs;
     const manualConfigsTested = Math.max(1, Math.round(totalConfigs * manualCoveragePct / 100));
     const manualEngineerHours = (manualConfigsTested * minPerConfig) / 60;
     const manualFteWeeks = manualEngineerHours / FTE_HOURS_PER_WEEK;
@@ -240,7 +250,7 @@ export default function TTMCalculator() {
       dollarsSaved,
       fullSweepDollarsSaved,
     };
-  }, [models, prompts, maxTokensVariants, fewShots, selfConsistency, otherDims, minPerConfig, manualCoveragePct, hourlyRate]);
+  }, [models, prompts, maxTokensVariants, fewShots, selfConsistency, otherDims, minPerConfig, manualCoveragePct, hourlyRate, customSpace]);
 
   // Republish the per-pass manual hours whenever it changes — ROI Calculator
   // listens on this key for its engineering-hours derivation.
@@ -419,9 +429,64 @@ export default function TTMCalculator() {
               Search-space dimensions
             </span>
             <div className="flex-1 h-px bg-slate-800" />
+            {!customSpace && (
+              <Link
+                to="/knob-explorer?from=ttm"
+                className="text-xs text-slate-400 hover:text-white inline-flex items-center gap-1 transition-colors whitespace-nowrap"
+              >
+                <Sparkles className="w-3.5 h-3.5" />
+                Configure custom search space →
+              </Link>
+            )}
           </motion.div>
 
-          {/* Inputs — search-space sliders */}
+          {/* Custom search-space card — shown instead of the 6 sliders when
+              the Knob Explorer has applied a configuration. */}
+          {customSpace && (
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.4 }}
+              className="mb-10 bg-blue-500/10 border border-blue-500/40 rounded-2xl p-5 md:p-6"
+            >
+              <div className="flex items-start justify-between gap-4 flex-wrap">
+                <div>
+                  <div className="flex items-center gap-2 mb-2">
+                    <Sparkles className="w-4 h-4 text-blue-300" />
+                    <span className="text-xs font-mono uppercase tracking-widest text-blue-300 font-bold">
+                      Custom search space · from Knob Explorer
+                    </span>
+                  </div>
+                  <div className="text-4xl md:text-5xl font-extrabold text-white tracking-tight font-mono tabular-nums">
+                    {customSpace.configs.toLocaleString()}
+                  </div>
+                  <div className="text-sm text-slate-400 mt-1">configurations</div>
+                </div>
+                <div className="flex flex-col gap-2">
+                  <button
+                    type="button"
+                    onClick={() => navigate("/knob-explorer?from=ttm")}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-500/20 text-blue-200 border border-blue-500/40 hover:bg-blue-500/30 transition-colors text-sm font-medium"
+                  >
+                    Edit in Knob Explorer
+                    <ArrowRight className="w-4 h-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => resetCustomSpace()}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-800/60 text-slate-300 border border-slate-700 hover:bg-slate-800 transition-colors text-xs"
+                  >
+                    <RotateCcw className="w-3.5 h-3.5" />
+                    Reset to slider mode
+                  </button>
+                </div>
+              </div>
+            </motion.div>
+          )}
+
+          {/* Inputs — search-space sliders. Hidden when a custom space from
+              the Knob Explorer is active. */}
+          {!customSpace && (
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -515,6 +580,7 @@ export default function TTMCalculator() {
               }
             />
           </motion.div>
+          )}
 
           {/* Section header: Your engineering parameters */}
           <motion.div


### PR DESCRIPTION
## Summary
Wires the new Knob Explorer into the existing TTM + ROI calculators as a single workflow. Combinatorics is the shared currency: write it once from Knob Explorer, both calcs pick it up.

### Knob Explorer
- Selections + sort preference now persist across reloads via \`useSharedSetting\`.
- Two new buttons in the sticky counter: **Apply to TTM** / **Apply to ROI**. Both write the current configs to a shared setting (\`traigent_custom_search_space\`); the button you click determines the destination.
- When the URL has \`?from=ttm\` or \`?from=roi\`, a return banner appears at the top: *"Return to TTM/ROI with this search space."*

### TTM Calculator
- New override: \`totalConfigs = customSpace?.configs ?? <existing slider product>\`. Single-line addition; all downstream math (engineer hours, weeks, dollars saved) flows from there.
- When custom is set, the 6-slider grid is replaced by a single card with the configs number + **Edit in Knob Explorer →** + **Reset to slider mode** buttons.
- A small **Configure custom search space →** link in the slider header for users who land on TTM first.

### ROI Calculator
- Zero math changes. Engineering-savings already inherits from TTM via the existing \`traigent_manual_hours_per_pass\` republishing chain.
- Orientation banner near the top when custom space is active, mirroring TTM's Edit / Reset actions.

## Why this is small + safe
- Reuses existing \`useSharedSetting\` (localStorage + storage-event cross-tab sync). No new state infra.
- Backward compatible: bare \`/ttm\` and \`/roi\` behave exactly as before when no custom space is set.
- One new file (\`useCustomSearchSpace.js\`, ~20 lines) wraps the new key for ergonomics.

## Test plan
- Build passes (\`npx vite build\`)
- Knob Explorer: pick models + knobs → counter shows N → click "Apply to TTM" → /ttm shows N as custom space with Edit/Reset
- TTM "Edit in Knob Explorer" → /knob-explorer?from=ttm → return banner appears → click banner → back on /ttm
- TTM "Reset to slider mode" → 6 sliders return, counter recomputes
- Same flow with ROI calc
- Refresh /knob-explorer → previous selections still there

🤖 Generated with [Claude Code](https://claude.com/claude-code)