### PR TITLE
feat(web): terminal installer — auditable install.sh + Get Started CTA flip

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,3 +1,6 @@
 /*
   Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://forms.hubspot.com; script-src 'self' https://www.googletagmanager.com https://*.clarity.ms https://*.hs-scripts.com https://*.hs-analytics.net https://*.hs-banner.com https://*.hscollectedforms.net https://*.hubspot.com https://*.hsforms.net https://*.hsforms.com https://*.hubapi.com https://*.usemessages.com https://*.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com https://*.hubspot.com https://*.usemessages.com; connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://*.clarity.ms https://*.hubspot.com https://*.hs-analytics.net https://*.hs-banner.com https://*.hscollectedforms.net https://*.hsforms.com https://*.hubapi.com https://*.usemessages.com wss://*.hubspot.com wss://*.usemessages.com https://*.posthog.com; frame-src https://*.hubspot.com https://*.usemessages.com https://*.hsforms.com; upgrade-insecure-requests
 
+/install.sh
+  Content-Type: text/x-shellscript; charset=utf-8
+  X-Content-Type-Options: nosniff

--- a/public/_headers
+++ b/public/_headers
@@ -1,6 +1,0 @@
-/*
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://forms.hubspot.com; script-src 'self' https://www.googletagmanager.com https://*.clarity.ms https://*.hs-scripts.com https://*.hs-analytics.net https://*.hs-banner.com https://*.hscollectedforms.net https://*.hubspot.com https://*.hsforms.net https://*.hsforms.com https://*.hubapi.com https://*.usemessages.com https://*.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com https://*.hubspot.com https://*.usemessages.com; connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://*.clarity.ms https://*.hubspot.com https://*.hs-analytics.net https://*.hs-banner.com https://*.hscollectedforms.net https://*.hsforms.com https://*.hubapi.com https://*.usemessages.com wss://*.hubspot.com wss://*.usemessages.com https://*.posthog.com; frame-src https://*.hubspot.com https://*.usemessages.com https://*.hsforms.com; upgrade-insecure-requests
-
-/install.sh
-  Content-Type: text/x-shellscript; charset=utf-8
-  X-Content-Type-Options: nosniff

--- a/public/agent.md
+++ b/public/agent.md
@@ -136,15 +136,15 @@ If a catalog entry is guidance rather than executable wiring, branch manually on
 
 ```bash
 traigent onboard
-traigent auth device-login
+traigent auth device-login  # if available; otherwise traigent auth login (API key from portal.traigent.ai); TRAIGENT_API_KEY works non-interactively
 ```
 
-For backend access in non-interactive environments, use `TRAIGENT_API_KEY`.
+For backend access, prefer `traigent auth device-login` when the installed SDK has it; otherwise use `traigent auth login` and paste an API key from `portal.traigent.ai`; `TRAIGENT_API_KEY` works in both paths for non-interactive environments.
 
 12. Use the appropriate algorithm and mode.
     - `random`: local.
     - `grid`: local.
-    - `tpe`: backend hybrid, with `traigent auth device-login` or `TRAIGENT_API_KEY`.
+    - `tpe`: backend hybrid, with `traigent auth device-login` if available; otherwise `traigent auth login` (API key from `portal.traigent.ai`); `TRAIGENT_API_KEY` works in both paths for non-interactive use.
 
 13. Read completed trials from the result table.
 
@@ -210,7 +210,7 @@ Draft evidence may support integration work. It does not certify improvement.
 4. Use a fresh interpreter/process after mock mode before real execution.
 5. Use large `timeout` values for real optimization so the run is not silently truncated.
 6. Prefer local `random` or `grid` until the evaluator is stable.
-7. Use backend hybrid `tpe` only when authenticated with `traigent auth device-login` or `TRAIGENT_API_KEY`.
+7. Use backend hybrid `tpe` only when authenticated with `traigent auth device-login` if available; otherwise `traigent auth login` (API key from `portal.traigent.ai`); `TRAIGENT_API_KEY` works in both paths for non-interactive use.
 8. Keep provider API keys out of code, docs, diffs, and logs.
 9. Keep baseline, optimization, rerank, and held-out evidence separate.
 10. Read reporting data from `result.to_dataframe()`.
@@ -239,6 +239,6 @@ The following are rolling out and must not be assumed available everywhere:
 
 1. `traigent mcp` local MCP server.
 2. Backend-generated example datasets.
-3. Free self-service signup plus device-login general availability.
+3. Free self-service signup and device-login general availability are rolling out; device-login exists in newer SDKs, so check `traigent auth device-login --help` before relying on it.
 
 This file is versioned. If SDK behavior changes, update this playbook with the new current surface.

--- a/public/agent.md
+++ b/public/agent.md
@@ -1,0 +1,244 @@
+# Traigent Coding-Agent Playbook
+
+Version: v1
+Date: 2026-06-05
+Audience: hosted coding agents reading this at runtime
+
+Traigent optimizes agent behavior by evaluating candidate configurations against a task-local dataset.
+It is useful only when the evaluator, tunable configuration space, cost controls, and evidence loop are
+real enough to support an honest decision.
+
+## Prime Directives
+
+1. Dry-run first. Validate the dataset, wiring, and result path in mock mode before any real run.
+2. Never spend real model tokens without explicit human approval for this run.
+3. Make only honest, task-local claims. Report "on this dataset slice", not universal improvement.
+4. Treat scaffolded evals as drafts until a human approves or replaces them.
+5. Finish with evidence, changed files, test results, cost spent, and a PR-ready summary.
+
+The `traigent first-prompt` command points coding agents here. Read this guide before changing code.
+
+## Decision Tree
+
+Start by answering one question:
+
+Does this project already have an evaluation dataset?
+
+If yes, use Track A.
+If no, use Track B.
+
+## Track A: Project Has An Eval
+
+1. Locate the evaluation source.
+   - Pytest goldens: tests that compare outputs to expected values.
+   - Promptfoo: prompt/eval cases with expected outputs or assertions.
+   - CSV: rows with inputs and labels, targets, scores, or expected answers.
+   - JSONL: one example per line.
+   - Existing application fixtures, golden files, or replay logs.
+
+2. Convert the source to Traigent JSONL.
+
+```jsonl
+{"input": {"question": "What is the refund policy?"}, "output": "refund policy answer"}
+{"input": {"ticket": "I was charged twice"}, "output": "billing"}
+```
+
+Use structured `input` values when the application needs more than one field.
+Preserve the expected answer, class, score target, or assertion payload in `output`.
+Keep provenance notes: file path, fixture source, owner, date, and whether the data is user-provided.
+
+3. Validate the dataset.
+
+```bash
+traigent validate eval.jsonl
+```
+
+Do not optimize until validation passes.
+
+4. Detect tunables already present in the code.
+   - Model, provider, temperature, top-p, max tokens.
+   - Prompt template, system message, examples, tool instructions.
+   - Retrieval depth, retriever, context order, evidence filters.
+   - Schema context, routing, self-consistency, repair policy, generation path.
+   - Any runtime branch that could be controlled by `cfg = traigent.get_config()`.
+
+5. Ask Traigent for catalog-backed recommendations.
+
+```bash
+traigent recommend
+```
+
+For Python code, prefer:
+
+```python
+configuration_space = traigent.recommend_configuration_space(agent_type)
+```
+
+Use the current catalog families when they match the task:
+`code_gen` and `rag`.
+
+6. Wire the optimizer.
+
+```python
+import traigent
+
+configuration_space = {
+    "model": ["gpt-4o-mini", "gpt-4o"],
+    "retrieval_k": [2, 4, 8],
+}
+
+@traigent.optimize(
+    configuration_space=configuration_space,
+    eval_dataset="eval.jsonl",
+    objectives=["accuracy", "cost"],
+    algorithm="random",
+    max_trials=4,
+    execution_mode="local",
+)
+async def answer(example):
+    cfg = traigent.get_config()
+    return await run_agent(
+        example["input"],
+        model=cfg["model"],
+        retrieval_k=cfg["retrieval_k"],
+    )
+```
+
+Every structural knob must change real runtime behavior. Declaring a knob is not enough.
+If a catalog entry is guidance rather than executable wiring, branch manually on `cfg`.
+
+7. Run a baseline on the eval.
+   - Use the current production/default configuration.
+   - Record dataset size, metric definitions, cost if any, and failures.
+   - Keep this separate from optimization results.
+
+8. Run mock optimization at zero cost.
+   - Use `traigent quickstart` for the packaged mock path when starting from the CLI.
+   - Use `execution_mode="local"` and `algorithm="random"` or `algorithm="grid"` for local checks.
+   - Keep `max_trials` small until the pipeline is proven.
+   - Confirm the decorated function runs, scores, and returns usable result tables.
+
+9. Estimate real cost.
+   - Upper bound: `max_trials * eval_rows * model_calls_per_example`.
+   - Include reruns, retries, held-out checks, and provider price assumptions.
+   - State the configured `TRAIGENT_RUN_COST_LIMIT`.
+
+10. Stop for human approval.
+    - Show the mock result and cost estimate.
+    - Ask for explicit go/no-go before any paid run.
+    - Do not infer approval from vague acceptance.
+
+11. Run the real optimization only after approval.
+    - Set the run cost limit.
+    - Set `TRAIGENT_COST_APPROVED=true`.
+    - Use fresh process state after mock mode.
+    - Authenticate if backend-backed algorithms are needed.
+
+```bash
+traigent onboard
+traigent auth device-login
+```
+
+For backend access in non-interactive environments, use `TRAIGENT_API_KEY`.
+
+12. Use the appropriate algorithm and mode.
+    - `random`: local.
+    - `grid`: local.
+    - `tpe`: backend hybrid, with `traigent auth device-login` or `TRAIGENT_API_KEY`.
+
+13. Read completed trials from the result table.
+
+```python
+result = await answer.optimize(
+    algorithm="tpe",
+    max_trials=80,
+    timeout=1800.0,
+)
+trials_df = result.to_dataframe()
+```
+
+Use `result.to_dataframe()` as the source of record for reporting.
+
+14. Check held-out performance.
+    - Keep a held-out slice separate from the optimization slice whenever possible.
+    - Compare baseline vs optimized on that held-out slice.
+    - Report failures, excluded rows, and sample counts.
+
+15. Inspect and export results.
+
+```bash
+traigent results list
+traigent results show
+traigent results compare
+traigent results rerank
+traigent export
+```
+
+## Track B: No Eval Yet
+
+1. Do not run paid optimization.
+2. Ask the user for 15-30 representative input/output examples.
+3. If the user cannot provide examples yet, scaffold a draft JSONL from the codebase.
+4. Mark the dataset provenance as `draft`.
+5. Mark all downstream measurements as `DRAFT EVIDENCE`.
+6. Validate the draft dataset with `traigent validate eval.jsonl`.
+7. Wire the decorator and config space as in Track A.
+8. Run mock-only checks to prove the plumbing.
+9. Stop and ask the human to approve or replace the dataset.
+10. Never run paid optimization on an unapproved eval.
+
+Draft evidence may support integration work. It does not certify improvement.
+
+## Honesty Rules
+
+1. Impacts are task-dependent.
+2. Say "on this eval slice" or "on this held-out slice".
+3. Do not claim universal gains, SOTA, or model superiority from one local run.
+4. Do not claim a single knob caused the gain unless held-out evidence isolates that effect.
+5. Report the selected configuration jointly: dataset, model family, wiring, objectives, and search mode.
+6. Generated evals never certify improvement until user-approved data is used.
+7. Mock scores prove plumbing only. They are not product evidence.
+8. If a run has too few trials, call variable attribution directional.
+9. If rows were removed, failed, retried, or manually scored, say so.
+10. If evidence is absent, stale, or unapproved, report the work as not ready.
+
+## Operational Guardrails
+
+1. Set `TRAIGENT_RUN_COST_LIMIT` before any real run.
+2. Set `TRAIGENT_COST_APPROVED=true` only after the user approves this run.
+3. Start a fresh study directory per run if your integration sets one.
+4. Use a fresh interpreter/process after mock mode before real execution.
+5. Use large `timeout` values for real optimization so the run is not silently truncated.
+6. Prefer local `random` or `grid` until the evaluator is stable.
+7. Use backend hybrid `tpe` only when authenticated with `traigent auth device-login` or `TRAIGENT_API_KEY`.
+8. Keep provider API keys out of code, docs, diffs, and logs.
+9. Keep baseline, optimization, rerank, and held-out evidence separate.
+10. Read reporting data from `result.to_dataframe()`.
+
+## Finish-Line Contract
+
+When you finish, deliver:
+
+1. Decorated function path and the final `configuration_space`.
+2. Every `cfg = traigent.get_config()` branch you wired.
+3. Eval dataset path and provenance: user-provided, existing project eval, or draft scaffold.
+4. Baseline metrics and optimized metrics on the optimization slice.
+5. Baseline vs optimized metrics on held-out data, if available.
+6. Total cost spent and configured cost limit.
+7. Significant tuned variables ranking, if available, with confidence labels.
+8. Changed files.
+9. Test commands and results.
+10. PR-ready summary with open risks and whether human approval is still required.
+
+Use the significant tuned variables report for post-run attribution when trials are available.
+Keep the language observational: "in this run, on this slice".
+
+## Capabilities Not Yet Available
+
+The following are rolling out and must not be assumed available everywhere:
+
+1. `traigent mcp` local MCP server.
+2. Backend-generated example datasets.
+3. Free self-service signup plus device-login general availability.
+
+This file is versioned. If SDK behavior changes, update this playbook with the new current surface.

--- a/public/install.sh
+++ b/public/install.sh
@@ -15,15 +15,79 @@ has() {
 }
 
 : "${HOME:?HOME is required}"
-PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+ORIGINAL_PATH="${PATH:-}"
+PATH="$HOME/.local/bin:$HOME/.cargo/bin${ORIGINAL_PATH:+:$ORIGINAL_PATH}"
 export PATH
 
-PACKAGE="traigent"
+# Keep the installer default aligned with the packaged quickstart dependencies.
+# Switch this to traigent[recommended] once that extras bundle ships.
+PACKAGE="traigent[integrations]"
 if [ -n "${TRAIGENT_VERSION:-}" ]; then
-  PACKAGE="traigent==${TRAIGENT_VERSION}"
+  PACKAGE="traigent[integrations]==${TRAIGENT_VERSION}"
 fi
 
-install_uv() {
+ATTEMPT_SUMMARY=""
+INSTALL_BIN_DIR=""
+
+append_attempt_summary() {
+  if [ -n "$ATTEMPT_SUMMARY" ]; then
+    ATTEMPT_SUMMARY="${ATTEMPT_SUMMARY}
+  - $*"
+  else
+    ATTEMPT_SUMMARY="  - $*"
+  fi
+}
+
+prepend_path() {
+  CURRENT_PATH="${PATH:-}"
+  PATH="$1${CURRENT_PATH:+:$CURRENT_PATH}"
+  export PATH
+}
+
+path_has_dir() {
+  case ":$ORIGINAL_PATH:" in
+    *":$1:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+uv_tool_bin_dir() {
+  if [ -n "${UV_TOOL_BIN_DIR:-}" ]; then
+    printf '%s\n' "$UV_TOOL_BIN_DIR"
+    return 0
+  fi
+
+  UV_BIN_DIR="$(uv tool dir --bin 2>/dev/null || true)"
+  if [ -n "$UV_BIN_DIR" ]; then
+    printf '%s\n' "$UV_BIN_DIR"
+  else
+    printf '%s/.local/bin\n' "$HOME"
+  fi
+}
+
+pipx_bin_dir() {
+  if [ -n "${PIPX_BIN_DIR:-}" ]; then
+    printf '%s\n' "$PIPX_BIN_DIR"
+  else
+    printf '%s/.local/bin\n' "$HOME"
+  fi
+}
+
+guard_root() {
+  # TRAIGENT_ALLOW_ROOT=1 overrides this guard for controlled admin/container use.
+  if [ "$(id -u)" != "0" ] || [ "${TRAIGENT_ALLOW_ROOT:-}" = "1" ]; then
+    return 0
+  fi
+
+  if [ -f /.dockerenv ] || [ -f /run/.containerenv ] || [ "${CI+x}" = "x" ]; then
+    say "notice: running as root inside a container/CI context; continuing."
+    return 0
+  fi
+
+  die "do not run this installer with sudo/root. Install as your normal user so 'traigent' lands on your user PATH. Set TRAIGENT_ALLOW_ROOT=1 to override."
+}
+
+ensure_uv() {
   if has uv; then
     return 0
   fi
@@ -35,42 +99,138 @@ install_uv() {
     return 1
   fi
 
-  curl -LsSf https://astral.sh/uv/install.sh | sh || true
-  has uv
+  UV_INSTALLER="${TMPDIR:-/tmp}/traigent-uv-install.$$"
+  if curl -LsSf https://astral.sh/uv/install.sh -o "$UV_INSTALLER" && sh "$UV_INSTALLER"; then
+    rm -f "$UV_INSTALLER"
+    if has uv; then
+      return 0
+    fi
+    say "uv bootstrap completed, but uv is not on PATH."
+    return 1
+  fi
+
+  rm -f "$UV_INSTALLER"
+  say "uv bootstrap failed."
+  return 1
 }
 
-install_with_pip() {
+attempt_uv() {
+  if ! ensure_uv; then
+    append_attempt_summary "uv: unavailable or bootstrap failed"
+    return 1
+  fi
+
+  say "Installing Traigent with uv..."
+  if uv tool install --force --upgrade "$PACKAGE"; then
+    INSTALL_BIN_DIR="$(uv_tool_bin_dir)"
+    prepend_path "$INSTALL_BIN_DIR"
+    append_attempt_summary "uv: succeeded"
+    return 0
+  fi
+
+  append_attempt_summary "uv: failed installing '$PACKAGE'"
+  return 1
+}
+
+attempt_pipx() {
+  if ! has pipx; then
+    append_attempt_summary "pipx: skipped (pipx not found)"
+    return 1
+  fi
+
+  say "uv did not complete. Installing Traigent with pipx..."
+  if pipx install --force "$PACKAGE"; then
+    INSTALL_BIN_DIR="$(pipx_bin_dir)"
+    prepend_path "$INSTALL_BIN_DIR"
+    append_attempt_summary "pipx: succeeded"
+    return 0
+  fi
+
+  append_attempt_summary "pipx: failed installing '$PACKAGE'"
+  return 1
+}
+
+print_pep668_help() {
+  say ""
+  say "pip refused to install because this Python environment is externally managed (PEP 668)."
+  say "Do not use --break-system-packages here. Install Traigent as a tool with uv or pipx instead:"
+  say "  curl -LsSf https://astral.sh/uv/install.sh | sh"
+  say "  uv tool install --force --upgrade '$PACKAGE'"
+  say "or:"
+  say "  python3 -m pip install --user pipx"
+  say "  pipx install --force '$PACKAGE'"
+}
+
+attempt_pip() {
   if has python3; then
     PYTHON=python3
   elif has python; then
     PYTHON=python
   else
-    die "Python is required for the pip fallback."
+    append_attempt_summary "pip: skipped (python not found)"
+    return 1
   fi
 
   USER_BASE="$("$PYTHON" -m site --user-base 2>/dev/null || printf '%s/.local' "$HOME")"
-  PATH="$USER_BASE/bin:$PATH"
-  export PATH
-  say "Installing Traigent with pip --user..."
-  "$PYTHON" -m pip install --user --upgrade "$PACKAGE"
+  INSTALL_BIN_DIR="$USER_BASE/bin"
+  prepend_path "$INSTALL_BIN_DIR"
+  PIP_ERROR_LOG="${TMPDIR:-/tmp}/traigent-pip-error.$$"
+
+  say "uv and pipx did not complete. Installing Traigent with pip --user..."
+  if "$PYTHON" -m pip install --user --upgrade "$PACKAGE" 2>"$PIP_ERROR_LOG"; then
+    rm -f "$PIP_ERROR_LOG"
+    append_attempt_summary "pip: succeeded"
+    return 0
+  else
+    PIP_STATUS=$?
+  fi
+
+  if grep -Eiq 'externally-managed-environment|externally managed' "$PIP_ERROR_LOG"; then
+    print_pep668_help
+  else
+    sed 's/^/pip: /' "$PIP_ERROR_LOG"
+  fi
+  rm -f "$PIP_ERROR_LOG"
+  append_attempt_summary "pip: failed installing '$PACKAGE'"
+  return "$PIP_STATUS"
 }
 
-if install_uv; then
-  say "Installing Traigent with uv..."
-  uv tool install --force --upgrade "$PACKAGE"
-elif has pipx; then
-  say "uv is unavailable. Installing Traigent with pipx..."
-  pipx install --force "$PACKAGE"
+print_path_persistence_hint() {
+  if [ -z "$INSTALL_BIN_DIR" ] || path_has_dir "$INSTALL_BIN_DIR"; then
+    return 0
+  fi
+
+  say ""
+  say "Add Traigent to PATH for future shells:"
+  say "  export PATH=\"$INSTALL_BIN_DIR:\$PATH\""
+  say "Add that line to your shell profile (for example ~/.profile, ~/.bashrc, or ~/.zshrc), then open a new terminal."
+}
+
+fail_all_installers() {
+  say ""
+  say "Traigent install failed after trying:"
+  printf '%s\n' "$ATTEMPT_SUMMARY"
+  die "install uv or pipx, or fix the pip error above, then rerun this installer."
+}
+
+guard_root
+
+if attempt_uv; then
+  :
+elif attempt_pipx; then
+  :
+elif attempt_pip; then
+  :
 else
-  say "uv and pipx are unavailable."
-  install_with_pip
+  fail_all_installers
 fi
 
-has traigent || die "traigent is not on PATH. Add $HOME/.local/bin to PATH, then rerun 'traigent info'."
+has traigent || die "traigent is not on PATH. Add ${INSTALL_BIN_DIR:-$HOME/.local/bin} to PATH, then rerun 'traigent info'."
 traigent info >/dev/null 2>&1 || die "'traigent info' failed. Run 'traigent info' for details."
 
 say ""
 say "Traigent is installed and 'traigent info' ran successfully."
+print_path_persistence_hint
 if traigent onboard --help >/dev/null 2>&1; then
   say "Next step:"
   say "  traigent onboard"

--- a/public/install.sh
+++ b/public/install.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+set -eu
+
+say() {
+  printf '%s\n' "$*"
+}
+
+die() {
+  say "error: $*"
+  exit 1
+}
+
+has() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+: "${HOME:?HOME is required}"
+PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+export PATH
+
+PACKAGE="traigent"
+if [ -n "${TRAIGENT_VERSION:-}" ]; then
+  PACKAGE="traigent==${TRAIGENT_VERSION}"
+fi
+
+install_uv() {
+  if has uv; then
+    return 0
+  fi
+
+  say "uv not found. Installing uv with Astral's official bootstrap:"
+  say "  curl -LsSf https://astral.sh/uv/install.sh | sh"
+  if ! has curl; then
+    say "curl not found; cannot run the uv bootstrap."
+    return 1
+  fi
+
+  curl -LsSf https://astral.sh/uv/install.sh | sh || true
+  has uv
+}
+
+install_with_pip() {
+  if has python3; then
+    PYTHON=python3
+  elif has python; then
+    PYTHON=python
+  else
+    die "Python is required for the pip fallback."
+  fi
+
+  USER_BASE="$("$PYTHON" -m site --user-base 2>/dev/null || printf '%s/.local' "$HOME")"
+  PATH="$USER_BASE/bin:$PATH"
+  export PATH
+  say "Installing Traigent with pip --user..."
+  "$PYTHON" -m pip install --user --upgrade "$PACKAGE"
+}
+
+if install_uv; then
+  say "Installing Traigent with uv..."
+  uv tool install --force --upgrade "$PACKAGE"
+elif has pipx; then
+  say "uv is unavailable. Installing Traigent with pipx..."
+  pipx install --force "$PACKAGE"
+else
+  say "uv and pipx are unavailable."
+  install_with_pip
+fi
+
+has traigent || die "traigent is not on PATH. Add $HOME/.local/bin to PATH, then rerun 'traigent info'."
+traigent info >/dev/null 2>&1 || die "'traigent info' failed. Run 'traigent info' for details."
+
+say ""
+say "Traigent is installed and 'traigent info' ran successfully."
+if traigent onboard --help >/dev/null 2>&1; then
+  say "Next step:"
+  say "  traigent onboard"
+else
+  say "Next steps for the current SDK:"
+  say "  1. Create or copy an API key from https://portal.traigent.ai"
+  say "  2. Run:"
+  say "     traigent auth login"
+  say "     python -m traigent.examples.quickstart"
+  say ""
+  say "The quickstart is a zero-cost mock run; it does not call an LLM provider."
+fi

--- a/src/components/InstallCommand.jsx
+++ b/src/components/InstallCommand.jsx
@@ -8,10 +8,9 @@ import { Check, Copy } from "lucide-react";
 /**
  * A single-line install command with a copy-to-clipboard affordance.
  *
- * The bundled `traigent quickstart` is the load-bearing demo on the
- * funnel: no API keys, no LLM provider calls, ~6 seconds to a results
- * table on a fresh laptop. This component is what lets a visitor copy
- * the command in one click without leaving the page.
+ * This component lets a visitor copy an install or quickstart command in
+ * one click without leaving the page. The packaged Python SDK quickstart
+ * is runnable as `python -m traigent.examples.quickstart`.
  *
  * @param {object}  props
  * @param {string}  props.command    — the shell string to display + copy

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -17,10 +17,11 @@ const SDK_SKILL_INSTALL_COMMAND = [
   "--skill traigent-integrations",
 ].join(" ");
 const TERMINAL_INSTALL_COMMAND = "curl -fsSL https://traigent.ai/install.sh | sh";
+// Switch these defaults to traigent[recommended] once that extras bundle ships.
 const MANUAL_INSTALL_COMMANDS = [
-  "uv tool install traigent",
-  "pipx install traigent",
-  "pip install traigent",
+  "uv tool install 'traigent[integrations]'",
+  "pipx install 'traigent[integrations]'",
+  "pip install 'traigent[integrations]'",
 ];
 
 export default function GetStarted() {
@@ -69,7 +70,7 @@ export default function GetStarted() {
           <div className="p-6 rounded-xl bg-slate-900/60 border border-slate-800 flex flex-col">
             <h2 className="text-xl font-semibold mb-2">Traigent SDK</h2>
             <p className="text-slate-300 mb-4">
-              Install the published Python SDK from your terminal. The bootstrap is a thin shell script that installs <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent</code>, verifies <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent info</code>, and never reads credentials. Today&apos;s SDK uses an API key from <a href="https://portal.traigent.ai" target="_blank" rel="noopener noreferrer" className="text-blue-300 hover:text-blue-200 underline underline-offset-4">portal.traigent.ai</a>; when <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent onboard</code> ships, the installer will detect it.
+              Install the published Python SDK from your terminal. The bootstrap is a thin shell script that installs <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent[integrations]</code>, verifies <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent info</code>, and never prompts for or reads credentials. Today&apos;s SDK uses an API key from <a href="https://portal.traigent.ai" target="_blank" rel="noopener noreferrer" className="text-blue-300 hover:text-blue-200 underline underline-offset-4">portal.traigent.ai</a>; when <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent onboard</code> ships, the installer will detect it.
             </p>
             <InstallCommand
               command={TERMINAL_INSTALL_COMMAND}

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -16,6 +16,12 @@ const SDK_SKILL_INSTALL_COMMAND = [
   "--skill traigent-debugging",
   "--skill traigent-integrations",
 ].join(" ");
+const TERMINAL_INSTALL_COMMAND = "curl -fsSL https://traigent.ai/install.sh | sh";
+const MANUAL_INSTALL_COMMANDS = [
+  "uv tool install traigent",
+  "pipx install traigent",
+  "pip install traigent",
+];
 
 export default function GetStarted() {
   return (
@@ -62,14 +68,53 @@ export default function GetStarted() {
 
           <div className="p-6 rounded-xl bg-slate-900/60 border border-slate-800 flex flex-col">
             <h2 className="text-xl font-semibold mb-2">Traigent SDK</h2>
-            <p className="text-slate-300 mb-4 flex-grow">
-              Attach to your existing AI calls with a decorator, run governed optimization on real workloads, and apply the best config. The bundled <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent quickstart</code> demo runs locally in mock mode — no API keys, no LLM provider calls — so you can validate the pipeline before pointing it at real LLMs.
+            <p className="text-slate-300 mb-4">
+              Install the published Python SDK from your terminal. The bootstrap is a thin shell script that installs <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent</code>, verifies <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent info</code>, and never reads credentials. Today&apos;s SDK uses an API key from <a href="https://portal.traigent.ai" target="_blank" rel="noopener noreferrer" className="text-blue-300 hover:text-blue-200 underline underline-offset-4">portal.traigent.ai</a>; when <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent onboard</code> ships, the installer will detect it.
             </p>
             <InstallCommand
-              command='uv tool install "traigent[recommended]" && traigent quickstart'
-              secondary="Prefer pip? `pip install` is a drop-in replacement."
+              command={TERMINAL_INSTALL_COMMAND}
+              secondary="Set TRAIGENT_VERSION before the command to pin a published SDK version."
               className="mb-4"
             />
+            <div className="border-t border-slate-800 pt-4 mb-4">
+              <h3 className="text-sm font-semibold text-slate-200 mb-2">or install manually</h3>
+              <div className="space-y-1 font-mono text-sm text-slate-300">
+                {MANUAL_INSTALL_COMMANDS.map((command) => (
+                  <div key={command}>
+                    <span className="text-slate-500 select-none">$ </span>
+                    <code>{command}</code>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="border-t border-slate-800 pt-4 mb-5 flex-grow">
+              <h3 className="text-sm font-semibold text-slate-200 mb-2">next steps</h3>
+              <div className="space-y-3 text-sm text-slate-300">
+                <div>
+                  <div className="text-slate-400 mb-1">If your installed SDK includes onboard:</div>
+                  <div className="font-mono">
+                    <span className="text-slate-500 select-none">$ </span>
+                    <code>traigent onboard</code>
+                  </div>
+                </div>
+                <div>
+                  <div className="text-slate-400 mb-1">Current SDK fallback:</div>
+                  <div className="space-y-1 font-mono">
+                    <div>
+                      <span className="text-slate-500 select-none">$ </span>
+                      <code>traigent auth login</code>
+                    </div>
+                    <div>
+                      <span className="text-slate-500 select-none">$ </span>
+                      <code>python -m traigent.examples.quickstart</code>
+                    </div>
+                  </div>
+                  <p className="text-xs text-slate-500 mt-2">
+                    Paste an API key from the portal when prompted; the packaged quickstart is a zero-cost mock run.
+                  </p>
+                </div>
+              </div>
+            </div>
             <div className="flex flex-wrap gap-3">
               <a
                 href="https://github.com/Traigent/Traigent"

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -133,7 +133,7 @@ export default function GetStarted() {
         <div className="mt-10 p-6 rounded-xl bg-slate-900/60 border border-slate-800">
           <h2 className="text-xl font-semibold mb-2">Drive it from your coding agent</h2>
           <p className="text-slate-300 mb-4 max-w-3xl">
-            Claude Code, Cursor, Codex, Gemini CLI and 30+ other agents pick up the Traigent skill bundle automatically. They&apos;ll guide you through dry-run-first setup, generate the eval dataset, and apply the best config — without you leaving your editor.
+            Claude Code, Cursor, Codex, Gemini CLI and 30+ other agents pick up the Traigent skill bundle automatically. They&apos;ll guide you through dry-run-first setup, generate the eval dataset, and apply the best config — without you leaving your editor. Coding agent? Point it at <a href="/agent.md" className="text-blue-300 hover:text-blue-200 underline underline-offset-4">traigent.ai/agent.md</a>.
           </p>
           <InstallCommand
             command={SDK_SKILL_INSTALL_COMMAND}


### PR DESCRIPTION
## Summary
Ships the terminal-installer entry point for the onboarding funnel:

- **`public/install.sh`** (served at `https://traigent.ai/install.sh` once on gh-pages): POSIX sh, `set -eu`, auditable in one read. Installs **`traigent[integrations]`** (matches the packaged quickstart's real dependencies — the previous CTA's bare-install would have produced a broken next step) via **uv → pipx → pip --user** fallback chain (each attempt non-fatal; clear summary if all fail). `TRAIGENT_VERSION` pin support. PEP 668 externally-managed Python detected with actionable uv/pipx guidance (no `--break-system-packages`). Container/CI-aware root guard (agent sandboxes keep working; laptop `sudo curl|sh` is refused with `TRAIGENT_ALLOW_ROOT=1` override). PATH-persistence hint when the tool bin dir wasn't on the user's original PATH. **Never prompts for or reads credentials.** Next-step logic detects `traigent onboard` (future SDK) and falls back to today's honest path: `traigent auth login` + `python -m traigent.examples.quickstart` (zero-cost mock).
- **GetStarted.jsx**: SDK card now leads with the copyable `curl -fsSL https://traigent.ai/install.sh | sh`, visible manual fallbacks (`uv tool install 'traigent[integrations]'` / pipx / pip), and the two-world next-steps block. Replaces the "Request SDK access → calendar" funnel for the SDK path; the enterprise/demo booking CTA remains.
- **Drift fixes**: the page previously advertised `traigent quickstart` and `traigent[recommended]` — neither exists in published traigent 0.11.x; copy now matches runtime exactly. Removed the `_headers` addition (GitHub Pages ignores it; canonical URL is `/install.sh`).

## Review cycle
Codex xhigh adversarial review (REQUEST-CHANGES) → all findings fixed: P1 extras/quickstart mismatch (verified against PyPI 0.11.4), uv-failure fallback, PATH persistence, PEP 668, root guard (captain-modified to stay container-friendly), copy narrowed to exactly what the script guarantees. Syntax-verified under sh/dash/bash; `npm run build` green; `#/get-started` render-checked desktop+mobile.

## Deploy note
Merging deploys (Actions → gh-pages). Safe to ship before the SDK's `onboard` lands — the script self-detects and the page describes both worlds honestly. Codacy MCP not available in this session; CI analysis applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)