### PR TITLE
polish(story): landing on Act 1 end + headlines + speed tweaks

### DIFF
--- a/src/lib/GuidedTour.jsx
+++ b/src/lib/GuidedTour.jsx
@@ -20,7 +20,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { motion } from "framer-motion";
 
-const SCROLL_SETTLE_MS = 650;
+const SCROLL_SETTLE_MS = 400;
 
 function findClickTarget(el) {
   // If the marker is on a wrapper, find the innermost clickable inside.
@@ -38,7 +38,15 @@ export default function GuidedTour({ active, steps, onComplete }) {
   useEffect(() => {
     if (!active) return undefined;
     if (stepIdx >= steps.length) {
-      const t = setTimeout(() => onComplete?.(), 200);
+      // Tour finished. Fire onComplete and CLEAR the highlight/cursor so
+      // the page settles into its static end state — otherwise the cursor
+      // + yellow box would sit on the last target indefinitely and the
+      // tour's end-frame would differ from a "final state" jump.
+      const t = setTimeout(() => {
+        onComplete?.();
+        setRect(null);
+        setCursorPos(null);
+      }, 200);
       return () => clearTimeout(t);
     }
     const step = steps[stepIdx];

--- a/src/pages/KnobExplorer.jsx
+++ b/src/pages/KnobExplorer.jsx
@@ -5,7 +5,7 @@
 // color-coded pills so the user can see which knobs are worth tuning.
 //
 // Reachable via the hidden ▸ menu in TopNav.
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { motion } from "framer-motion";
@@ -33,61 +33,61 @@ import GuidedTour from "../lib/GuidedTour";
 // Product: 5×4×3×3×3×3×3×2 = 9,720; ×6 models = 58,320.
 const BIRD_TOUR_STEPS = [
   // Intro: orient on the controls (no clicks)
-  { selector: '[data-tour="legend"]',       dwellMs: 1700 },
-  { selector: '[data-tour="counter"]',      dwellMs: 1700 },
-  { selector: '[data-tour="sort-toggle"]',  dwellMs: 1500 },
+  { selector: '[data-tour="legend"]',       dwellMs: 1100 },
+  { selector: '[data-tour="counter"]',      dwellMs: 1100 },
+  { selector: '[data-tour="sort-toggle"]',  dwellMs: 1000 },
 
   // Expand OpenAI; select GPT-4o and GPT-4o mini (highlight: full grid row)
-  { selector: '[data-tour="vendor-OpenAI"]', click: true, dwellMs: 700 },
+  { selector: '[data-tour="vendor-OpenAI"]', click: true, dwellMs: 400 },
   { selector: '[data-tour="vendor-grid-OpenAI"]',
-    clickSelector: '[data-tour="model-gpt-4o"]',     dwellMs: 700 },
+    clickSelector: '[data-tour="model-gpt-4o"]',     dwellMs: 400 },
   { selector: '[data-tour="vendor-grid-OpenAI"]',
-    clickSelector: '[data-tour="model-gpt-4o-mini"]', dwellMs: 700 },
+    clickSelector: '[data-tour="model-gpt-4o-mini"]', dwellMs: 400 },
 
   // Expand Anthropic; select Sonnet + Haiku
-  { selector: '[data-tour="vendor-Anthropic"]', click: true, dwellMs: 700 },
+  { selector: '[data-tour="vendor-Anthropic"]', click: true, dwellMs: 400 },
   { selector: '[data-tour="vendor-grid-Anthropic"]',
-    clickSelector: '[data-tour="model-claude-3.5-sonnet"]', dwellMs: 700 },
+    clickSelector: '[data-tour="model-claude-3.5-sonnet"]', dwellMs: 400 },
   { selector: '[data-tour="vendor-grid-Anthropic"]',
-    clickSelector: '[data-tour="model-claude-3.5-haiku"]',  dwellMs: 700 },
+    clickSelector: '[data-tour="model-claude-3.5-haiku"]',  dwellMs: 400 },
 
   // Expand Google; select Gemini Flash
-  { selector: '[data-tour="vendor-Google"]', click: true, dwellMs: 700 },
+  { selector: '[data-tour="vendor-Google"]', click: true, dwellMs: 400 },
   { selector: '[data-tour="vendor-grid-Google"]',
-    clickSelector: '[data-tour="model-gemini-1.5-flash"]', dwellMs: 700 },
+    clickSelector: '[data-tour="model-gemini-1.5-flash"]', dwellMs: 400 },
 
   // Expand Meta; select Llama 70B
-  { selector: '[data-tour="vendor-Meta"]', click: true, dwellMs: 700 },
+  { selector: '[data-tour="vendor-Meta"]', click: true, dwellMs: 400 },
   { selector: '[data-tour="vendor-grid-Meta"]',
-    clickSelector: '[data-tour="model-llama-3.1-70b"]', dwellMs: 700 },
+    clickSelector: '[data-tour="model-llama-3.1-70b"]', dwellMs: 400 },
 
-  // Enable 12 knobs to multiply the search space toward ~8.4M.
   // For few-shot-k we ALSO demo value clicks (deselect 10, reselect 10) so
   // the viewer sees value-level interaction. The other knobs use defaults.
   { selector: '[data-tour="knob-row-few-shot-k"]',
-    clickSelector: '[data-tour="knob-toggle-few-shot-k"]', dwellMs: 600 },
+    clickSelector: '[data-tour="knob-toggle-few-shot-k"]', dwellMs: 400 },
   { selector: '[data-tour="knob-row-few-shot-k"]',
-    clickSelector: '[data-tour="value-few-shot-k-10"]',    dwellMs: 450 },
+    clickSelector: '[data-tour="value-few-shot-k-10"]',    dwellMs: 350 },
   { selector: '[data-tour="knob-row-few-shot-k"]',
-    clickSelector: '[data-tour="value-few-shot-k-10"]',    dwellMs: 450 },
+    clickSelector: '[data-tour="value-few-shot-k-10"]',    dwellMs: 350 },
 
   { selector: '[data-tour="knob-row-example-selection"]',
-    clickSelector: '[data-tour="knob-toggle-example-selection"]', dwellMs: 500 },
+    clickSelector: '[data-tour="knob-toggle-example-selection"]', dwellMs: 350 },
   { selector: '[data-tour="knob-row-cot"]',
-    clickSelector: '[data-tour="knob-toggle-cot"]', dwellMs: 500 },
+    clickSelector: '[data-tour="knob-toggle-cot"]', dwellMs: 350 },
   { selector: '[data-tour="knob-row-self-consistency"]',
-    clickSelector: '[data-tour="knob-toggle-self-consistency"]', dwellMs: 500 },
+    clickSelector: '[data-tour="knob-toggle-self-consistency"]', dwellMs: 350 },
   { selector: '[data-tour="knob-row-self-correction"]',
-    clickSelector: '[data-tour="knob-toggle-self-correction"]', dwellMs: 500 },
+    clickSelector: '[data-tour="knob-toggle-self-correction"]', dwellMs: 350 },
   { selector: '[data-tour="knob-row-decomposition"]',
-    clickSelector: '[data-tour="knob-toggle-decomposition"]', dwellMs: 500 },
+    clickSelector: '[data-tour="knob-toggle-decomposition"]', dwellMs: 350 },
   { selector: '[data-tour="knob-row-reflection"]',
-    clickSelector: '[data-tour="knob-toggle-reflection"]', dwellMs: 500 },
+    clickSelector: '[data-tour="knob-toggle-reflection"]', dwellMs: 350 },
   { selector: '[data-tour="knob-row-tool-execution"]',
-    clickSelector: '[data-tour="knob-toggle-tool-execution"]', dwellMs: 500 },
+    clickSelector: '[data-tour="knob-toggle-tool-execution"]', dwellMs: 350 },
 
-  // Outro — pan back to the counter to land on the big config number.
-  { selector: '[data-tour="counter"]', dwellMs: 1000 },
+  // Outro — pan back to the counter to land on 58,320 and hold for 2s so
+  // the viewer reads the headline figure before Act 3 takes over.
+  { selector: '[data-tour="counter"]', dwellMs: 2000 },
 ];
 
 // =============================================================================
@@ -661,6 +661,16 @@ export default function KnobExplorer() {
   const showFinal = searchParams.get("final") === "1";
   useRemoveChatWidget();
 
+  // STABLE callback for GuidedTour — an inline arrow here would change every
+  // render. GuidedTour's effect depends on onComplete identity, and the tour
+  // updates state on every click (selectedModels / knobValues / expandedVendors),
+  // which re-renders KnobExplorer. An unstable callback would make the effect
+  // re-run mid-step and RE-FIRE the current step's click, producing the
+  // open/close cycle on OpenAI we saw.
+  const handleTourComplete = useCallback(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, []);
+
   // Set of vendor names currently expanded in the Models section. Lifted here
   // so the grid wrapper can apply col-span-full to expanded cells. Default
   // matches BIRD final state when ?guided=BIRD&final=1 so the model section
@@ -773,7 +783,11 @@ export default function KnobExplorer() {
         <meta name="robots" content="noindex" />
       </Helmet>
       <ChatKillerStyle />
-      <GuidedTour active={guided === "BIRD" && !showFinal} steps={BIRD_TOUR_STEPS} />
+      <GuidedTour
+        active={guided === "BIRD" && !showFinal}
+        steps={BIRD_TOUR_STEPS}
+        onComplete={handleTourComplete}
+      />
 
       <section className="bg-[#080808] text-white min-h-screen py-10 md:py-14">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/pages/OptimizationDemo.jsx
+++ b/src/pages/OptimizationDemo.jsx
@@ -607,8 +607,11 @@ export default function OptimizationDemo() {
   const showFinal = searchParams.get("final") === "1";
   useRemoveChatWidget();
 
-  const [scene, setScene] = useState(0);          // 0 = idle / not started
-  const [isPlaying, setIsPlaying] = useState(false);
+  // When ?autostart=1 is set (the /story embed case), initialize state
+  // directly to scene 1 + playing so the idle "Start" screen never flashes
+  // and there's no autostart-delay dead time at the head of the demo.
+  const [scene, setScene] = useState(autostart && !showFinal ? 1 : 0);
+  const [isPlaying, setIsPlaying] = useState(autostart && !showFinal);
   const [speedMultiplier, setSpeedMultiplier] = useState(initialSpeed);
   const [phase1Visible, setPhase1Visible] = useState(0);
   const [phase2Visible, setPhase2Visible] = useState(0);
@@ -630,13 +633,10 @@ export default function OptimizationDemo() {
     setIsPlaying(true);
   }, [reset]);
 
-  // Autostart on mount when ?autostart=1 (used when /demo is embedded in /story).
-  useEffect(() => {
-    if (!autostart) return;
-    if (showFinal) return; // showFinal takes precedence, skips auto-play
-    const t = setTimeout(() => start(), 400);
-    return () => clearTimeout(t);
-  }, [autostart, start, showFinal]);
+  // Autostart is handled by the useState initializers above (scene=1,
+  // isPlaying=true on mount when ?autostart=1). No separate effect needed —
+  // the previous setTimeout(start, 400) added ~1s of dead time at the head
+  // of the embedded demo.
 
   // ?final=1 → jump straight to the terminal state on mount: Scene 5 with
   // every Phase-1 and Phase-2 trial revealed and the winners card visible.

--- a/src/pages/StoryMovie.jsx
+++ b/src/pages/StoryMovie.jsx
@@ -328,6 +328,12 @@ function Act5Punch({ startAtEnd = false, paused = false }) {
   const handleNarrationComplete = useCallback(() => setNarrationDone(true), []);
   return (
     <div className="w-full h-full flex flex-col items-center justify-center px-8 md:px-16">
+      {/* Fixed "The Win" headline — same treatment as Act 1's "The Problem"
+          and Act 3's "What everyone wants", with an emerald accent that
+          thematically signals success. */}
+      <h1 className="text-3xl md:text-5xl lg:text-6xl font-bold text-emerald-300 tracking-tight mb-6 md:mb-8">
+        The Win
+      </h1>
       {/* Narration + tagline + buttons sit in a single column centered
           vertically as one group. The tagline/buttons block reserves its
           layout space from the start (rendered with opacity 0 until the
@@ -335,7 +341,9 @@ function Act5Punch({ startAtEnd = false, paused = false }) {
           when the buttons fade in. */}
       <Narration
         sentences={ACT_5_SENTENCES}
-        wpm={315}
+        wpm={470}
+        rowPauseMs={70}
+        sentencePauseMs={270}
         onComplete={handleNarrationComplete}
         noWrapper
         paused={paused}
@@ -422,10 +430,34 @@ function Act1Problem({ onComplete, paused, startAtEnd }) {
 }
 
 const ACT_3_SENTENCES = [
-  ["We want to rapidly find", "the optimal accuracy"],
-  ["Then we want similar accuracies", "but with much lower LLM costs"],
+  ["Rapidly find the best accuracy"],
+  ["Then find similar accuracies", "but with much lower LLM costs"],
   ["Let's see how Traigent", "does this automatically."],
 ];
+
+// Act 3 wrapper — fixed "What everyone wants" headline at the top, with
+// the narration centered below as one vertically-centered group. Mirrors
+// Act1Problem's structure but with a sky-blue accent (aspirational vs
+// rose's "problem" signal).
+function Act3Want({ onComplete, paused, startAtEnd }) {
+  return (
+    <div className="w-full h-full flex flex-col items-center justify-center px-8 md:px-16">
+      <h1 className="text-3xl md:text-5xl lg:text-6xl font-bold text-sky-300 tracking-tight mb-6 md:mb-8">
+        What everyone wants
+      </h1>
+      <Narration
+        sentences={ACT_3_SENTENCES}
+        wpm={470}
+        rowPauseMs={70}
+        sentencePauseMs={270}
+        onComplete={onComplete}
+        paused={paused}
+        startAtEnd={startAtEnd}
+        noWrapper
+      />
+    </div>
+  );
+}
 
 // Render signature: (onComplete, restart, opts) where opts may carry
 // { paused: bool, showFinal: bool } for the playback controls.
@@ -445,11 +477,11 @@ const ACTS = [
   {
     id: 2,
     label: "The config space",
-    durationMs: 35_000,
+    durationMs: 24_500,
     render: (onComplete, _restart, opts = {}) => (
       <EmbeddedAct
         src={`/#/knob-explorer?guided=BIRD&chrome=hidden${opts.showFinal ? "&final=1" : ""}`}
-        durationMs={35_000}
+        durationMs={24_500}
         title="Knob space — BIRD configuration"
         onComplete={onComplete}
         paused={opts.paused}
@@ -462,9 +494,7 @@ const ACTS = [
     label: "The want",
     durationMs: 20_000,
     render: (onComplete, _restart, opts = {}) => (
-      <Narration
-        sentences={ACT_3_SENTENCES}
-        wpm={315}
+      <Act3Want
         onComplete={onComplete}
         paused={opts.paused}
         startAtEnd={opts.showFinal}
@@ -504,15 +534,25 @@ const ACTS = [
 // Page
 // =============================================================================
 
+// Initial landing state — the page opens directly on the end-frame of
+// Act 1 (paused, all narration revealed). This makes the page immediately
+// content-rich (no "click to start" idle screen) so a LinkedIn or social
+// visitor lands inside the story rather than on a splash. Restart-from-top
+// returns to this same state.
+const INITIAL_ACT = 1;
+const INITIAL_PAUSED = true;
+const INITIAL_SHOW_FINAL = true;
+
 export default function StoryMovie() {
-  // currentAct: 0 = idle (haven't started), 1..5 = act in progress, 6 = done.
-  const [currentAct, setCurrentAct] = useState(0);
-  const [isPaused, setIsPaused] = useState(false);
+  // currentAct: 0 = idle / splash (no longer the default — reachable only
+  // if something explicitly sets it back to 0), 1..5 = act in progress.
+  const [currentAct, setCurrentAct] = useState(INITIAL_ACT);
+  const [isPaused, setIsPaused] = useState(INITIAL_PAUSED);
   // True when the current act should render in its FINAL frame (all narration
   // rows revealed for text acts; iframe page in its terminal state for
   // embedded acts). Set when the user clicks an "End Act N" button. Cleared
   // on any natural advance.
-  const [showFinalState, setShowFinalState] = useState(false);
+  const [showFinalState, setShowFinalState] = useState(INITIAL_SHOW_FINAL);
   // Elapsed ms in the current act — drives the per-act progress fill on the
   // controls bar.
   const [actElapsedMs, setActElapsedMs] = useState(0);
@@ -534,13 +574,15 @@ export default function StoryMovie() {
     setCurrentAct(0);
     setTimeout(() => setCurrentAct(1), 100);
   }, []);
-  // "Restart from the top" — returns to the idle screen (the big Play button).
+  // "Restart from the top" — returns to the initial end-of-Act-1 landing
+  // state (paused, all narration revealed). Same shape as the page's first
+  // mount.
   const restartFromTop = useCallback(() => {
     advancingRef.current = false;
-    setIsPaused(false);
-    setShowFinalState(false);
+    setIsPaused(INITIAL_PAUSED);
+    setShowFinalState(INITIAL_SHOW_FINAL);
     setActElapsedMs(0);
-    setCurrentAct(0);
+    setCurrentAct(INITIAL_ACT);
   }, []);
 
   const advance = useCallback(() => {
@@ -711,6 +753,37 @@ export default function StoryMovie() {
             {/* Act indicator */}
             <div className="absolute top-4 right-4 text-[10px] font-mono uppercase tracking-widest text-slate-600 z-50">
               Act {act.id} / {ACTS.length} · {act.label}
+            </div>
+          </div>
+        )}
+
+        {/* Landing-state hint — shown only when sitting on Act 1's end frame
+            (the default initial state). Cues the viewer toward the controls
+            bar so they know they can play through or jump straight to any
+            scene. Hides as soon as anything else happens. */}
+        {currentAct === 1 && isPaused && showFinalState && (
+          <div className="absolute bottom-30 left-0 right-0 z-40 flex justify-center pointer-events-none px-4" style={{ bottom: "7.5rem" }}>
+            <div className="pointer-events-auto inline-flex items-center gap-2.5 md:gap-3 px-3 md:px-4 py-2 md:py-2.5 rounded-full bg-yellow-400/20 border border-yellow-400/70 backdrop-blur">
+              <span className="text-base md:text-xl text-white font-medium">
+                {/* A real, clickable play button — same handler as the bottom-
+                    bar Play. Solid blue so it pops against the yellow pill
+                    background as the obvious next action. */}
+                <button
+                  type="button"
+                  onClick={togglePause}
+                  className="inline-flex items-center gap-1 mr-1.5 px-2.5 py-0.5 rounded-full bg-[#1A6BF5] hover:bg-[#4D8EF8] text-white font-bold transition-colors shadow-lg shadow-blue-500/40 align-baseline"
+                >
+                  <Play className="w-3.5 h-3.5 md:w-4 md:h-4 fill-white" />
+                  play
+                </button>
+                or jump directly to scenes
+              </span>
+              <span
+                className="text-2xl md:text-3xl text-yellow-200 font-bold animate-bounce"
+                style={{ filter: "drop-shadow(0 0 12px rgba(250, 204, 21, 0.8))" }}
+              >
+                ↓
+              </span>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
Follow-up polish on the /story walkthrough that shipped in #59. Headline changes:

- **Page lands directly on Act 1's end-frame** (paused, narration revealed). No more 'click to start' splash. ↺ Restart returns to the same state.
- **Floating yellow pill** on the landing slide with a real, clickable ▶ play button.
- **Headlines added** on Act 3 ('What everyone wants', sky) and Act 5 ('The Win', emerald).
- **Acts 3 and 5 narration ~50% faster** (wpm 315 → 470, pauses shortened).
- **~1s of dead time removed** at Act 4's head (initialize demo state to scene 1 + playing on mount instead of waiting 400ms + transitioning).
- **GuidedTour cleanup**: highlight + cursor clear on completion; KnobExplorer scrolls to top so the played-tour end frame matches the ?final=1 jump frame.
- **Bug fix**: `handleTourComplete` wrapped in useCallback (an unstable inline arrow was making the tour re-fire the current step's click → OpenAI open/close loop).
- **Act 2 duration tightened** (35s → 24.5s — tour runs faster, 2s dwell on 58,320 preserved).
- Copy polish across the controls bar labels, hint pill, narration text, and idle subtitle.

## Test plan
- [ ] `/#/story` loads directly on Act 1's end-frame (no idle splash)
- [ ] Yellow hint pill is visible with clickable ▶ play button
- [ ] Click the inline ▶ play → advances to Act 2 and plays
- [ ] Act 2 plays through smoothly; ends with sticky 58,320 counter, no lingering cursor
- [ ] Button 2 (jump to end of Act 2) and end-of-played-Act-2 look identical
- [ ] Act 3 has 'What everyone wants' headline (sky-300, smaller font)
- [ ] Act 4 starts immediately with Scene 1 weights (no 1s blank)
- [ ] Act 5 has 'The Win' headline (emerald-300); narration zips by ~50% faster than Act 1's
- [ ] Restart-from-top (↺) returns to Act 1's end-frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)