### PR TITLE
feat(growth): known-contact tracking on pricing/calculators/knob-explorer/pitch decks

### DIFF
--- a/src/lib/hubspotForms.js
+++ b/src/lib/hubspotForms.js
@@ -8,10 +8,16 @@
 const HUBSPOT_PORTAL_ID = "148486827";
 const STARTNOW_FORM_ID = "35384a3e-7386-45b0-924e-84e5d6f637e4";
 const PORTAL_FORM_ID = "692b03aa-e984-411c-8792-2e86baed2614";
-// /story is intentionally NOT gated — anyone can watch. We still want a
-// notification when a *known* contact watches it, so a known-contact
-// pageview fires a silent submission to this form.
+// Tracking-only forms — surfaces are intentionally NOT gated (anyone can
+// view), but a known HubSpot contact viewing fires a silent submission so
+// the founder gets an intent notification. One form per surface so the
+// HubSpot notification surfaces the right context.
 const STORY_FORM_ID = "3af25090-75c0-4291-8889-3221ea0e3f2d";
+const PRICING_FORM_ID = "57287a7b-6d54-4fcd-8eae-6336100ca57e";
+const TTM_FORM_ID = "157b3560-f3c7-428e-af44-73d9326d839f";
+const ROI_FORM_ID = "b1a8947a-65bf-4da1-a2a9-7c6748d43d25";
+const KNOB_EXPLORER_FORM_ID = "a9bc858e-add8-4094-995a-188ae08fd56e";
+const PITCH_DECK_FORM_ID = "728ef1b3-0a23-476b-9a3d-bcae6ec6ba64";
 
 function readHubSpotCookie() {
   if (typeof document === "undefined") return "";
@@ -63,6 +69,26 @@ export function notifyPortalRepeat({ email, location }) {
 
 export function notifyStoryWatched({ email, location }) {
   return notifyRepeatVisit({ email, formId: STORY_FORM_ID, location, label: "Story watched" });
+}
+
+export function notifyPricingViewed({ email, location }) {
+  return notifyRepeatVisit({ email, formId: PRICING_FORM_ID, location, label: "Pricing intent" });
+}
+
+export function notifyTtmCalcViewed({ email, location }) {
+  return notifyRepeatVisit({ email, formId: TTM_FORM_ID, location, label: "TTM calculator" });
+}
+
+export function notifyRoiCalcViewed({ email, location }) {
+  return notifyRepeatVisit({ email, formId: ROI_FORM_ID, location, label: "ROI calculator" });
+}
+
+export function notifyKnobExplorerViewed({ email, location }) {
+  return notifyRepeatVisit({ email, formId: KNOB_EXPLORER_FORM_ID, location, label: "Knob Explorer" });
+}
+
+export function notifyPitchDeckViewed({ email, location }) {
+  return notifyRepeatVisit({ email, formId: PITCH_DECK_FORM_ID, location, label: "Slide deck viewed" });
 }
 
 export { PORTAL_FORM_ID };

--- a/src/lib/useKnownContactNotify.js
+++ b/src/lib/useKnownContactNotify.js
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from "react";
+import { checkKnownContact } from "./hubspotIdentify";
+import { trackEvent } from "./analytics";
+
+/**
+ * One-shot known-contact notification hook. Drop into any page that
+ * should NOT be gated (no email form), but where the founder still wants
+ * a HubSpot notification when a *known* contact lands on it.
+ *
+ * On mount: checks whether the visitor's hubspotutk cookie maps to a
+ * known HubSpot contact via the hsutk Worker. If yes, silently submits
+ * to the surface's tracking form and fires a PostHog/GA4 event. Fires at
+ * most once per page-mount; safe to drop in without UI side effects.
+ *
+ *   useKnownContactNotify({
+ *     notify: notifyPricingViewed,
+ *     location: "pricing_page",
+ *     eventName: "pricing_viewed_known",
+ *   });
+ */
+export function useKnownContactNotify({ notify, location, eventName }) {
+  const firedRef = useRef(false);
+  useEffect(() => {
+    if (firedRef.current) return;
+    let cancelled = false;
+    checkKnownContact().then((result) => {
+      if (cancelled) return;
+      if (!(result && result.known && result.email)) return;
+      firedRef.current = true;
+      try { notify({ email: result.email, location }); } catch { /* noop */ }
+      if (eventName) trackEvent(eventName, { location });
+    });
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/pages/KnobExplorer.jsx
+++ b/src/pages/KnobExplorer.jsx
@@ -13,6 +13,8 @@ import { ArrowLeft, ArrowRight, ChevronDown, ChevronUp, Clock, DollarSign, Spark
 import { useSharedSetting } from "../lib/useSharedSetting";
 import { useCustomSearchSpace } from "../lib/useCustomSearchSpace";
 import { useRemoveChatWidget } from "../lib/useRemoveChatWidget";
+import { useKnownContactNotify } from "../lib/useKnownContactNotify";
+import { notifyKnobExplorerViewed } from "../lib/hubspotForms";
 import ChatKillerStyle from "../lib/ChatKillerStyle";
 import GuidedTour from "../lib/GuidedTour";
 
@@ -634,6 +636,11 @@ function sortKnobsByImpact(knobs, metric) {
 }
 
 export default function KnobExplorer() {
+  useKnownContactNotify({
+    notify: notifyKnobExplorerViewed,
+    location: "knob_explorer_page",
+    eventName: "knob_explorer_viewed_known",
+  });
   // Persist selections + sort preference across reloads / tabs so the user
   // can leave the page and come back to the same configuration.
   const [selectedModels, setSelectedModels] = useSharedSetting(

--- a/src/pages/Pitch.jsx
+++ b/src/pages/Pitch.jsx
@@ -4,6 +4,8 @@ import { ChevronLeft, ChevronRight, Home, Maximize2 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { ConvergenceDiagram, KillerStatsGrid, ThreeProductsGrid } from "./pitch/shared";
+import { useKnownContactNotify } from "../lib/useKnownContactNotify";
+import { notifyPitchDeckViewed } from "../lib/hubspotForms";
 
 // ===================================================================
 // Brand tokens — single source of truth so all slides match the site.
@@ -198,6 +200,11 @@ const slides = [
 // Deck shell — keyboard nav, fullscreen, transitions.
 // ===================================================================
 export default function Pitch() {
+  useKnownContactNotify({
+    notify: notifyPitchDeckViewed,
+    location: "pitch",
+    eventName: "pitch_deck_viewed_known",
+  });
   const [current, setCurrent] = useState(0);
   const [direction, setDirection] = useState(1);
   const containerRef = useRef(null);

--- a/src/pages/PitchFull.jsx
+++ b/src/pages/PitchFull.jsx
@@ -6,6 +6,8 @@ import { Helmet } from "react-helmet-async";
 import { ConvergenceDiagram, KillerStatsGrid, ThreeProductsGrid } from "./pitch/shared";
 import { OnePager2Slide } from "./OnePager2";
 import BrandMark from "../components/BrandMark";
+import { useKnownContactNotify } from "../lib/useKnownContactNotify";
+import { notifyPitchDeckViewed } from "../lib/hubspotForms";
 
 // ===================================================================
 // Brand tokens
@@ -1390,5 +1392,10 @@ export function PitchDeck({ slides }) {
 // (e.g. /pitch-short) compose PitchDeck with their own slides arrays.
 // ===================================================================
 export default function PitchFull() {
+  useKnownContactNotify({
+    notify: notifyPitchDeckViewed,
+    location: "pitch_full",
+    eventName: "pitch_deck_viewed_known",
+  });
   return <PitchDeck slides={FULL_SLIDES} />;
 }

--- a/src/pages/PitchShort2.jsx
+++ b/src/pages/PitchShort2.jsx
@@ -11,6 +11,8 @@ import { useParams, useSearchParams } from "react-router-dom";
 import { SHORT_SLIDES } from "./PitchShort";
 import { OnePager2Slide } from "./OnePager2";
 import BrandMark from "../components/BrandMark";
+import { useKnownContactNotify } from "../lib/useKnownContactNotify";
+import { notifyPitchDeckViewed } from "../lib/hubspotForms";
 
 // Named presets — URLs like /pitch-short-2/extended-product-presentation map
 // onto specific range/exclude filters here, so each deck has a readable URL
@@ -188,6 +190,11 @@ function resolveSlides(rangeParam, excludeParam, allSlides) {
 }
 
 export default function PitchShort2() {
+  useKnownContactNotify({
+    notify: notifyPitchDeckViewed,
+    location: "pitch_short_2",
+    eventName: "pitch_deck_viewed_known",
+  });
   const scale = useViewportScale();
   useRemoveChatWidget();
   const { preset } = useParams();

--- a/src/pages/Pricing.jsx
+++ b/src/pages/Pricing.jsx
@@ -13,6 +13,8 @@ import {
 } from "lucide-react";
 import { trackEvent } from "../lib/analytics";
 import StartNowModal from "../components/StartNowModal";
+import { useKnownContactNotify } from "../lib/useKnownContactNotify";
+import { notifyPricingViewed } from "../lib/hubspotForms";
 
 const BLUE = "#1A6BF5";
 const BLUE_LIGHT = "#4D8EF8";
@@ -241,6 +243,11 @@ function FeatureRow({ label, free, starter, pro, enterprise, section = false }) 
 // ============================================================================
 export default function Pricing() {
   const [showStartNow, setShowStartNow] = useState(false);
+  useKnownContactNotify({
+    notify: notifyPricingViewed,
+    location: "pricing_page",
+    eventName: "pricing_viewed_known",
+  });
   return (
     <div className="bg-[#080808] text-white min-h-screen">
       <Helmet>

--- a/src/pages/ROICalculator.jsx
+++ b/src/pages/ROICalculator.jsx
@@ -8,6 +8,8 @@ import { useSharedSetting } from "../lib/useSharedSetting";
 import { useCustomSearchSpace } from "../lib/useCustomSearchSpace";
 import StartNowModal from "../components/StartNowModal";
 import CalculatorTopBar from "../components/CalculatorTopBar";
+import { useKnownContactNotify } from "../lib/useKnownContactNotify";
+import { notifyRoiCalcViewed } from "../lib/hubspotForms";
 
 const BLUE = "#1A6BF5";
 
@@ -81,6 +83,11 @@ function Stat({ label, value, sublabel, icon: Icon, accent }) {
 
 export default function ROICalculator() {
   const [showStartNow, setShowStartNow] = useState(false);
+  useKnownContactNotify({
+    notify: notifyRoiCalcViewed,
+    location: "roi_calculator_page",
+    eventName: "roi_calc_viewed_known",
+  });
   const [monthlySpend, setMonthlySpend] = useState(DEFAULT_MONTHLY_SPEND);
   // Engineering side is now derived from the TTM Calculator's per-pass figure
   // multiplied by a user-set optimization cadence. Both are shared via localStorage.

--- a/src/pages/TTMCalculator.jsx
+++ b/src/pages/TTMCalculator.jsx
@@ -7,6 +7,8 @@ import { trackEvent } from "../lib/analytics";
 import { useSharedSetting } from "../lib/useSharedSetting";
 import { useCustomSearchSpace } from "../lib/useCustomSearchSpace";
 import CalculatorTopBar from "../components/CalculatorTopBar";
+import { useKnownContactNotify } from "../lib/useKnownContactNotify";
+import { notifyTtmCalcViewed } from "../lib/hubspotForms";
 
 const BLUE = "#1A6BF5";
 const BLUE_LIGHT = "#4D8EF8";
@@ -168,6 +170,11 @@ function otherDimensionsExamples() {
 }
 
 export default function TTMCalculator() {
+  useKnownContactNotify({
+    notify: notifyTtmCalcViewed,
+    location: "ttm_calculator_page",
+    eventName: "ttm_calc_viewed_known",
+  });
   const [models, setModels] = useState(6);
   const [prompts, setPrompts] = useState(3);
   const [maxTokensVariants, setMaxTokensVariants] = useState(3);


### PR DESCRIPTION
## Summary
Adds tracking-only known-contact notifications to 5 high-buying-intent surfaces. **No form, no UI change, no friction for any visitor.** A known HubSpot contact landing on any of these silently fires a submission to the surface's dedicated form so the founder gets a high-signal intent ping.

| Surface | HubSpot form | pageName label |
|---|---|---|
| /pricing | 57287a7b-... | Pricing intent |
| /ttm | 157b3560-... | TTM calculator |
| /roi | b1a8947a-... | ROI calculator |
| /knob-explorer | a9bc858e-... | Knob Explorer |
| /pitch, /pitch-full, /pitch-short-2 | 728ef1b3-... | Slide deck viewed |

## Notes
- New `useKnownContactNotify` hook centralises the pattern so adding a new tracked surface is a 4-line addition.
- PitchShort.jsx + PitchShort3.jsx left untouched per project user-WIP rule; the commit message includes the exact snippet to paste manually.
- Anonymous visitors are entirely unaffected.

## Test plan (post-Worker deploy)
- [ ] As a known contact, visit /pricing → HubSpot Pricing intent form ticks up
- [ ] As a known contact, visit /roi → ROI form ticks up
- [ ] As a known contact, visit /pitch-short-2 → Pitch deck form ticks up
- [ ] As an anonymous visitor, hit all 5 → no form on any of the 5 HubSpot dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)