### PR TITLE
chore(growth): set repeat-notify throttle to 0 for E2E testing

### DIFF
--- a/src/components/academy/AcademyEmailGate.jsx
+++ b/src/components/academy/AcademyEmailGate.jsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from "react";
 import { trackEvent } from "../../lib/analytics";
 
-// Same 24h throttle window as the Start Now repeat-notify, so a repeat
-// visitor never triggers more than one HubSpot notification per day per
-// surface. The academy gate stores its own entry per course.
-const REPEAT_NOTIFY_THROTTLE_MS = 24 * 60 * 60 * 1000;
+// TEMP — set to 0 for end-to-end testing across all 3 gates. Bump back to
+// 60 * 60 * 1000 (1 hour) once Amir confirms repeat notifications land.
+const REPEAT_NOTIFY_THROTTLE_MS = 0;
 
 // Configuration read at build time. The Forms API is CORS-enabled and our
 // CSP already allows api.hsforms.com via the *.hsforms.com entry.

--- a/src/lib/startNowGate.js
+++ b/src/lib/startNowGate.js
@@ -12,7 +12,9 @@
 
 const STORAGE_KEY = "traigent_start_now_unlocked";
 const TTL_MS = 90 * 24 * 60 * 60 * 1000;
-const REPEAT_NOTIFY_THROTTLE_MS = 24 * 60 * 60 * 1000;
+// TEMP — set to 0 for end-to-end testing across all 3 gates. Bump back to
+// 60 * 60 * 1000 (1 hour) once Amir confirms repeat notifications land.
+const REPEAT_NOTIFY_THROTTLE_MS = 0;
 
 function readEntry() {
   if (typeof window === "undefined") return null;


### PR DESCRIPTION
Temporary — set REPEAT_NOTIFY_THROTTLE_MS to 0 in both gates so every modal open / page revisit fires the silent re-submit, so Amir can verify all 3 forms (Start Now, Course A, Course B) wire notifications correctly. Will bump back to 1h once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)