### PR TITLE
feat(growth): gate Open portal behind HubSpot form (shared TTL)

### DIFF
--- a/src/components/HubSpotStartNowForm.jsx
+++ b/src/components/HubSpotStartNowForm.jsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 
 const HUBSPOT_SCRIPT_SRC = "https://js-eu1.hsforms.net/forms/embed/v2.js";
 const HUBSPOT_PORTAL_ID = "148486827";
-const HUBSPOT_FORM_ID = "35384a3e-7386-45b0-924e-84e5d6f637e4";
+const HUBSPOT_DEFAULT_FORM_ID = "35384a3e-7386-45b0-924e-84e5d6f637e4";
 const HUBSPOT_REGION = "eu1";
 
 let scriptPromise = null;
@@ -100,7 +100,11 @@ function loadHubSpotScript() {
  * @param {Function} props.onSuccess  — fires after HubSpot confirms submission
  * @param {string}   [props.targetId] — DOM id for the form container
  */
-export default function HubSpotStartNowForm({ onSuccess, targetId = "hs-start-now-form" }) {
+export default function HubSpotStartNowForm({
+  onSuccess,
+  targetId = "hs-start-now-form",
+  formId = HUBSPOT_DEFAULT_FORM_ID,
+}) {
   const onSuccessRef = useRef(onSuccess);
   onSuccessRef.current = onSuccess;
   // We grab the email value off the HubSpot form DOM in onFormSubmit (which
@@ -138,7 +142,7 @@ export default function HubSpotStartNowForm({ onSuccess, targetId = "hs-start-no
         }
         hbspt.forms.create({
           portalId: HUBSPOT_PORTAL_ID,
-          formId: HUBSPOT_FORM_ID,
+          formId,
           region: HUBSPOT_REGION,
           target: `#${targetId}`,
           onFormReady: () => {
@@ -175,7 +179,7 @@ export default function HubSpotStartNowForm({ onSuccess, targetId = "hs-start-no
       cancelled = true;
       window.removeEventListener("message", handleHsMessage);
     };
-  }, [targetId]);
+  }, [targetId, formId]);
 
   return (
     <div>

--- a/src/components/PortalGateModal.jsx
+++ b/src/components/PortalGateModal.jsx
@@ -1,0 +1,142 @@
+/* eslint-disable react/prop-types */
+import { useEffect, useState } from "react";
+import { X, ExternalLink } from "lucide-react";
+import HubSpotStartNowForm from "./HubSpotStartNowForm";
+import {
+  isUnlocked,
+  markUnlocked,
+  getUnlockedEmail,
+  shouldNotifyRepeatVisit,
+} from "../lib/startNowGate";
+import { notifyPortalRepeat, PORTAL_FORM_ID } from "../lib/hubspotForms";
+import { trackEvent } from "../lib/analytics";
+
+const PORTAL_URL = "https://portal.traigent.ai";
+
+/**
+ * Two-state modal mirroring StartNowModal but for the portal entry:
+ *   1. Locked  → HubSpot portal form captures email
+ *   2. Unlocked → "Click to open the portal" CTA
+ *
+ * Shares the 90-day localStorage TTL with Start Now (same key, same
+ * `markUnlocked` / `getUnlockedEmail`), so submitting either form unlocks
+ * both surfaces. The repeat-visit notification goes to the PORTAL form
+ * specifically — so the founder sees "they came back for portal" rather
+ * than "they came back for the SDK".
+ *
+ * The `location` prop is the breadcrumb of which "Open portal" was
+ * clicked (topnav / topnav_mobile / footer / …).
+ */
+export default function PortalGateModal({ onClose, location = "unknown" }) {
+  const [unlocked, setUnlocked] = useState(() => isUnlocked());
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [onClose]);
+
+  // If the modal opens already unlocked (user previously submitted Start Now
+  // or Portal), fire the silent portal re-notify so the founder sees
+  // "they came back for the portal". Throttled by shouldNotifyRepeatVisit
+  // so we don't spam on every reopen.
+  useEffect(() => {
+    if (!unlocked) return;
+    if (!shouldNotifyRepeatVisit()) return;
+    const email = getUnlockedEmail();
+    if (!email) return;
+    notifyPortalRepeat({ email, location });
+    trackEvent("portal_repeat_visit", { location });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSubmitted = (email) => {
+    markUnlocked(email);
+    setUnlocked(true);
+    trackEvent("portal_form_submitted", { location });
+  };
+
+  const handleOpenPortal = () => {
+    trackEvent("portal_opened", { location });
+    window.open(PORTAL_URL, "_blank", "noopener,noreferrer");
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/80 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="portal-gate-title"
+        className="relative bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl max-w-2xl w-full p-8 max-h-[90vh] overflow-y-auto"
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-slate-400 hover:text-white transition-colors"
+          aria-label="Close"
+        >
+          <X className="w-5 h-5" />
+        </button>
+
+        {unlocked ? (
+          <UnlockedView onOpenPortal={handleOpenPortal} />
+        ) : (
+          <LockedView onSubmitted={handleSubmitted} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LockedView({ onSubmitted }) {
+  return (
+    <>
+      <h2 id="portal-gate-title" className="text-2xl font-bold text-white mb-2">
+        Open the Traigent portal
+      </h2>
+      <p className="text-slate-400 mb-6">
+        Tell us where to send setup tips — the portal opens as soon as you
+        submit.
+      </p>
+      <HubSpotStartNowForm
+        formId={PORTAL_FORM_ID}
+        onSuccess={onSubmitted}
+        targetId="hs-portal-gate-form"
+      />
+    </>
+  );
+}
+
+function UnlockedView({ onOpenPortal }) {
+  return (
+    <>
+      <h2 id="portal-gate-title" className="text-2xl font-bold text-white mb-2">
+        Welcome back — open the portal
+      </h2>
+      <p className="text-slate-400 mb-6">
+        Your account at <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">portal.traigent.ai</code> — manage agents, optimization runs, and API keys.
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={onOpenPortal}
+          className="inline-flex items-center bg-[#1A6BF5] hover:bg-[#4D8EF8] text-white px-6 py-3 rounded-lg text-sm font-medium transition-colors"
+        >
+          Open portal
+          <ExternalLink className="ml-2 h-4 w-4" />
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -2,8 +2,15 @@ import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { ChevronDown, Github, Menu, X } from "lucide-react";
 import StartNowModal from "./StartNowModal";
+import PortalGateModal from "./PortalGateModal";
 import BrandMark from "./BrandMark";
 import { trackEvent } from "../lib/analytics";
+import {
+  isUnlocked,
+  getUnlockedEmail,
+  shouldNotifyRepeatVisit,
+} from "../lib/startNowGate";
+import { notifyPortalRepeat } from "../lib/hubspotForms";
 
 const PORTAL_URL = "https://portal.traigent.ai";
 const DEMO_URL = "https://meetings-eu1.hubspot.com/amir8";
@@ -192,6 +199,25 @@ function MobileSectionLabel({ children }) {
 export default function TopNav() {
   const [openMenu, setOpenMenu] = useState(null);
   const [showStartNow, setShowStartNow] = useState(false);
+  const [showPortalGate, setShowPortalGate] = useState(false);
+
+  // Click handler for the "Open portal" CTA. Unlocked visitors skip the gate
+  // entirely (no friction — that was the whole point of the unlock) and we
+  // silently re-notify HubSpot in the background. Locked visitors get the
+  // form. The `loc` parameter is the breadcrumb (topnav / topnav_mobile).
+  const handleOpenPortal = (loc) => {
+    if (isUnlocked()) {
+      const email = getUnlockedEmail();
+      if (email && shouldNotifyRepeatVisit()) {
+        notifyPortalRepeat({ email, location: loc });
+      }
+      trackEvent("portal_opened", { location: loc });
+      window.open(PORTAL_URL, "_blank", "noopener,noreferrer");
+      return;
+    }
+    trackEvent("portal_clicked_gated", { location: loc });
+    setShowPortalGate(true);
+  };
   const [mobileOpen, setMobileOpen] = useState(false);
   const [pitchMenuOpen, setPitchMenuOpen] = useState(false);
   const pitchMenuRef = useRef(null);
@@ -325,15 +351,13 @@ export default function TopNav() {
               >
                 <Github className="w-5 h-5" />
               </a>
-              <a
-                href={PORTAL_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackEvent("portal_opened", { location: "topnav" })}
+              <button
+                type="button"
+                onClick={() => handleOpenPortal("topnav")}
                 className="text-sm text-slate-300 hover:text-white transition-colors whitespace-nowrap"
               >
                 Open portal
-              </a>
+              </button>
               <button
                 onClick={() => {
                   trackEvent("start_now_clicked", { location: "topnav" });
@@ -485,15 +509,13 @@ export default function TopNav() {
 
             {/* CTAs pinned to the bottom */}
             <div className="border-t border-slate-800 px-4 sm:px-6 py-4 flex flex-col gap-2 flex-shrink-0">
-              <a
-                href={PORTAL_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => { trackEvent("portal_opened", { location: "topnav_mobile" }); closeMobile(); }}
+              <button
+                type="button"
+                onClick={() => { handleOpenPortal("topnav_mobile"); closeMobile(); }}
                 className="text-center text-sm text-slate-300 hover:text-white py-2 transition-colors"
               >
                 Open portal
-              </a>
+              </button>
               <button
                 type="button"
                 onClick={() => {
@@ -530,6 +552,7 @@ export default function TopNav() {
       )}
 
       {showStartNow && <StartNowModal onClose={() => setShowStartNow(false)} location="topnav" />}
+      {showPortalGate && <PortalGateModal onClose={() => setShowPortalGate(false)} location="topnav" />}
     </>
   );
 }

--- a/src/lib/hubspotForms.js
+++ b/src/lib/hubspotForms.js
@@ -7,6 +7,7 @@
 
 const HUBSPOT_PORTAL_ID = "148486827";
 const STARTNOW_FORM_ID = "35384a3e-7386-45b0-924e-84e5d6f637e4";
+const PORTAL_FORM_ID = "692b03aa-e984-411c-8792-2e86baed2614";
 
 function readHubSpotCookie() {
   if (typeof document === "undefined") return "";
@@ -15,12 +16,18 @@ function readHubSpotCookie() {
 }
 
 /**
- * Silently re-submit the Start Now form for an already-known visitor. Used
- * to fire a HubSpot notification ("amir@traigent.ai came back") without
+ * Silently re-submit a HubSpot form for an already-known visitor — fires
+ * the form's notification workflow ("amir@traigent.ai came back") without
  * making the visitor fill the form again. No-op when email is empty.
+ *
+ * @param {object} opts
+ * @param {string} opts.email   — visitor email
+ * @param {string} opts.formId  — HubSpot form GUID to submit to
+ * @param {string} opts.location — surface (topnav / homepage_hero / etc)
+ * @param {string} opts.label    — short label for the pageName ("Start Now", "Portal")
  */
-export async function notifyStartNowRepeat({ email, location, formId = STARTNOW_FORM_ID }) {
-  if (!email) return;
+export async function notifyRepeatVisit({ email, formId, location, label }) {
+  if (!email || !formId) return;
   const url = `https://api.hsforms.com/submissions/v3/integration/submit/${HUBSPOT_PORTAL_ID}/${formId}`;
   try {
     await fetch(url, {
@@ -32,7 +39,7 @@ export async function notifyStartNowRepeat({ email, location, formId = STARTNOW_
         context: {
           hutk: readHubSpotCookie(),
           pageUri: typeof window !== "undefined" ? window.location.href : "",
-          pageName: `Traigent — Start Now (repeat: ${location || "unknown"})`,
+          pageName: `Traigent — ${label || "Repeat visit"} (repeat: ${location || "unknown"})`,
         },
       }),
     });
@@ -40,3 +47,14 @@ export async function notifyStartNowRepeat({ email, location, formId = STARTNOW_
     // Silent — the unlock flow must continue even if HubSpot is unreachable.
   }
 }
+
+/** Convenience wrappers so call sites don't have to remember form IDs. */
+export function notifyStartNowRepeat({ email, location }) {
+  return notifyRepeatVisit({ email, formId: STARTNOW_FORM_ID, location, label: "Start Now" });
+}
+
+export function notifyPortalRepeat({ email, location }) {
+  return notifyRepeatVisit({ email, formId: PORTAL_FORM_ID, location, label: "Portal" });
+}
+
+export { PORTAL_FORM_ID };


### PR DESCRIPTION
## Summary
- Adds a HubSpot form gate on the TopNav **Open portal** link (desktop + mobile)
- Uses the new dedicated **Portal access form** (formId 692b03aa-e984-411c-8792-2e86baed2614) so HubSpot can distinguish portal intent from Start Now intent
- Shares the 90-day localStorage TTL with Start Now — submitting either form unlocks both surfaces (visitor never fills two forms)
- Already-unlocked visitors **skip the gate entirely** — no UX regression for repeat visitors. Silent re-notify still fires to the portal form so the founder sees the recall signal.

## Plumbing
- `HubSpotStartNowForm` accepts `formId` prop (backward-compatible default)
- `hubspotForms.js`: generic `notifyRepeatVisit({ formId, label, ... })` with thin `notifyStartNowRepeat` / `notifyPortalRepeat` wrappers
- New `PortalGateModal` mirrors StartNowModal's two-state shape

## Test plan
- Clear localStorage `traigent_start_now_unlocked` to start fresh
- Click TopNav **Open portal** → HubSpot portal form renders
- Submit → modal swaps to **Open portal** button → click → portal.traigent.ai in new tab
- HubSpot dashboard: Portal access form submissions tick up by 1
- Click **Start Now** → install command appears immediately (no second form — shared unlock)
- Re-click **Open portal** → portal opens directly with no modal
- HubSpot: Portal access form gets a repeat submission with `pageName: Traigent — Portal (repeat: topnav)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)