### PR TITLE
fix(growth): capture Start Now email via DOM (fixes silent repeat-visit no-op)

### DIFF
--- a/src/components/HubSpotStartNowForm.jsx
+++ b/src/components/HubSpotStartNowForm.jsx
@@ -39,6 +39,36 @@ function extractEmailFromCallbackData(data) {
   return "";
 }
 
+// Reads the email input value off the jQuery-wrapped form HubSpot passes to
+// onFormSubmit. Falls back gracefully if HubSpot ever ships a plain DOM form.
+function readEmailFromHsForm($form) {
+  if (!$form) return "";
+  const formEl =
+    (typeof $form.get === "function" && $form.get(0)) ||
+    (Array.isArray($form) && $form[0]) ||
+    (typeof $form === "object" && $form[0]) ||
+    (typeof $form === "object" && $form.form) ||
+    null;
+  if (!formEl || !formEl.querySelector) return "";
+  const input =
+    formEl.querySelector('input[type="email"]') ||
+    formEl.querySelector('input[name="email"]');
+  return (input && typeof input.value === "string") ? input.value.trim() : "";
+}
+
+// Belt-and-suspenders: read the email straight out of the target container,
+// regardless of how HubSpot wrapped the input. Used as the final fallback
+// when neither the callback nor the captured ref produced a value.
+function readEmailFromTarget(targetId) {
+  if (typeof document === "undefined") return "";
+  const root = document.getElementById(targetId);
+  if (!root) return "";
+  const input =
+    root.querySelector('input[type="email"]') ||
+    root.querySelector('input[name="email"]');
+  return (input && typeof input.value === "string") ? input.value.trim() : "";
+}
+
 /** Load the HubSpot embed script once and cache the promise. */
 function loadHubSpotScript() {
   if (scriptPromise) return scriptPromise;
@@ -73,6 +103,12 @@ function loadHubSpotScript() {
 export default function HubSpotStartNowForm({ onSuccess, targetId = "hs-start-now-form" }) {
   const onSuccessRef = useRef(onSuccess);
   onSuccessRef.current = onSuccess;
+  // We grab the email value off the HubSpot form DOM in onFormSubmit (which
+  // fires BEFORE submission) and stash it here, then read it back when
+  // onFormSubmitted fires. The postMessage / inline-callback data shape
+  // sometimes omits submissionValues entirely, so DOM read is the load-
+  // bearing capture path — the other extractors are kept as safety nets.
+  const capturedEmailRef = useRef("");
   const [status, setStatus] = useState("loading"); // "loading" | "ready" | "error"
 
   useEffect(() => {
@@ -88,7 +124,8 @@ export default function HubSpotStartNowForm({ onSuccess, targetId = "hs-start-no
       if (d.eventName === "onFormSubmitted") {
         // eslint-disable-next-line no-console
         console.debug("[hs-form] postMessage onFormSubmitted", d);
-        onSuccessRef.current?.(extractEmail(d));
+        const email = extractEmail(d) || capturedEmailRef.current || readEmailFromTarget(targetId);
+        onSuccessRef.current?.(email);
       }
     };
     window.addEventListener("message", handleHsMessage);
@@ -108,14 +145,22 @@ export default function HubSpotStartNowForm({ onSuccess, targetId = "hs-start-no
             // eslint-disable-next-line no-console
             console.debug("[hs-form] onFormReady");
           },
-          onFormSubmit: () => {
+          onFormSubmit: ($form) => {
+            // CAPTURE EMAIL HERE — this fires BEFORE submission, while the
+            // form DOM still holds the values the visitor typed.
+            const captured = readEmailFromHsForm($form) || readEmailFromTarget(targetId);
+            capturedEmailRef.current = captured;
             // eslint-disable-next-line no-console
-            console.debug("[hs-form] onFormSubmit (click)");
+            console.debug("[hs-form] onFormSubmit captured email:", captured);
           },
           onFormSubmitted: (_form, data) => {
             // eslint-disable-next-line no-console
             console.debug("[hs-form] inline onFormSubmitted", data);
-            onSuccessRef.current?.(extractEmailFromCallbackData(data));
+            const email =
+              extractEmailFromCallbackData(data) ||
+              capturedEmailRef.current ||
+              readEmailFromTarget(targetId);
+            onSuccessRef.current?.(email);
           },
         });
         setStatus("ready");


### PR DESCRIPTION
## Root cause
HubSpot's embed v2 `onFormSubmitted` callback / postMessage often omits `submissionValues` entirely. So `extractEmail()` returned `""`, `markUnlocked("")` stamped localStorage with an empty email, and every repeat visit early-returned in `notifyStartNowRepeat` on `if (!email) return;`.

Visible in HubSpot Forms dashboard: **Start Now → 8 page views, 1 submission**. The first submit landed; the repeats were silent no-ops on our side. Course A (3 subs) and Course B (4 subs) were unaffected because the academy gate owns its own input field — never depended on HubSpot's data shape.

## Fix
Capture email straight off the form DOM in `onFormSubmit` (fires BEFORE submission), stash in a ref, prefer it over the callback's submissionValues. Final fallback reads the input out of the target container directly.

## Test plan
- Clear localStorage `traigent_start_now_unlocked`
- Submit Start Now in incognito → modal swaps; HubSpot dashboard shows new submission
- Close + reopen modal → HubSpot dashboard shows ANOTHER submission (this was the broken case)
- Console: `[hs-form] onFormSubmit captured email: <your email>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)