### PR TITLE
feat(growth): auto-unlock known HubSpot contacts + /story tracking pixel

### DIFF
--- a/src/components/PortalGateModal.jsx
+++ b/src/components/PortalGateModal.jsx
@@ -9,6 +9,7 @@ import {
   shouldNotifyRepeatVisit,
 } from "../lib/startNowGate";
 import { notifyPortalRepeat, PORTAL_FORM_ID } from "../lib/hubspotForms";
+import { checkKnownContact } from "../lib/hubspotIdentify";
 import { trackEvent } from "../lib/analytics";
 
 const PORTAL_URL = "https://portal.traigent.ai";
@@ -29,6 +30,7 @@ const PORTAL_URL = "https://portal.traigent.ai";
  */
 export default function PortalGateModal({ onClose, location = "unknown" }) {
   const [unlocked, setUnlocked] = useState(() => isUnlocked());
+  const [checkingIdentity, setCheckingIdentity] = useState(() => !isUnlocked());
 
   useEffect(() => {
     const onKey = (e) => {
@@ -42,10 +44,8 @@ export default function PortalGateModal({ onClose, location = "unknown" }) {
     };
   }, [onClose]);
 
-  // If the modal opens already unlocked (user previously submitted Start Now
-  // or Portal), fire the silent portal re-notify so the founder sees
-  // "they came back for the portal". Throttled by shouldNotifyRepeatVisit
-  // so we don't spam on every reopen.
+  // If the modal opens already unlocked, fire the silent portal re-notify
+  // so the founder sees "they came back for the portal". Throttled.
   useEffect(() => {
     if (!unlocked) return;
     if (!shouldNotifyRepeatVisit()) return;
@@ -53,6 +53,24 @@ export default function PortalGateModal({ onClose, location = "unknown" }) {
     if (!email) return;
     notifyPortalRepeat({ email, location });
     trackEvent("portal_repeat_visit", { location });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Identity check via Cloudflare Worker (Contact Us / meeting / BCC etc).
+  useEffect(() => {
+    if (unlocked) return;
+    let cancelled = false;
+    checkKnownContact().then((result) => {
+      if (cancelled) return;
+      if (result && result.known && result.email) {
+        markUnlocked(result.email);
+        setUnlocked(true);
+        notifyPortalRepeat({ email: result.email, location });
+        trackEvent("portal_auto_unlocked", { location });
+      }
+      setCheckingIdentity(false);
+    });
+    return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -89,13 +107,26 @@ export default function PortalGateModal({ onClose, location = "unknown" }) {
           <X className="w-5 h-5" />
         </button>
 
-        {unlocked ? (
+        {checkingIdentity ? (
+          <CheckingView />
+        ) : unlocked ? (
           <UnlockedView onOpenPortal={handleOpenPortal} />
         ) : (
           <LockedView onSubmitted={handleSubmitted} />
         )}
       </div>
     </div>
+  );
+}
+
+function CheckingView() {
+  return (
+    <>
+      <h2 id="portal-gate-title" className="text-2xl font-bold text-white mb-2">
+        Open the Traigent portal
+      </h2>
+      <p className="text-slate-400 mb-6 animate-pulse">Checking your access…</p>
+    </>
   );
 }
 

--- a/src/components/StartNowModal.jsx
+++ b/src/components/StartNowModal.jsx
@@ -10,6 +10,7 @@ import {
   shouldNotifyRepeatVisit,
 } from "../lib/startNowGate";
 import { notifyStartNowRepeat } from "../lib/hubspotForms";
+import { checkKnownContact } from "../lib/hubspotIdentify";
 import { trackEvent } from "../lib/analytics";
 
 /**
@@ -25,6 +26,10 @@ import { trackEvent } from "../lib/analytics";
 export default function StartNowModal({ onClose, location = "unknown" }) {
   // Initialize from localStorage so repeat visitors skip the form.
   const [unlocked, setUnlocked] = useState(() => isUnlocked());
+  // Briefly check whether the hubspotutk cookie maps to a known HubSpot
+  // contact (Contact Us submitter, meeting booker, BCC'd lead, etc.). If
+  // it does, auto-unlock without showing the form.
+  const [checkingIdentity, setCheckingIdentity] = useState(() => !isUnlocked());
 
   useEffect(() => {
     const onKey = (e) => {
@@ -40,8 +45,8 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
 
   // When an already-unlocked visitor reopens the modal, silently re-submit
   // their stored email to HubSpot so the founder gets a notification that
-  // they came back. Throttled to once per 24h per visitor (see
-  // shouldNotifyRepeatVisit in startNowGate.js) so the inbox stays sane.
+  // they came back. Throttled by shouldNotifyRepeatVisit so the inbox
+  // stays sane.
   useEffect(() => {
     if (!unlocked) return;
     if (!shouldNotifyRepeatVisit()) return;
@@ -51,6 +56,27 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
     trackEvent("start_now_repeat_visit", { location });
     // We only want this to fire on mount when the modal opens unlocked,
     // never re-fire on re-render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Identity check via the Cloudflare Worker. Runs once on mount when not
+  // locally unlocked. If the visitor's hubspotutk cookie maps to a known
+  // HubSpot contact, auto-unlock + fire the re-notify to this gate's
+  // form. Falls through to the form on any failure / timeout / no match.
+  useEffect(() => {
+    if (unlocked) return;
+    let cancelled = false;
+    checkKnownContact().then((result) => {
+      if (cancelled) return;
+      if (result && result.known && result.email) {
+        markUnlocked(result.email);
+        setUnlocked(true);
+        notifyStartNowRepeat({ email: result.email, location });
+        trackEvent("start_now_auto_unlocked", { location });
+      }
+      setCheckingIdentity(false);
+    });
+    return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -81,13 +107,26 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
           <X className="w-5 h-5" />
         </button>
 
-        {unlocked ? (
+        {checkingIdentity ? (
+          <CheckingView />
+        ) : unlocked ? (
           <UnlockedView />
         ) : (
           <LockedView onSubmitted={handleSubmitted} />
         )}
       </div>
     </div>
+  );
+}
+
+function CheckingView() {
+  return (
+    <>
+      <h2 id="start-now-title" className="text-2xl font-bold text-white mb-2">
+        Start Now — Free
+      </h2>
+      <p className="text-slate-400 mb-6 animate-pulse">Checking your access…</p>
+    </>
   );
 }
 

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -7,10 +7,12 @@ import BrandMark from "./BrandMark";
 import { trackEvent } from "../lib/analytics";
 import {
   isUnlocked,
+  markUnlocked,
   getUnlockedEmail,
   shouldNotifyRepeatVisit,
 } from "../lib/startNowGate";
 import { notifyPortalRepeat } from "../lib/hubspotForms";
+import { checkKnownContact } from "../lib/hubspotIdentify";
 
 const PORTAL_URL = "https://portal.traigent.ai";
 const DEMO_URL = "https://meetings-eu1.hubspot.com/amir8";
@@ -201,17 +203,29 @@ export default function TopNav() {
   const [showStartNow, setShowStartNow] = useState(false);
   const [showPortalGate, setShowPortalGate] = useState(false);
 
-  // Click handler for the "Open portal" CTA. Unlocked visitors skip the gate
-  // entirely (no friction — that was the whole point of the unlock) and we
-  // silently re-notify HubSpot in the background. Locked visitors get the
-  // form. The `loc` parameter is the breadcrumb (topnav / topnav_mobile).
-  const handleOpenPortal = (loc) => {
+  // Click handler for the "Open portal" CTA. Three paths:
+  //   1. Locally unlocked → open portal immediately + silent re-notify
+  //   2. Not locally unlocked but recognized as a known HubSpot contact
+  //      via the hsutk Worker → mark unlocked + re-notify + open portal
+  //   3. Genuinely new visitor → show the gate modal
+  // The Worker check is cached for 1h in localStorage so repeat clicks are
+  // instant after the first.
+  const handleOpenPortal = async (loc) => {
     if (isUnlocked()) {
       const email = getUnlockedEmail();
       if (email && shouldNotifyRepeatVisit()) {
         notifyPortalRepeat({ email, location: loc });
       }
       trackEvent("portal_opened", { location: loc });
+      window.open(PORTAL_URL, "_blank", "noopener,noreferrer");
+      return;
+    }
+    const result = await checkKnownContact();
+    if (result && result.known && result.email) {
+      markUnlocked(result.email);
+      notifyPortalRepeat({ email: result.email, location: loc });
+      trackEvent("portal_opened", { location: loc });
+      trackEvent("portal_auto_unlocked", { location: loc });
       window.open(PORTAL_URL, "_blank", "noopener,noreferrer");
       return;
     }

--- a/src/components/academy/AcademyEmailGate.jsx
+++ b/src/components/academy/AcademyEmailGate.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { trackEvent } from "../../lib/analytics";
+import { checkKnownContact } from "../../lib/hubspotIdentify";
 
 // TEMP — set to 0 for end-to-end testing across all 3 gates. Bump back to
 // 60 * 60 * 1000 (1 hour) once Amir confirms repeat notifications land.
@@ -149,6 +150,35 @@ export default function AcademyEmailGate({ courseSlug, courseTitle, formId, chil
       formId: effectiveFormId,
     }).catch(() => {});
     trackEvent("academy_repeat_visit", { course: courseSlug });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Identity check via the hsutk Worker — auto-unlock known contacts for
+  // this course (they may have submitted Start Now, opened a meeting, or
+  // shown up via BCC linkage without ever touching this academy gate).
+  useEffect(() => {
+    if (unlocked) return;
+    if (!HUBSPOT_PORTAL_ID || !effectiveFormId) return;
+    let cancelled = false;
+    checkKnownContact().then((result) => {
+      if (cancelled) return;
+      if (!(result && result.known && result.email)) return;
+      writeUnlockEntry(courseSlug, {
+        email: result.email,
+        ts: Date.now(),
+        lastNotifiedTs: Date.now(),
+      });
+      // Fire the per-course re-notify so HubSpot sees "they came back
+      // for this course" specifically.
+      submitToHubSpot({
+        email: result.email,
+        courseTitle: `${courseTitle} (auto-unlock — known contact)`,
+        formId: effectiveFormId,
+      }).catch(() => {});
+      trackEvent("academy_auto_unlocked", { course: courseSlug });
+      setUnlocked(true);
+    });
+    return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const [email, setEmail] = useState("");

--- a/src/lib/hubspotForms.js
+++ b/src/lib/hubspotForms.js
@@ -8,6 +8,10 @@
 const HUBSPOT_PORTAL_ID = "148486827";
 const STARTNOW_FORM_ID = "35384a3e-7386-45b0-924e-84e5d6f637e4";
 const PORTAL_FORM_ID = "692b03aa-e984-411c-8792-2e86baed2614";
+// /story is intentionally NOT gated — anyone can watch. We still want a
+// notification when a *known* contact watches it, so a known-contact
+// pageview fires a silent submission to this form.
+const STORY_FORM_ID = "3af25090-75c0-4291-8889-3221ea0e3f2d";
 
 function readHubSpotCookie() {
   if (typeof document === "undefined") return "";
@@ -55,6 +59,10 @@ export function notifyStartNowRepeat({ email, location }) {
 
 export function notifyPortalRepeat({ email, location }) {
   return notifyRepeatVisit({ email, formId: PORTAL_FORM_ID, location, label: "Portal" });
+}
+
+export function notifyStoryWatched({ email, location }) {
+  return notifyRepeatVisit({ email, formId: STORY_FORM_ID, location, label: "Story watched" });
 }
 
 export { PORTAL_FORM_ID };

--- a/src/lib/hubspotIdentify.js
+++ b/src/lib/hubspotIdentify.js
@@ -1,0 +1,86 @@
+// Client-side check: is the current visitor already a known HubSpot
+// contact? Calls the traigent-hsutk-check Cloudflare Worker which proxies
+// HubSpot's Contacts API.
+//
+// Returns:
+//   { known: true,  email: "..." }   when matched
+//   { known: false }                 when no match
+//   null                             when the check is unconfigured,
+//                                    times out, or errors — caller should
+//                                    fall back to showing the gate
+//
+// The result is cached in localStorage for 1 hour so we don't hit the
+// Worker on every page load. A change in identity is rare; an hour stale
+// is fine.
+
+const CHECK_URL = import.meta.env.VITE_HSUTK_CHECK_URL || "";
+const CACHE_KEY = "traigent_hsutk_check";
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const REQUEST_TIMEOUT_MS = 1500;
+
+function readHubSpotCookie() {
+  if (typeof document === "undefined") return "";
+  const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]+)/);
+  return match ? decodeURIComponent(match[1]) : "";
+}
+
+function readCache(utk) {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed.utk !== utk) return null;
+    if (Date.now() - parsed.ts > CACHE_TTL_MS) return null;
+    return parsed.result;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(utk, result) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ utk, ts: Date.now(), result })
+    );
+  } catch {
+    /* private mode / quota — silent */
+  }
+}
+
+/**
+ * Race the Worker call against a short timeout so the gate doesn't sit
+ * spinning if the network is slow. Caller treats `null` as "couldn't
+ * decide — show the form".
+ */
+export async function checkKnownContact() {
+  if (!CHECK_URL) return null;
+  const utk = readHubSpotCookie();
+  if (!utk) return { known: false };
+
+  const cached = readCache(utk);
+  if (cached) return cached;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    const res = await fetch(
+      `${CHECK_URL}/check?utk=${encodeURIComponent(utk)}`,
+      { signal: controller.signal }
+    );
+    clearTimeout(timer);
+
+    if (!res.ok) return null;
+    const result = await res.json();
+    // Shape guard — the Worker is supposed to return { known: boolean,
+    // email?: string }. Anything else, treat as no answer.
+    if (typeof result?.known !== "boolean") return null;
+
+    writeCache(utk, result);
+    return result;
+  } catch {
+    return null;
+  }
+}

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -11,6 +11,7 @@ import {
   shouldNotifyRepeatVisit,
 } from "../lib/startNowGate";
 import { notifyStartNowRepeat } from "../lib/hubspotForms";
+import { checkKnownContact } from "../lib/hubspotIdentify";
 import { trackEvent } from "../lib/analytics";
 
 const createPageUrl = (path) => path;
@@ -47,6 +48,23 @@ export default function GetStarted() {
     if (!email) return;
     notifyStartNowRepeat({ email, location: "get_started_page" });
     trackEvent("start_now_repeat_visit", { location: "get_started_page" });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Identity check via the hsutk Worker — auto-unlock known contacts.
+  useEffect(() => {
+    if (unlocked) return;
+    let cancelled = false;
+    checkKnownContact().then((result) => {
+      if (cancelled) return;
+      if (result && result.known && result.email) {
+        markUnlocked(result.email);
+        setUnlocked(true);
+        notifyStartNowRepeat({ email: result.email, location: "get_started_page" });
+        trackEvent("start_now_auto_unlocked", { location: "get_started_page" });
+      }
+    });
+    return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/pages/StoryMovie.jsx
+++ b/src/pages/StoryMovie.jsx
@@ -19,6 +19,9 @@ import { ArrowLeft, ArrowRight, ChevronDown, ChevronUp, Pause, Play, RotateCcw, 
 import { useRemoveChatWidget } from "../lib/useRemoveChatWidget";
 import ChatKillerStyle from "../lib/ChatKillerStyle";
 import StartNowModal from "../components/StartNowModal";
+import { checkKnownContact } from "../lib/hubspotIdentify";
+import { notifyStoryWatched } from "../lib/hubspotForms";
+import { trackEvent } from "../lib/analytics";
 
 // Same CTA URL as the homepage TopNav — HubSpot meeting booking.
 const DEMO_BOOKING_URL = "https://meetings-eu1.hubspot.com/amir8";
@@ -815,6 +818,21 @@ export default function StoryMovie() {
   const [actElapsedMs, setActElapsedMs] = useState(0);
   const advancingRef = useRef(false);
   useRemoveChatWidget();
+
+  // /story is intentionally ungated — no email form. We still want a
+  // notification when a known HubSpot contact watches it (Contact Us
+  // submitter, meeting booker, BCC-linked lead). Identity check fires once
+  // on mount; if known, silently re-submits to the Story-watched form.
+  useEffect(() => {
+    let cancelled = false;
+    checkKnownContact().then((result) => {
+      if (cancelled) return;
+      if (!(result && result.known && result.email)) return;
+      notifyStoryWatched({ email: result.email, location: "story_page" });
+      trackEvent("story_watched_known", { location: "story_page" });
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   const start = useCallback(() => {
     advancingRef.current = false;


### PR DESCRIPTION
## Summary
Known HubSpot contacts (Contact Us submitters, meeting bookers, BCC-to-HubSpot leads, manual adds) no longer have to fill any gate form. A Cloudflare Worker proxies their hubspotutk cookie to HubSpot's Contacts API; if matched, the gate auto-unlocks and silently re-submits to that gate's form so the founder still gets the recall notification.

## Worker
Lives in **D:\2026 job search\TRAIGENT-AI\hsutk-check-worker\** — README has deploy instructions. Until VITE_HSUTK_CHECK_URL is set in GH Actions vars, the check is a no-op and gates behave exactly like before. **Zero regression risk during rollout.**

## /story
Intentionally NOT gated. But a known contact's pageview fires a silent submission to the new Story-watched form (3af25090-75c0-4291-8889-3221ea0e3f2d) — pure tracking pixel.

## Test plan (after Worker deploy + VITE_HSUTK_CHECK_URL set)
- [ ] Open /story while signed in as a known contact → HubSpot Story-watched form gets 1 submission
- [ ] Click Start Now while known → 'Checking your access…' for ~500ms then install command appears, NO form
- [ ] Open portal while known → portal.traigent.ai opens directly, no modal
- [ ] Visit /academy/agents-in-production while known → course content unlocks, course-A form gets 1 submission
- [ ] localStorage.traigent_hsutk_check is populated and respected for 1h

🤖 Generated with [Claude Code](https://claude.com/claude-code)