### PR TITLE
Real, data-driven optimization demo (BIRD/Spider/HotpotQA) — replaces fake table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1144,9 +1144,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1161,9 +1158,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1178,9 +1172,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1195,9 +1186,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1212,9 +1200,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1229,9 +1214,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1246,9 +1228,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1263,9 +1242,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1280,9 +1256,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1297,9 +1270,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1314,9 +1284,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1331,9 +1298,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1348,9 +1312,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prebuild": "./scripts/update-version.sh",
     "build": "vite build && cp -f public/404.html dist/ 2>/dev/null || copy public\\404.html dist\\ 2>nul || true",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "validate:replay": "node scripts/validate_replay.mjs",
     "preview": "vite preview",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"

--- a/scripts/validate_replay.mjs
+++ b/scripts/validate_replay.mjs
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const artifactsDir = path.join(process.cwd(), 'src', 'data', 'demoArtifacts');
+const files = fs.readdirSync(artifactsDir)
+  .filter((file) => file.endsWith('.v1.json'))
+  .sort();
+
+const findLatencyKeys = (value, trail = []) => {
+  if (!value || typeof value !== 'object') return [];
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => findLatencyKeys(item, [...trail, String(index)]));
+  }
+
+  return Object.entries(value).flatMap(([key, child]) => {
+    const nextTrail = [...trail, key];
+    const ownMatch = key.toLowerCase().includes('latency') ? [nextTrail.join('.')] : [];
+    return ownMatch.concat(findLatencyKeys(child, nextTrail));
+  });
+};
+
+const assertReplay = (file, replay) => {
+  const errors = [];
+  const latencyKeys = findLatencyKeys(replay);
+
+  if (latencyKeys.length > 0) {
+    errors.push(`latency keys found: ${latencyKeys.join(', ')}`);
+  }
+
+  if (replay.frames?.heldout?.n !== 30) {
+    errors.push(`heldout.n expected 30, received ${replay.frames?.heldout?.n}`);
+  }
+
+  if (replay.frames?.isolation?.n !== 10) {
+    errors.push(`isolation.n expected 10, received ${replay.frames?.isolation?.n}`);
+  }
+
+  if (!Number.isFinite(replay.frames?.optimization?.trial_count) || replay.frames.optimization.trial_count <= 0) {
+    errors.push(`optimization.trial_count must be greater than 0, received ${replay.frames?.optimization?.trial_count}`);
+  }
+
+  if (!replay.limitations?.includes('not_sota')) {
+    errors.push('limitations must include not_sota');
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`${file}: ${errors.join('; ')}`);
+  }
+};
+
+for (const file of files) {
+  const fullPath = path.join(artifactsDir, file);
+  const replay = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+  assertReplay(file, replay);
+  console.log(
+    `${file}: passed (heldout n=${replay.frames.heldout.n}, isolation n=${replay.frames.isolation.n}, trials=${replay.frames.optimization.trial_count})`
+  );
+}
+
+console.log(`validate_replay: checked ${files.length} replay artifacts`);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import AgentsInProduction from './pages/academy/AgentsInProduction'
 import StatisticalSEWorkshop from './pages/academy/StatisticalSEWorkshop'
 import KnobExplorer from './pages/KnobExplorer'
 import OptimizationDemo from './pages/OptimizationDemo'
+import DemoGallery from './pages/DemoGallery'
 import Layout from './layout'
 import ExternalRedirect from './components/ExternalRedirect'
 
@@ -70,6 +71,7 @@ export default function App() {
           element={<ExternalRedirect to="https://portal.traigent.ai/refund" label="refund" />}
         />
         <Route path="pricing" element={<Pricing />} />
+        <Route path="demos" element={<DemoGallery />} />
         <Route path="academy" element={<AcademyIndex />} />
         <Route path="academy/agents-in-production" element={<AgentsInProduction />} />
         <Route path="academy/statistical-se-workshop" element={<StatisticalSEWorkshop />} />

--- a/src/components/OptimizationTable.css
+++ b/src/components/OptimizationTable.css
@@ -982,3 +982,307 @@
     margin-top: 8px;
   }
 }
+
+/* Real replay path */
+.opt-real {
+  gap: 18px;
+  align-items: stretch;
+  justify-content: flex-start;
+}
+
+.opt-container.opt-real.opt-embedded {
+  min-height: 640px;
+  height: 640px;
+  padding: 28px 22px;
+}
+
+.real-replay-header {
+  width: 100%;
+  max-width: 1320px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.real-honest-banner {
+  color: #93c5fd;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.real-replay-header h2 {
+  color: #fff;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.15;
+  margin: 0;
+}
+
+.real-replay-header h2 span {
+  color: #64748b;
+}
+
+.real-delta-pill {
+  color: #4ade80;
+  background: rgba(74, 222, 128, 0.12);
+  border: 1px solid rgba(74, 222, 128, 0.35);
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 1.3rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.real-frame-tabs {
+  width: 100%;
+  max-width: 1320px;
+  display: flex;
+  gap: 8px;
+}
+
+.real-frame-tabs button {
+  color: #94a3b8;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-weight: 700;
+  transition: all 0.2s ease;
+}
+
+.real-frame-tabs button:hover,
+.real-frame-tabs button.active {
+  color: #fff;
+  background: rgba(77, 195, 255, 0.16);
+  border-color: rgba(77, 195, 255, 0.5);
+}
+
+.real-frame-panel {
+  width: 100%;
+  max-width: 1320px;
+  animation: fadeIn 0.35s ease;
+}
+
+.real-frame-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 10px;
+}
+
+.real-frame-kicker {
+  color: #4dc3ff;
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 0.78rem;
+  margin: 0;
+}
+
+.real-frame-heading h3 {
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.real-table-wrapper {
+  width: 100%;
+  max-height: 330px;
+  overflow: auto;
+  border: 1px solid #333;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.real-replay-table {
+  width: 100%;
+  min-width: 960px;
+  font-size: 0.72rem;
+}
+
+.real-replay-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #0a0a0a;
+  padding: 8px 10px;
+}
+
+.real-replay-table td {
+  padding: 7px 10px;
+  max-width: 170px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.heldout-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.heldout-card,
+.isolation-card {
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+  padding: 16px;
+}
+
+.heldout-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.heldout-card-best {
+  border-color: rgba(74, 222, 128, 0.45);
+  background: rgba(74, 222, 128, 0.08);
+}
+
+.heldout-delta {
+  border-color: rgba(77, 195, 255, 0.45);
+  background: rgba(77, 195, 255, 0.08);
+}
+
+.heldout-label,
+.isolation-knob {
+  color: #94a3b8;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.heldout-card strong,
+.isolation-card strong {
+  color: #fff;
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 1.15rem;
+  line-height: 1.2;
+}
+
+.heldout-card span,
+.isolation-card span {
+  color: #94a3b8;
+}
+
+.isolation-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.isolation-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 142px;
+}
+
+.isolation-card em {
+  color: #4ade80;
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-style: normal;
+  font-weight: 800;
+}
+
+.real-replay-footer {
+  width: 100%;
+  max-width: 1320px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.real-limitations {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.real-limitations li {
+  color: #cbd5e1;
+  background: rgba(148, 163, 184, 0.11);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 8px;
+  padding: 6px 9px;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.opt-real .controls {
+  margin-top: 0;
+}
+
+@media (max-width: 1024px) {
+  .opt-container.opt-real.opt-embedded {
+    min-height: 620px;
+    height: 620px;
+  }
+
+  .real-replay-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .real-replay-header h2 {
+    font-size: 1.55rem;
+  }
+
+  .heldout-grid,
+  .isolation-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .real-replay-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 768px) {
+  .opt-container.opt-real.opt-embedded {
+    min-height: 700px;
+    height: 700px;
+    padding: 22px 14px;
+  }
+
+  .real-frame-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .real-replay-header h2 {
+    font-size: 1.25rem;
+  }
+
+  .real-delta-pill {
+    font-size: 1rem;
+  }
+
+  .real-frame-tabs {
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+
+  .heldout-grid,
+  .isolation-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .real-table-wrapper {
+    max-height: 300px;
+  }
+}

--- a/src/components/OptimizationTable.jsx
+++ b/src/components/OptimizationTable.jsx
@@ -86,7 +86,7 @@ const FRAMES = {
 const summaryRowIds = [16, 15, 8, 9];
 const baselineRow = keyRows.find(r => r.id === 16);
 
-export default function OptimizationTable({ autoPlay = true, embedded = false }) {
+function LegacyOptimizationTable({ autoPlay = true, embedded = false }) {
   const [frame, setFrame] = useState(autoPlay ? FRAMES.INTRO : FRAMES.HIGHLIGHT_16);
   const [isPlaying, setIsPlaying] = useState(autoPlay);
   const [showPauseIndicator, setShowPauseIndicator] = useState(false);
@@ -456,4 +456,284 @@ export default function OptimizationTable({ autoPlay = true, embedded = false })
       )}
     </div>
   );
+}
+
+const REAL_FRAMES = {
+  OPTIMIZATION: 0,
+  HELDOUT: 1,
+  ISOLATION: 2,
+};
+
+const realFrameMeta = [
+  { id: REAL_FRAMES.OPTIMIZATION, label: 'Search' },
+  { id: REAL_FRAMES.HELDOUT, label: 'Held-out' },
+  { id: REAL_FRAMES.ISOLATION, label: 'Isolation' },
+];
+
+export const deriveReplayColumns = (dataset) => dataset?.knobs?.map((knob) => knob.key) ?? [];
+
+const demoLabels = {
+  'bird-sql-optimizer': 'BIRD mini-dev',
+  'text2sql-sota-optimizer': 'Spider',
+  'hotpotqa-rag-optimizer': 'HotpotQA',
+};
+
+const formatPercent = (value, maximumFractionDigits = 1) => {
+  const percentage = Number(value) * 100;
+  return `${new Intl.NumberFormat('en-US', {
+    maximumFractionDigits,
+  }).format(percentage)}%`;
+};
+
+const formatPp = (value) => new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+}).format(Number(value));
+
+const formatCost = (value) => `$${Number(value).toLocaleString('en-US', {
+  minimumFractionDigits: 6,
+  maximumFractionDigits: 6,
+})}`;
+
+const formatValue = (value) => String(value);
+
+const formatLimitation = (limitation) => limitation.replaceAll('_', ' ');
+
+function OptimizationReplay({ dataset, columns, autoPlay = true, embedded = false, demoLabel }) {
+  const [frame, setFrame] = useState(REAL_FRAMES.OPTIMIZATION);
+  const [isPlaying, setIsPlaying] = useState(autoPlay);
+  const [showPauseIndicator, setShowPauseIndicator] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const containerRef = useRef(null);
+
+  const replayColumns = columns?.length ? columns : deriveReplayColumns(dataset);
+  const optimization = dataset.frames.optimization;
+  const heldout = dataset.frames.heldout;
+  const isolation = dataset.frames.isolation;
+  const label = demoLabel || demoLabels[dataset.run.demo] || dataset.run.demo;
+  const banner = `${label} · fixed slice · real Bedrock Haiku · not a SOTA claim`;
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => document.removeEventListener('fullscreenchange', handleFullscreenChange);
+  }, []);
+
+  useEffect(() => {
+    if (!isPlaying) return;
+
+    const timer = setTimeout(() => {
+      setFrame((currentFrame) => {
+        if (currentFrame >= REAL_FRAMES.ISOLATION) {
+          setIsPlaying(false);
+          return currentFrame;
+        }
+        return currentFrame + 1;
+      });
+    }, frame === REAL_FRAMES.OPTIMIZATION ? 3600 : 3200);
+
+    return () => clearTimeout(timer);
+  }, [frame, isPlaying]);
+
+  const toggleFullscreen = (e) => {
+    e.stopPropagation();
+    if (!containerRef.current) return;
+
+    if (!document.fullscreenElement) {
+      containerRef.current.requestFullscreen?.() ||
+        containerRef.current.webkitRequestFullscreen?.() ||
+        containerRef.current.msRequestFullscreen?.();
+    } else {
+      document.exitFullscreen?.() ||
+        document.webkitExitFullscreen?.() ||
+        document.msExitFullscreen?.();
+    }
+  };
+
+  const restart = (e) => {
+    e?.stopPropagation();
+    setFrame(REAL_FRAMES.OPTIMIZATION);
+    setIsPlaying(true);
+  };
+
+  const showFrame = (nextFrame, e) => {
+    e.stopPropagation();
+    setFrame(nextFrame);
+    setIsPlaying(false);
+  };
+
+  const togglePause = () => {
+    setIsPlaying((playing) => !playing);
+    setShowPauseIndicator(true);
+    setTimeout(() => setShowPauseIndicator(false), 600);
+  };
+
+  const FullscreenButton = () => (
+    embedded && (
+      <button
+        className="fullscreen-btn"
+        onClick={toggleFullscreen}
+        title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+      >
+        {isFullscreen ? '⤫' : '⤢'}
+      </button>
+    )
+  );
+
+  const PauseIndicator = () => (
+    showPauseIndicator && (
+      <div className="pause-indicator">
+        {isPlaying ? '▶' : '⏸'}
+      </div>
+    )
+  );
+
+  const containerClass = embedded && !isFullscreen
+    ? 'opt-container opt-real opt-embedded clickable'
+    : 'opt-container opt-real clickable';
+
+  const renderOptimizationFrame = () => (
+    <section className="real-frame-panel">
+      <div className="real-frame-heading">
+        <p className="real-frame-kicker">Optimization search · {optimization.trial_count} trials · n={optimization.n} · selection only</p>
+        <h3>Configuration search history</h3>
+      </div>
+      <div className="real-table-wrapper">
+        <table className="opt-table real-replay-table">
+          <thead>
+            <tr>
+              <th>#</th>
+              {replayColumns.map((column) => (
+                <th key={column}>{column}</th>
+              ))}
+              <th>accuracy</th>
+              <th>selected</th>
+            </tr>
+          </thead>
+          <tbody>
+            {optimization.rows.map((row) => (
+              <tr key={row.trial_index} className={row.is_best ? 'overview-highlight' : ''}>
+                <td className="row-id">{row.trial_index}</td>
+                {replayColumns.map((column) => (
+                  <td key={column}>{formatValue(row.config[column])}</td>
+                ))}
+                <td className={row.is_best ? 'highlight-green' : ''}>{formatPercent(row.accuracy)}</td>
+                <td>{row.is_best ? 'best' : 'candidate'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+
+  const renderHeldoutFrame = () => (
+    <section className="real-frame-panel">
+      <div className="real-frame-heading">
+        <p className="real-frame-kicker">Held-out check · n={heldout.n} · real Bedrock Haiku</p>
+        <h3>Baseline versus optimized on held-out examples</h3>
+      </div>
+      <div className="heldout-grid">
+        {[
+          ['Baseline', heldout.baseline],
+          ['Optimized', heldout.optimized],
+        ].map(([name, result]) => (
+          <div key={name} className={`heldout-card ${name === 'Optimized' ? 'heldout-card-best' : ''}`}>
+            <span className="heldout-label">{name}</span>
+            <strong>{result.correct}/{result.total} = {formatPercent(result.accuracy)}</strong>
+            <span>held-out cost {formatCost(result.cost_usd)}</span>
+          </div>
+        ))}
+        <div className="heldout-card heldout-delta">
+          <span className="heldout-label">Delta</span>
+          <strong>Δ{formatPp(heldout.delta.accuracy_pp)}pp</strong>
+          <span>{heldout.delta.correct} more correct</span>
+        </div>
+      </div>
+    </section>
+  );
+
+  const renderIsolationFrame = () => (
+    <section className="real-frame-panel">
+      <div className="real-frame-heading">
+        <p className="real-frame-kicker">Isolation levers · n={isolation.n} · not joint causality</p>
+        <h3>Single-lever isolation checks</h3>
+      </div>
+      <div className="isolation-grid">
+        {isolation.cards.map((card) => (
+          <div key={card.knob} className="isolation-card">
+            <span className="isolation-knob">{card.knob}</span>
+            <strong>{formatValue(card.baseline_value)} → {formatValue(card.best_value)}</strong>
+            <span>{formatPercent(card.baseline_accuracy)} → {formatPercent(card.best_accuracy)}</span>
+            <em>Δ{formatPp(card.delta_pp)}pp</em>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+
+  return (
+    <div ref={containerRef} className={containerClass} onClick={togglePause}>
+      <FullscreenButton />
+      <PauseIndicator />
+
+      <div className="real-replay-header">
+        <div>
+          <p className="real-honest-banner">{banner}</p>
+          <h2>
+            {heldout.baseline.correct}/{heldout.baseline.total} = {formatPercent(heldout.baseline.accuracy)}
+            <span> → </span>
+            {heldout.optimized.correct}/{heldout.optimized.total} = {formatPercent(heldout.optimized.accuracy)}
+          </h2>
+        </div>
+        <div className="real-delta-pill">+{formatPp(heldout.delta.accuracy_pp)}pp</div>
+      </div>
+
+      <div className="real-frame-tabs" onClick={(e) => e.stopPropagation()}>
+        {realFrameMeta.map((item) => (
+          <button
+            key={item.id}
+            className={frame === item.id ? 'active' : ''}
+            onClick={(e) => showFrame(item.id, e)}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      {frame === REAL_FRAMES.OPTIMIZATION && renderOptimizationFrame()}
+      {frame === REAL_FRAMES.HELDOUT && renderHeldoutFrame()}
+      {frame === REAL_FRAMES.ISOLATION && renderIsolationFrame()}
+
+      <div className="real-replay-footer">
+        <ul className="real-limitations">
+          {dataset.limitations.map((limitation) => (
+            <li key={limitation}>{formatLimitation(limitation)}</li>
+          ))}
+        </ul>
+        <div className="controls">
+          <button onClick={restart} className="opt-btn primary">↻ Replay</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { OptimizationReplay };
+
+export default function OptimizationTable({ autoPlay = true, embedded = false, dataset, columns, demoLabel }) {
+  if (dataset) {
+    return (
+      <OptimizationReplay
+        dataset={dataset}
+        columns={columns}
+        autoPlay={autoPlay}
+        embedded={embedded}
+        demoLabel={demoLabel}
+      />
+    );
+  }
+
+  return <LegacyOptimizationTable autoPlay={autoPlay} embedded={embedded} />;
 }

--- a/src/data/demoArtifacts/bird.v1.json
+++ b/src/data/demoArtifacts/bird.v1.json
@@ -1,0 +1,385 @@
+{
+  "schema_version": "traigent.optimization_replay.v1",
+  "run": {
+    "run_id": "bird-minidev-300-naive",
+    "demo": "bird-sql-optimizer",
+    "mode": "real_bedrock",
+    "model_id": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "git_sha": "774a01c",
+    "source_artifacts": [
+      {
+        "name": "spine.py",
+        "path": "src/spine.py",
+        "sha256": "80c5956837316e507fcc8b2656f5b66a43d44a62b8f1c3e773b5885eca52f01d"
+      },
+      {
+        "name": "manifest.json",
+        "path": "artifacts/manifest.json",
+        "sha256": "0cca3059862ed6ada2cf21dd75946854045c99f7d0cb438c8f3dcc176a1ace6a"
+      },
+      {
+        "name": "02_trials.jsonl",
+        "path": "artifacts/02_trials.jsonl",
+        "sha256": "9537398cd8fc41001784144b2dec113e2ce00497f976dd2b8fbaba2a89dfe3e4"
+      },
+      {
+        "name": "03_best_opt_config.json",
+        "path": "artifacts/03_best_opt_config.json",
+        "sha256": "fe1a600ccaf948843cc9d2ff8a14bfc57a6d7823d4ea1ad139e7d94e6df201f8"
+      },
+      {
+        "name": "07_heldout_report.json",
+        "path": "artifacts/07_heldout_report.json",
+        "sha256": "593a6fdb2ae90337ac16643de6255e525241dbe2f2bef453bb26fe5f2713ea01"
+      },
+      {
+        "name": "isolation_summary.json",
+        "path": "artifacts/isolation/isolation_summary.json",
+        "sha256": "b7af997aefef69d54b7e3fc036c30f2580dfc8e106a38038a6c492b3055dd9ce"
+      }
+    ]
+  },
+  "knobs": [
+    {
+      "key": "schema_context",
+      "type": "choice",
+      "values": [
+        "none",
+        "full_ddl_fk",
+        "linked_top6"
+      ],
+      "baseline": "none",
+      "optimized": "full_ddl_fk"
+    },
+    {
+      "key": "evidence_usage",
+      "type": "choice",
+      "values": [
+        "off",
+        "hint_appended"
+      ],
+      "baseline": "off",
+      "optimized": "hint_appended"
+    },
+    {
+      "key": "generation_path",
+      "type": "choice",
+      "values": [
+        "direct_dail",
+        "query_plan_cot",
+        "divide_conquer_cot"
+      ],
+      "baseline": "direct_dail",
+      "optimized": "divide_conquer_cot"
+    },
+    {
+      "key": "fewshot_k",
+      "type": "int",
+      "values": [
+        0,
+        1,
+        3
+      ],
+      "baseline": 0,
+      "optimized": 1
+    },
+    {
+      "key": "fewshot_selector",
+      "type": "choice",
+      "values": [
+        "random",
+        "masked_question_similarity"
+      ],
+      "baseline": "random",
+      "optimized": "masked_question_similarity"
+    },
+    {
+      "key": "candidate_count",
+      "type": "int",
+      "values": [
+        1,
+        2
+      ],
+      "baseline": 1,
+      "optimized": 1
+    },
+    {
+      "key": "repair_policy",
+      "type": "choice",
+      "values": [
+        "off",
+        "sqlite_error_once"
+      ],
+      "baseline": "off",
+      "optimized": "sqlite_error_once"
+    }
+  ],
+  "frames": {
+    "optimization": {
+      "scope": "opt_mini",
+      "n": 6,
+      "trial_count": 14,
+      "rows": [
+        {
+          "trial_index": 0,
+          "config": {
+            "schema_context": "none",
+            "evidence_usage": "off",
+            "generation_path": "direct_dail",
+            "fewshot_k": 0,
+            "fewshot_selector": "random",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.0,
+          "is_best": false
+        },
+        {
+          "trial_index": 1,
+          "config": {
+            "schema_context": "full_ddl_fk",
+            "evidence_usage": "hint_appended",
+            "generation_path": "divide_conquer_cot",
+            "fewshot_k": 1,
+            "fewshot_selector": "masked_question_similarity",
+            "candidate_count": 1,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.6666666666666666,
+          "is_best": true
+        },
+        {
+          "trial_index": 2,
+          "config": {
+            "schema_context": "none",
+            "evidence_usage": "off",
+            "generation_path": "divide_conquer_cot",
+            "fewshot_k": 1,
+            "fewshot_selector": "random",
+            "candidate_count": 2,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.0,
+          "is_best": false
+        },
+        {
+          "trial_index": 3,
+          "config": {
+            "schema_context": "full_ddl_fk",
+            "evidence_usage": "hint_appended",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 3,
+            "fewshot_selector": "masked_question_similarity",
+            "candidate_count": 2,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.6666666666666666,
+          "is_best": false
+        },
+        {
+          "trial_index": 4,
+          "config": {
+            "schema_context": "linked_top6",
+            "evidence_usage": "hint_appended",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 0,
+            "fewshot_selector": "random",
+            "candidate_count": 2,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.5,
+          "is_best": false
+        },
+        {
+          "trial_index": 5,
+          "config": {
+            "schema_context": "full_ddl_fk",
+            "evidence_usage": "off",
+            "generation_path": "direct_dail",
+            "fewshot_k": 1,
+            "fewshot_selector": "random",
+            "candidate_count": 1,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.3333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 6,
+          "config": {
+            "schema_context": "linked_top6",
+            "evidence_usage": "hint_appended",
+            "generation_path": "divide_conquer_cot",
+            "fewshot_k": 3,
+            "fewshot_selector": "masked_question_similarity",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.6666666666666666,
+          "is_best": false
+        },
+        {
+          "trial_index": 7,
+          "config": {
+            "schema_context": "none",
+            "evidence_usage": "off",
+            "generation_path": "direct_dail",
+            "fewshot_k": 0,
+            "fewshot_selector": "masked_question_similarity",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.0,
+          "is_best": false
+        },
+        {
+          "trial_index": 8,
+          "config": {
+            "schema_context": "full_ddl_fk",
+            "evidence_usage": "hint_appended",
+            "generation_path": "divide_conquer_cot",
+            "fewshot_k": 1,
+            "fewshot_selector": "masked_question_similarity",
+            "candidate_count": 2,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.6666666666666666,
+          "is_best": false
+        },
+        {
+          "trial_index": 9,
+          "config": {
+            "schema_context": "linked_top6",
+            "evidence_usage": "off",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 3,
+            "fewshot_selector": "random",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.3333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 10,
+          "config": {
+            "schema_context": "none",
+            "evidence_usage": "hint_appended",
+            "generation_path": "direct_dail",
+            "fewshot_k": 0,
+            "fewshot_selector": "masked_question_similarity",
+            "candidate_count": 2,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.16666666666666666,
+          "is_best": false
+        },
+        {
+          "trial_index": 11,
+          "config": {
+            "schema_context": "full_ddl_fk",
+            "evidence_usage": "hint_appended",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 3,
+            "fewshot_selector": "masked_question_similarity",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.6666666666666666,
+          "is_best": false
+        },
+        {
+          "trial_index": 12,
+          "config": {
+            "schema_context": "linked_top6",
+            "evidence_usage": "off",
+            "generation_path": "divide_conquer_cot",
+            "fewshot_k": 1,
+            "fewshot_selector": "random",
+            "candidate_count": 2,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.3333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 13,
+          "config": {
+            "schema_context": "full_ddl_fk",
+            "evidence_usage": "hint_appended",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 3,
+            "fewshot_selector": "masked_question_similarity",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.6666666666666666,
+          "is_best": false
+        }
+      ]
+    },
+    "heldout": {
+      "scope": "heldout",
+      "n": 30,
+      "baseline": {
+        "correct": 1,
+        "total": 30,
+        "accuracy": 0.033333,
+        "cost_usd": 0.010933
+      },
+      "optimized": {
+        "correct": 16,
+        "total": 30,
+        "accuracy": 0.533333,
+        "cost_usd": 0.066489
+      },
+      "delta": {
+        "accuracy_pp": 50.0,
+        "correct": 15
+      }
+    },
+    "isolation": {
+      "scope": "isolation",
+      "n": 10,
+      "cards": [
+        {
+          "knob": "schema_context",
+          "baseline_value": "none",
+          "baseline_accuracy": 0.0,
+          "best_value": "linked_top6",
+          "best_accuracy": 0.4,
+          "delta_pp": 40.0
+        },
+        {
+          "knob": "evidence_usage",
+          "baseline_value": "off",
+          "baseline_accuracy": 0.0,
+          "best_value": "hint_appended",
+          "best_accuracy": 0.1,
+          "delta_pp": 10.0
+        },
+        {
+          "knob": "fewshot_k",
+          "baseline_value": 0,
+          "baseline_accuracy": 0.0,
+          "best_value": 0,
+          "best_accuracy": 0.0,
+          "delta_pp": 0.0
+        },
+        {
+          "knob": "generation_path",
+          "baseline_value": "direct_dail",
+          "baseline_accuracy": 0.0,
+          "best_value": "direct_dail",
+          "best_accuracy": 0.0,
+          "delta_pp": 0.0
+        }
+      ]
+    }
+  },
+  "limitations": [
+    "latency_not_measured",
+    "not_sota",
+    "not_statistical_significance"
+  ]
+}

--- a/src/data/demoArtifacts/hotpotqa.v1.json
+++ b/src/data/demoArtifacts/hotpotqa.v1.json
@@ -1,0 +1,416 @@
+{
+  "schema_version": "traigent.optimization_replay.v1",
+  "run": {
+    "run_id": "hotpotqa-rag-300-naive",
+    "demo": "hotpotqa-rag-optimizer",
+    "mode": "real_bedrock",
+    "model_id": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "git_sha": "774a01c",
+    "source_artifacts": [
+      {
+        "name": "spine.py",
+        "path": "src/spine.py",
+        "sha256": "0dc769ad6bb34ce1c4ce2497f0c5c83c31d373e8c1800931bbcafbf6e437398e"
+      },
+      {
+        "name": "manifest.json",
+        "path": "artifacts/manifest.json",
+        "sha256": "edef2cf03ac280c0ba4a15d288c7e43842ab7ed297169f6bcc2e42a74462ea05"
+      },
+      {
+        "name": "02_trials.jsonl",
+        "path": "artifacts/02_trials.jsonl",
+        "sha256": "a6167d4afcd450242b784eeb15ac05fa1b3cefd3cb5a6ce5eb4bcdcff3d36fe5"
+      },
+      {
+        "name": "03_best_opt_config.json",
+        "path": "artifacts/03_best_opt_config.json",
+        "sha256": "dc97febb04263f2abfb98fabf81ee39b0f568a45e637c90d62ebe5fa9375b434"
+      },
+      {
+        "name": "07_heldout_report.json",
+        "path": "artifacts/07_heldout_report.json",
+        "sha256": "18306607c7dd69e539013807266b7aa4ad7a036c243c5477a24d2a814cdfdb84"
+      },
+      {
+        "name": "isolation_summary.json",
+        "path": "artifacts/isolation/isolation_summary.json",
+        "sha256": "a201fd3fe93e682c41aa7434ff3f677f0e526853c254f2b9296d83cea1c5d4f5"
+      }
+    ]
+  },
+  "knobs": [
+    {
+      "key": "retriever",
+      "type": "choice",
+      "values": [
+        "first_paragraph",
+        "bm25_question",
+        "bm25_title_question"
+      ],
+      "baseline": "first_paragraph",
+      "optimized": "bm25_title_question"
+    },
+    {
+      "key": "retrieval_k",
+      "type": "int",
+      "values": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "baseline": 1,
+      "optimized": 5
+    },
+    {
+      "key": "query_strategy",
+      "type": "choice",
+      "values": [
+        "single_hop",
+        "decompose_bridge"
+      ],
+      "baseline": "single_hop",
+      "optimized": "single_hop"
+    },
+    {
+      "key": "context_order",
+      "type": "choice",
+      "values": [
+        "as_retrieved",
+        "score_desc",
+        "score_asc"
+      ],
+      "baseline": "as_retrieved",
+      "optimized": "score_asc"
+    },
+    {
+      "key": "answer_path",
+      "type": "choice",
+      "values": [
+        "direct",
+        "extract_then_answer",
+        "cot_then_answer"
+      ],
+      "baseline": "direct",
+      "optimized": "extract_then_answer"
+    },
+    {
+      "key": "fewshot_k",
+      "type": "int",
+      "values": [
+        0,
+        1,
+        2
+      ],
+      "baseline": 0,
+      "optimized": 2
+    },
+    {
+      "key": "self_consistency",
+      "type": "int",
+      "values": [
+        1,
+        3
+      ],
+      "baseline": 1,
+      "optimized": 3
+    }
+  ],
+  "frames": {
+    "optimization": {
+      "scope": "opt_mini",
+      "n": 8,
+      "trial_count": 16,
+      "rows": [
+        {
+          "trial_index": 0,
+          "config": {
+            "retriever": "first_paragraph",
+            "retrieval_k": 1,
+            "query_strategy": "single_hop",
+            "context_order": "as_retrieved",
+            "answer_path": "direct",
+            "fewshot_k": 0,
+            "self_consistency": 1
+          },
+          "accuracy": 0.125,
+          "is_best": false
+        },
+        {
+          "trial_index": 1,
+          "config": {
+            "retriever": "bm25_question",
+            "retrieval_k": 2,
+            "query_strategy": "single_hop",
+            "context_order": "as_retrieved",
+            "answer_path": "extract_then_answer",
+            "fewshot_k": 2,
+            "self_consistency": 1
+          },
+          "accuracy": 0.125,
+          "is_best": false
+        },
+        {
+          "trial_index": 2,
+          "config": {
+            "retriever": "first_paragraph",
+            "retrieval_k": 5,
+            "query_strategy": "decompose_bridge",
+            "context_order": "score_asc",
+            "answer_path": "extract_then_answer",
+            "fewshot_k": 0,
+            "self_consistency": 3
+          },
+          "accuracy": 0.25,
+          "is_best": false
+        },
+        {
+          "trial_index": 3,
+          "config": {
+            "retriever": "first_paragraph",
+            "retrieval_k": 5,
+            "query_strategy": "decompose_bridge",
+            "context_order": "as_retrieved",
+            "answer_path": "extract_then_answer",
+            "fewshot_k": 0,
+            "self_consistency": 3
+          },
+          "accuracy": 0.25,
+          "is_best": false
+        },
+        {
+          "trial_index": 4,
+          "config": {
+            "retriever": "bm25_title_question",
+            "retrieval_k": 5,
+            "query_strategy": "single_hop",
+            "context_order": "score_asc",
+            "answer_path": "extract_then_answer",
+            "fewshot_k": 2,
+            "self_consistency": 3
+          },
+          "accuracy": 0.5,
+          "is_best": true
+        },
+        {
+          "trial_index": 5,
+          "config": {
+            "retriever": "bm25_question",
+            "retrieval_k": 2,
+            "query_strategy": "single_hop",
+            "context_order": "score_asc",
+            "answer_path": "cot_then_answer",
+            "fewshot_k": 0,
+            "self_consistency": 3
+          },
+          "accuracy": 0.25,
+          "is_best": false
+        },
+        {
+          "trial_index": 6,
+          "config": {
+            "retriever": "bm25_title_question",
+            "retrieval_k": 3,
+            "query_strategy": "decompose_bridge",
+            "context_order": "score_desc",
+            "answer_path": "direct",
+            "fewshot_k": 1,
+            "self_consistency": 1
+          },
+          "accuracy": 0.375,
+          "is_best": false
+        },
+        {
+          "trial_index": 7,
+          "config": {
+            "retriever": "bm25_title_question",
+            "retrieval_k": 1,
+            "query_strategy": "single_hop",
+            "context_order": "score_desc",
+            "answer_path": "cot_then_answer",
+            "fewshot_k": 2,
+            "self_consistency": 1
+          },
+          "accuracy": 0.5,
+          "is_best": false
+        },
+        {
+          "trial_index": 8,
+          "config": {
+            "retriever": "bm25_title_question",
+            "retrieval_k": 3,
+            "query_strategy": "decompose_bridge",
+            "context_order": "score_asc",
+            "answer_path": "direct",
+            "fewshot_k": 1,
+            "self_consistency": 3
+          },
+          "accuracy": 0.375,
+          "is_best": false
+        },
+        {
+          "trial_index": 9,
+          "config": {
+            "retriever": "bm25_question",
+            "retrieval_k": 1,
+            "query_strategy": "single_hop",
+            "context_order": "score_desc",
+            "answer_path": "cot_then_answer",
+            "fewshot_k": 2,
+            "self_consistency": 1
+          },
+          "accuracy": 0.5,
+          "is_best": false
+        },
+        {
+          "trial_index": 10,
+          "config": {
+            "retriever": "first_paragraph",
+            "retrieval_k": 5,
+            "query_strategy": "decompose_bridge",
+            "context_order": "as_retrieved",
+            "answer_path": "direct",
+            "fewshot_k": 1,
+            "self_consistency": 3
+          },
+          "accuracy": 0.25,
+          "is_best": false
+        },
+        {
+          "trial_index": 11,
+          "config": {
+            "retriever": "bm25_title_question",
+            "retrieval_k": 1,
+            "query_strategy": "single_hop",
+            "context_order": "score_desc",
+            "answer_path": "cot_then_answer",
+            "fewshot_k": 2,
+            "self_consistency": 1
+          },
+          "accuracy": 0.5,
+          "is_best": false
+        },
+        {
+          "trial_index": 12,
+          "config": {
+            "retriever": "bm25_question",
+            "retrieval_k": 2,
+            "query_strategy": "single_hop",
+            "context_order": "score_asc",
+            "answer_path": "extract_then_answer",
+            "fewshot_k": 1,
+            "self_consistency": 3
+          },
+          "accuracy": 0.125,
+          "is_best": false
+        },
+        {
+          "trial_index": 13,
+          "config": {
+            "retriever": "bm25_title_question",
+            "retrieval_k": 3,
+            "query_strategy": "decompose_bridge",
+            "context_order": "score_desc",
+            "answer_path": "cot_then_answer",
+            "fewshot_k": 2,
+            "self_consistency": 1
+          },
+          "accuracy": 0.25,
+          "is_best": false
+        },
+        {
+          "trial_index": 14,
+          "config": {
+            "retriever": "first_paragraph",
+            "retrieval_k": 5,
+            "query_strategy": "single_hop",
+            "context_order": "as_retrieved",
+            "answer_path": "direct",
+            "fewshot_k": 0,
+            "self_consistency": 3
+          },
+          "accuracy": 0.375,
+          "is_best": false
+        },
+        {
+          "trial_index": 15,
+          "config": {
+            "retriever": "bm25_question",
+            "retrieval_k": 1,
+            "query_strategy": "decompose_bridge",
+            "context_order": "score_asc",
+            "answer_path": "extract_then_answer",
+            "fewshot_k": 1,
+            "self_consistency": 1
+          },
+          "accuracy": 0.125,
+          "is_best": false
+        }
+      ]
+    },
+    "heldout": {
+      "scope": "heldout",
+      "n": 30,
+      "baseline": {
+        "correct": 6,
+        "total": 30,
+        "accuracy": 0.2,
+        "cost_usd": 0.0
+      },
+      "optimized": {
+        "correct": 19,
+        "total": 30,
+        "accuracy": 0.633333,
+        "cost_usd": 0.171358
+      },
+      "delta": {
+        "accuracy_pp": 43.3333,
+        "correct": 13
+      }
+    },
+    "isolation": {
+      "scope": "isolation",
+      "n": 10,
+      "cards": [
+        {
+          "knob": "retriever",
+          "baseline_value": "first_paragraph",
+          "baseline_accuracy": 0.3,
+          "best_value": "first_paragraph",
+          "best_accuracy": 0.3,
+          "delta_pp": 0.0
+        },
+        {
+          "knob": "retrieval_k",
+          "baseline_value": 1,
+          "baseline_accuracy": 0.3,
+          "best_value": 5,
+          "best_accuracy": 0.4,
+          "delta_pp": 10.0
+        },
+        {
+          "knob": "query_strategy",
+          "baseline_value": "single_hop",
+          "baseline_accuracy": 0.3,
+          "best_value": "single_hop",
+          "best_accuracy": 0.3,
+          "delta_pp": 0.0
+        },
+        {
+          "knob": "self_consistency",
+          "baseline_value": 1,
+          "baseline_accuracy": 0.3,
+          "best_value": 1,
+          "best_accuracy": 0.3,
+          "delta_pp": 0.0
+        }
+      ]
+    }
+  },
+  "limitations": [
+    "latency_not_measured",
+    "not_sota",
+    "not_statistical_significance"
+  ]
+}

--- a/src/data/demoArtifacts/replays.js
+++ b/src/data/demoArtifacts/replays.js
@@ -1,0 +1,31 @@
+import birdReplay from './bird.v1.json';
+import spiderReplay from './spider.v1.json';
+import hotpotqaReplay from './hotpotqa.v1.json';
+
+export const replayDemos = [
+  {
+    id: 'bird',
+    name: 'BIRD',
+    label: 'BIRD mini-dev',
+    deck: 'SQL optimizer fixed slice',
+    dataset: birdReplay,
+  },
+  {
+    id: 'spider',
+    name: 'Spider',
+    label: 'Spider',
+    deck: 'Text-to-SQL fixed slice',
+    dataset: spiderReplay,
+  },
+  {
+    id: 'hotpotqa',
+    name: 'HotpotQA',
+    label: 'HotpotQA',
+    deck: 'RAG QA fixed slice',
+    dataset: hotpotqaReplay,
+  },
+];
+
+export const birdDemo = replayDemos[0];
+
+export const replayColumns = (dataset) => dataset.knobs.map((knob) => knob.key);

--- a/src/data/demoArtifacts/spider.v1.json
+++ b/src/data/demoArtifacts/spider.v1.json
@@ -1,0 +1,531 @@
+{
+  "schema_version": "traigent.optimization_replay.v1",
+  "run": {
+    "run_id": "text2sql-spider-200-naive",
+    "demo": "text2sql-sota-optimizer",
+    "mode": "real_bedrock",
+    "model_id": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "git_sha": "76e76ab",
+    "source_artifacts": [
+      {
+        "name": "spine.py",
+        "path": "src/spine.py",
+        "sha256": "fa72bc58bde70d6e5c9fad9383c695fbc9932194f8e8198f65304d47cbf88852"
+      },
+      {
+        "name": "manifest.json",
+        "path": "artifacts/manifest.json",
+        "sha256": "42b143d25ec3ac1b5279d75e6e06a2fa9a38c1e87fe1f3a7849b276dbca72c97"
+      },
+      {
+        "name": "02_trials.jsonl",
+        "path": "artifacts/02_trials.jsonl",
+        "sha256": "3111b96d25e133ebbc5e6278af208a4f4df67189b187ea26fa7f712a78fe0462"
+      },
+      {
+        "name": "03_best_opt_config.json",
+        "path": "artifacts/03_best_opt_config.json",
+        "sha256": "304146a299f00856321c3043ca1f0d3ef8b8c452b0ed5d95f3d300865744c222"
+      },
+      {
+        "name": "07_heldout_report.json",
+        "path": "artifacts/07_heldout_report.json",
+        "sha256": "65e10e486893f720d943bae4b3be5dd513e40f07e968d6d335eab52c3ba0d87c"
+      },
+      {
+        "name": "isolation_summary.json",
+        "path": "artifacts/isolation/isolation_summary.json",
+        "sha256": "033840cf689b1775a06c277fcaac65b178eb011d6536eac4586f8ef91420e6ba"
+      }
+    ]
+  },
+  "knobs": [
+    {
+      "key": "schema_context",
+      "type": "choice",
+      "values": [
+        "none",
+        "full_ddl_fk",
+        "linked_top6",
+        "linked_top10"
+      ],
+      "baseline": "none",
+      "optimized": "linked_top6"
+    },
+    {
+      "key": "generation_path",
+      "type": "choice",
+      "values": [
+        "direct_dail",
+        "query_plan_cot",
+        "divide_conquer_cot"
+      ],
+      "baseline": "direct_dail",
+      "optimized": "query_plan_cot"
+    },
+    {
+      "key": "fewshot_k",
+      "type": "int",
+      "values": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "baseline": 0,
+      "optimized": 5
+    },
+    {
+      "key": "fewshot_selector",
+      "type": "choice",
+      "values": [
+        "random",
+        "masked_question_similarity",
+        "dail_selection"
+      ],
+      "baseline": "random",
+      "optimized": "masked_question_similarity"
+    },
+    {
+      "key": "example_organization",
+      "type": "choice",
+      "values": [
+        "full_info",
+        "sql_only",
+        "dail_qa_sql"
+      ],
+      "baseline": "sql_only",
+      "optimized": "full_info"
+    },
+    {
+      "key": "candidate_count",
+      "type": "int",
+      "values": [
+        1,
+        2,
+        3
+      ],
+      "baseline": 1,
+      "optimized": 2
+    },
+    {
+      "key": "repair_policy",
+      "type": "choice",
+      "values": [
+        "off",
+        "sqlite_error_once",
+        "sqlite_error_or_empty_once"
+      ],
+      "baseline": "off",
+      "optimized": "sqlite_error_once"
+    }
+  ],
+  "frames": {
+    "optimization": {
+      "scope": "opt_mini",
+      "n": 15,
+      "trial_count": 24,
+      "rows": [
+        {
+          "trial_index": 0,
+          "config": {
+            "schema_context": "none",
+            "generation_path": "direct_dail",
+            "fewshot_k": 0,
+            "fewshot_selector": "random",
+            "example_organization": "sql_only",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.13333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 1,
+          "config": {
+            "schema_context": "full_ddl_fk",
+            "generation_path": "direct_dail",
+            "fewshot_k": 0,
+            "fewshot_selector": "dail_selection",
+            "example_organization": "dail_qa_sql",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.6,
+          "is_best": false
+        },
+        {
+          "trial_index": 2,
+          "config": {
+            "schema_context": "linked_top10",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 5,
+            "fewshot_selector": "masked_question_similarity",
+            "example_organization": "dail_qa_sql",
+            "candidate_count": 1,
+            "repair_policy": "sqlite_error_or_empty_once"
+          },
+          "accuracy": 0.5333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 3,
+          "config": {
+            "schema_context": "none",
+            "generation_path": "divide_conquer_cot",
+            "fewshot_k": 0,
+            "fewshot_selector": "dail_selection",
+            "example_organization": "dail_qa_sql",
+            "candidate_count": 3,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.2,
+          "is_best": false
+        },
+        {
+          "trial_index": 4,
+          "config": {
+            "schema_context": "linked_top6",
+            "generation_path": "direct_dail",
+            "fewshot_k": 5,
+            "fewshot_selector": "masked_question_similarity",
+            "example_organization": "sql_only",
+            "candidate_count": 2,
+            "repair_policy": "sqlite_error_or_empty_once"
+          },
+          "accuracy": 0.5333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 5,
+          "config": {
+            "schema_context": "linked_top6",
+            "generation_path": "direct_dail",
+            "fewshot_k": 0,
+            "fewshot_selector": "masked_question_similarity",
+            "example_organization": "full_info",
+            "candidate_count": 3,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.5333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 6,
+          "config": {
+            "schema_context": "full_ddl_fk",
+            "generation_path": "direct_dail",
+            "fewshot_k": 1,
+            "fewshot_selector": "random",
+            "example_organization": "sql_only",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.5333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 7,
+          "config": {
+            "schema_context": "full_ddl_fk",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 3,
+            "fewshot_selector": "dail_selection",
+            "example_organization": "dail_qa_sql",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.6,
+          "is_best": false
+        },
+        {
+          "trial_index": 8,
+          "config": {
+            "schema_context": "none",
+            "generation_path": "divide_conquer_cot",
+            "fewshot_k": 0,
+            "fewshot_selector": "random",
+            "example_organization": "full_info",
+            "candidate_count": 2,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.2,
+          "is_best": false
+        },
+        {
+          "trial_index": 9,
+          "config": {
+            "schema_context": "full_ddl_fk",
+            "generation_path": "direct_dail",
+            "fewshot_k": 3,
+            "fewshot_selector": "dail_selection",
+            "example_organization": "dail_qa_sql",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.6,
+          "is_best": false
+        },
+        {
+          "trial_index": 10,
+          "config": {
+            "schema_context": "linked_top10",
+            "generation_path": "direct_dail",
+            "fewshot_k": 1,
+            "fewshot_selector": "dail_selection",
+            "example_organization": "sql_only",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.6,
+          "is_best": false
+        },
+        {
+          "trial_index": 11,
+          "config": {
+            "schema_context": "none",
+            "generation_path": "direct_dail",
+            "fewshot_k": 0,
+            "fewshot_selector": "random",
+            "example_organization": "sql_only",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.13333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 12,
+          "config": {
+            "schema_context": "none",
+            "generation_path": "divide_conquer_cot",
+            "fewshot_k": 0,
+            "fewshot_selector": "random",
+            "example_organization": "sql_only",
+            "candidate_count": 2,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.13333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 13,
+          "config": {
+            "schema_context": "none",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 0,
+            "fewshot_selector": "random",
+            "example_organization": "sql_only",
+            "candidate_count": 3,
+            "repair_policy": "sqlite_error_or_empty_once"
+          },
+          "accuracy": 0.13333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 14,
+          "config": {
+            "schema_context": "none",
+            "generation_path": "direct_dail",
+            "fewshot_k": 1,
+            "fewshot_selector": "random",
+            "example_organization": "full_info",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.06666666666666667,
+          "is_best": false
+        },
+        {
+          "trial_index": 15,
+          "config": {
+            "schema_context": "linked_top10",
+            "generation_path": "direct_dail",
+            "fewshot_k": 3,
+            "fewshot_selector": "random",
+            "example_organization": "sql_only",
+            "candidate_count": 1,
+            "repair_policy": "off"
+          },
+          "accuracy": 0.5333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 16,
+          "config": {
+            "schema_context": "linked_top6",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 5,
+            "fewshot_selector": "masked_question_similarity",
+            "example_organization": "full_info",
+            "candidate_count": 2,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.6666666666666666,
+          "is_best": false
+        },
+        {
+          "trial_index": 17,
+          "config": {
+            "schema_context": "linked_top6",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 5,
+            "fewshot_selector": "masked_question_similarity",
+            "example_organization": "full_info",
+            "candidate_count": 2,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.6666666666666666,
+          "is_best": true
+        },
+        {
+          "trial_index": 18,
+          "config": {
+            "schema_context": "linked_top6",
+            "generation_path": "divide_conquer_cot",
+            "fewshot_k": 5,
+            "fewshot_selector": "masked_question_similarity",
+            "example_organization": "full_info",
+            "candidate_count": 3,
+            "repair_policy": "sqlite_error_or_empty_once"
+          },
+          "accuracy": 0.6,
+          "is_best": false
+        },
+        {
+          "trial_index": 19,
+          "config": {
+            "schema_context": "linked_top10",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 5,
+            "fewshot_selector": "dail_selection",
+            "example_organization": "dail_qa_sql",
+            "candidate_count": 2,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.5333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 20,
+          "config": {
+            "schema_context": "full_ddl_fk",
+            "generation_path": "divide_conquer_cot",
+            "fewshot_k": 3,
+            "fewshot_selector": "masked_question_similarity",
+            "example_organization": "dail_qa_sql",
+            "candidate_count": 3,
+            "repair_policy": "sqlite_error_or_empty_once"
+          },
+          "accuracy": 0.6,
+          "is_best": false
+        },
+        {
+          "trial_index": 21,
+          "config": {
+            "schema_context": "linked_top6",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 1,
+            "fewshot_selector": "masked_question_similarity",
+            "example_organization": "full_info",
+            "candidate_count": 2,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.5333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 22,
+          "config": {
+            "schema_context": "linked_top10",
+            "generation_path": "divide_conquer_cot",
+            "fewshot_k": 5,
+            "fewshot_selector": "dail_selection",
+            "example_organization": "dail_qa_sql",
+            "candidate_count": 3,
+            "repair_policy": "sqlite_error_or_empty_once"
+          },
+          "accuracy": 0.5333333333333333,
+          "is_best": false
+        },
+        {
+          "trial_index": 23,
+          "config": {
+            "schema_context": "linked_top6",
+            "generation_path": "query_plan_cot",
+            "fewshot_k": 1,
+            "fewshot_selector": "masked_question_similarity",
+            "example_organization": "full_info",
+            "candidate_count": 3,
+            "repair_policy": "sqlite_error_once"
+          },
+          "accuracy": 0.5333333333333333,
+          "is_best": false
+        }
+      ]
+    },
+    "heldout": {
+      "scope": "heldout",
+      "n": 30,
+      "baseline": {
+        "correct": 6,
+        "total": 30,
+        "accuracy": 0.2,
+        "cost_usd": 0.011632
+      },
+      "optimized": {
+        "correct": 19,
+        "total": 30,
+        "accuracy": 0.633333,
+        "cost_usd": 0.154664
+      },
+      "delta": {
+        "accuracy_pp": 43.3333,
+        "correct": 13
+      }
+    },
+    "isolation": {
+      "scope": "isolation",
+      "n": 10,
+      "cards": [
+        {
+          "knob": "schema_context",
+          "baseline_value": "none",
+          "baseline_accuracy": 0.3,
+          "best_value": "full_ddl_fk",
+          "best_accuracy": 0.6,
+          "delta_pp": 30.0
+        },
+        {
+          "knob": "fewshot_k",
+          "baseline_value": 0,
+          "baseline_accuracy": 0.3,
+          "best_value": 0,
+          "best_accuracy": 0.3,
+          "delta_pp": 0.0
+        },
+        {
+          "knob": "generation_path",
+          "baseline_value": "direct_dail",
+          "baseline_accuracy": 0.3,
+          "best_value": "direct_dail",
+          "best_accuracy": 0.3,
+          "delta_pp": 0.0
+        },
+        {
+          "knob": "repair_policy",
+          "baseline_value": "off",
+          "baseline_accuracy": 0.3,
+          "best_value": "off",
+          "best_accuracy": 0.3,
+          "delta_pp": 0.0
+        }
+      ]
+    }
+  },
+  "limitations": [
+    "latency_not_measured",
+    "not_sota",
+    "not_statistical_significance"
+  ]
+}

--- a/src/pages/DemoGallery.jsx
+++ b/src/pages/DemoGallery.jsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import OptimizationTable from '../components/OptimizationTable';
+import { replayColumns, replayDemos } from '../data/demoArtifacts/replays';
+
+const formatPercent = (value) => `${new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+}).format(Number(value) * 100)}%`;
+
+const formatPp = (value) => new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+}).format(Number(value));
+
+const headlineFor = (dataset) => {
+  const heldout = dataset.frames.heldout;
+  return `${heldout.baseline.correct}/${heldout.baseline.total} = ${formatPercent(heldout.baseline.accuracy)} -> ${heldout.optimized.correct}/${heldout.optimized.total} = ${formatPercent(heldout.optimized.accuracy)} (+${formatPp(heldout.delta.accuracy_pp)}pp)`;
+};
+
+export default function DemoGallery() {
+  const [activeDemoId, setActiveDemoId] = useState(replayDemos[0].id);
+  const activeDemo = replayDemos.find((demo) => demo.id === activeDemoId) || replayDemos[0];
+
+  return (
+    <>
+      <Helmet>
+        <title>Real Optimization Replays | Traigent</title>
+        <meta
+          name="description"
+          content="Real fixed-slice optimization replays for BIRD, Spider, and HotpotQA using Bedrock Haiku artifacts."
+        />
+      </Helmet>
+      <main className="min-h-screen bg-[#080808] text-white">
+        <section className="px-4 py-12 sm:px-6 lg:px-8">
+          <div className="mx-auto max-w-7xl">
+            <div className="mb-8 max-w-3xl">
+              <p className="mb-3 text-xs font-bold uppercase tracking-[0.2em] text-[#4D8EF8]">
+                Real optimization replay gallery
+              </p>
+              <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+                Fixed-slice benchmark demos, separated by evidence scope.
+              </h1>
+              <p className="text-lg leading-relaxed text-slate-300">
+                Each card expands a three-frame replay: optimization search, held-out check, and isolation levers.
+                The limitations are shown in the replay for each benchmark.
+              </p>
+            </div>
+
+            <div className="mb-8 grid gap-4 md:grid-cols-3">
+              {replayDemos.map((demo) => {
+                const isActive = demo.id === activeDemo.id;
+                return (
+                  <button
+                    key={demo.id}
+                    type="button"
+                    onClick={() => setActiveDemoId(demo.id)}
+                    className={`rounded-lg border p-5 text-left transition-colors ${
+                      isActive
+                        ? 'border-[#4D8EF8] bg-[#4D8EF8]/12'
+                        : 'border-slate-800 bg-slate-950/60 hover:border-slate-600'
+                    }`}
+                  >
+                    <span className="mb-3 block text-xs font-bold uppercase tracking-[0.16em] text-slate-400">
+                      {demo.deck}
+                    </span>
+                    <strong className="mb-3 block text-2xl font-bold text-white">{demo.name}</strong>
+                    <span className="block font-mono text-sm leading-relaxed text-slate-300">
+                      {headlineFor(demo.dataset)}
+                    </span>
+                    <span className="mt-4 inline-flex rounded-md border border-slate-700 px-3 py-1 text-sm font-semibold text-slate-200">
+                      {isActive ? 'Showing replay' : 'Open replay'}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <OptimizationTable
+              dataset={activeDemo.dataset}
+              columns={replayColumns(activeDemo.dataset)}
+              demoLabel={activeDemo.label}
+              autoPlay={false}
+            />
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -19,6 +19,7 @@ import StartNowModal from "../components/StartNowModal";
 import ContactSection from "../components/ContactSection";
 import BlogHighlights from "../components/BlogHighlights";
 import { trackEvent } from "../lib/analytics";
+import { birdDemo, replayColumns } from "../data/demoArtifacts/replays";
 
 // Placeholder for the Button component
 const Button = ({ children, className, onClick, size }) => (
@@ -242,6 +243,21 @@ export default function Homepage() {
                   ))}
                 </ul>
               </div>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.24 }}
+              className="mt-8 mb-8"
+            >
+              <OptimizationTable
+                dataset={birdDemo.dataset}
+                columns={replayColumns(birdDemo.dataset)}
+                demoLabel={birdDemo.label}
+                autoPlay={true}
+                embedded={true}
+              />
             </motion.div>
 
 

--- a/src/pages/TableDemo.jsx
+++ b/src/pages/TableDemo.jsx
@@ -1,5 +1,13 @@
 import OptimizationTable from '../components/OptimizationTable';
+import { birdDemo, replayColumns } from '../data/demoArtifacts/replays';
 
 export default function TableDemo() {
-  return <OptimizationTable autoPlay={true} />;
+  return (
+    <OptimizationTable
+      dataset={birdDemo.dataset}
+      columns={replayColumns(birdDemo.dataset)}
+      demoLabel={birdDemo.label}
+      autoPlay={true}
+    />
+  );
 }

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "v-Traigent/traigent-web-fix/492-marketing-portal-links-2026-05-20-13:11",
+  "version": "v-Traigent/traigent-web-feature/real-optimization-web-demo-2026-06-02-20:58",
   "repo": "Traigent/traigent-web",
-  "branch": "fix/492-marketing-portal-links",
-  "buildTime": "2026-05-20-13:11"
+  "branch": "feature/real-optimization-web-demo",
+  "buildTime": "2026-06-02-20:58"
 }


### PR DESCRIPTION
## Real, data-driven optimization demo (BIRD / Spider / HotpotQA) — replaces the fake table

The marketing `OptimizationTable` showed hardcoded **fake** values (`gpt-5.1`, accuracy 45→90%,
synthetic cost/latency). This makes it **data-driven** and feeds it **real** values emitted from our
actual Bedrock optimization runs — no fabricated numbers.

### What changed
- **`OptimizationTable` is now data-driven** (`dataset` + `columns` props; Amir's animation preserved).
  The fake path is retained only as `LegacyOptimizationTable` for the pitch-deck slide; all public
  surfaces render real data.
- **`src/data/demoArtifacts/{bird,spider,hotpotqa}.v1.json`** — `traigent.optimization_replay.v1`
  artifacts emitted (by a TraigentDemo script) from committed run artifacts; `replays.js` loader.
- **Three SEPARATE, scope-labeled frames** per demo (never one flat mixed-scope table): optimization
  search (opt-mini, no cost/latency), held-out check (n=30, real Bedrock Haiku), isolation levers
  (n=10). Per-demo honest banner — `fixed slice · real Bedrock Haiku · not a SOTA claim` — plus the
  `limitations` list.
- **No `latency` anywhere** on the real-data path (it was never measured). Structural-knob columns
  (`schema_context`, `evidence_usage`, …) replace the fake `model/temperature/maxTokens/latency`.
- **New `/#/demos` gallery** (`DemoGallery.jsx`) — BIRD / Spider / HotpotQA selector, each expanding the
  3-frame replay. **Homepage hero** now shows the real **BIRD** replay, explicitly labeled.
- **`scripts/validate_replay.mjs`** (`npm run validate:replay`) asserts the contract: no `latency`
  key, held-out n=30, isolation n=10, `limitations` includes `not_sota`.

### Real held-out headlines (measured, fixed slice, not SOTA)
- BIRD mini-dev: **1/30 → 16/30 (+50.0pp)** · Spider: **6/30 → 19/30 (+43.3pp)** · HotpotQA RAG:
  **6/30 → 19/30 (+43.3pp)**. All Bedrock Claude Haiku 4.5 (Sonnet 4.6 confirm), each <$1.

### Verification
- `npm run build` ✓ · `npm run validate:replay` ✓ (all 3) · visually confirmed homepage hero +
  `/#/demos` gallery render real numbers with honest labels and the 3 separate frames.

### PR checklist
1. Worst-case prod path — N/A (static marketing site; no policy surface).
2. Production-branch test — N/A; replay contract validated by `validate_replay.mjs`.
3. Contract regeneration — none (the replay JSON is emitted from committed demo artifacts; emitter
   ships in a TraigentDemo PR).
4. Public surface delta — new `/#/demos` route + data-driven table; homepage hero now real (labeled).
5. Review threads — none yet; will resolve before merge.
6. Quality gates — none relaxed (no new deps; only a `validate:replay` script added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
