### PR TITLE
feat: consent-gate known-contact identification and analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ VITE_CLARITY_ID=
 VITE_HUBSPOT_PORTAL_ID=
 VITE_HUBSPOT_REGION=
 
-# Known HubSpot contact identification — keep disabled until consent/legal review is complete.
+# Known HubSpot contact identification — keep disabled until production enablement is approved.
 # VITE_HSUTK_CHECK_URL is the Cloudflare Worker URL, and the feature flag must be "true"
 # before the site reads hubspotutk or calls the Worker.
 VITE_HSUTK_IDENTIFY_ENABLED=false
@@ -21,7 +21,7 @@ VITE_HSUTK_CHECK_URL=
 # HubSpot Academy form GUID — the form embedded on /academy/* pages to gate
 # course content behind email submission. Create the form in HubSpot UI
 # (Marketing → Forms → Create form), then paste its GUID here. When unset,
-# academy pages render a "coming soon" placeholder instead of the embed.
+# academy pages render a "coming soon" message instead of the embed.
 VITE_HUBSPOT_ACADEMY_FORM_ID=
 
 # PostHog — get from https://posthog.com (Project Settings → Project Variables).

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ VITE_CLARITY_ID=
 VITE_HUBSPOT_PORTAL_ID=
 VITE_HUBSPOT_REGION=
 
+# Known HubSpot contact identification — keep disabled until consent/legal review is complete.
+# VITE_HSUTK_CHECK_URL is the Cloudflare Worker URL, and the feature flag must be "true"
+# before the site reads hubspotutk or calls the Worker.
+VITE_HSUTK_IDENTIFY_ENABLED=false
+VITE_HSUTK_CHECK_URL=
+
 # HubSpot Academy form GUID — the form embedded on /academy/* pages to gate
 # course content behind email submission. Create the form in HubSpot UI
 # (Marketing → Forms → Create form), then paste its GUID here. When unset,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,10 +28,13 @@ import OptimizationDemo from './pages/OptimizationDemo'
 import StoryMovie from './pages/StoryMovie'
 import Layout from './layout'
 import ExternalRedirect from './components/ExternalRedirect'
+import CookieConsent from './components/CookieConsent'
 
 export default function App() {
   return (
-    <Routes>
+    <>
+      <CookieConsent />
+      <Routes>
       <Route path="table-demo" element={<TableDemo />} />
       {/* Pitch decks & outreach one-pager — no layout/nav, full-bleed slides */}
       <Route path="pitch" element={<Pitch />} />
@@ -77,5 +80,6 @@ export default function App() {
         <Route path="academy/statistical-se-workshop" element={<StatisticalSEWorkshop />} />
       </Route>
     </Routes>
+    </>
   )
 } 

--- a/src/components/CookieConsent.jsx
+++ b/src/components/CookieConsent.jsx
@@ -1,0 +1,72 @@
+import React, { useState, useEffect } from 'react';
+import { hasMarketingConsent, setConsent, subscribeConsent } from '../lib/consent';
+
+export default function CookieConsent() {
+  const [showBanner, setShowBanner] = useState(false);
+  const [showPreferences, setShowPreferences] = useState(false);
+
+  useEffect(() => {
+    // If there's no explicit choice yet, show the banner
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('traigent_marketing_consent');
+      if (stored === null) {
+        setShowBanner(true);
+      }
+    }
+  }, []);
+
+  const handleAccept = () => {
+    setConsent(true);
+    setShowBanner(false);
+    setShowPreferences(false);
+  };
+
+  const handleReject = () => {
+    setConsent(false);
+    setShowBanner(false);
+    setShowPreferences(false);
+  };
+
+  // Allow users to change their choice later by exposing a method or button
+  // For simplicity, we can have a small floating button to reopen preferences
+  // if they have already made a choice.
+
+  if (!showBanner && !showPreferences) {
+    return (
+      <button
+        onClick={() => setShowPreferences(true)}
+        className="fixed bottom-4 left-4 z-[9999] bg-slate-800 text-slate-300 text-xs px-3 py-2 rounded-full shadow-lg hover:bg-slate-700 transition-colors border border-slate-700"
+      >
+        Cookie Preferences
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-[10000] p-4 sm:p-6 pointer-events-none">
+      <div className="max-w-4xl mx-auto bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 pointer-events-auto flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+        <div className="flex-1">
+          <h3 className="text-white font-semibold mb-2">Cookie Preferences</h3>
+          <p className="text-slate-300 text-sm">
+            We use cookies to improve your experience, understand how you interact with our site, and personalize our marketing. 
+            By clicking "Accept", you consent to our use of these cookies. You can change your choice at any time.
+          </p>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          <button
+            onClick={handleReject}
+            className="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white bg-slate-800 hover:bg-slate-700 rounded-lg transition-colors border border-slate-700"
+          >
+            Reject All
+          </button>
+          <button
+            onClick={handleAccept}
+            className="px-4 py-2 text-sm font-medium text-white bg-[#1A6BF5] hover:bg-[#4D8EF8] rounded-lg transition-colors"
+          >
+            Accept All
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CookieConsent.jsx
+++ b/src/components/CookieConsent.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { setConsent } from '../lib/consent';
+import { getConsentRecord, setConsent } from '../lib/consent';
 
 export default function CookieConsent() {
   const [showBanner, setShowBanner] = useState(false);
@@ -8,8 +8,7 @@ export default function CookieConsent() {
   useEffect(() => {
     // If there's no explicit choice yet, show the banner
     if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('traigent_marketing_consent');
-      if (stored === null) {
+      if (!getConsentRecord()) {
         setShowBanner(true);
       }
     }
@@ -51,7 +50,15 @@ export default function CookieConsent() {
           <h3 className="text-white font-semibold mb-2">Cookie Preferences</h3>
           <p className="text-slate-300 text-sm">
             We use cookies to improve your experience, understand how you interact with our site, and personalize our marketing. 
-            By clicking "Accept", you consent to our use of these cookies. You can change your choice at any time.
+            By clicking "Accept", you consent to our use of these cookies. You can change your choice at any time.{' '}
+            <a
+              href="https://portal.traigent.ai/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-300 hover:text-blue-200 underline underline-offset-2"
+            >
+              Privacy Policy
+            </a>
           </p>
         </div>
         <div className="flex items-center gap-3 shrink-0">

--- a/src/components/CookieConsent.jsx
+++ b/src/components/CookieConsent.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { hasMarketingConsent, setConsent, subscribeConsent } from '../lib/consent';
+import { useState, useEffect } from 'react';
+import { setConsent } from '../lib/consent';
 
 export default function CookieConsent() {
   const [showBanner, setShowBanner] = useState(false);
@@ -21,7 +21,9 @@ export default function CookieConsent() {
     setShowPreferences(false);
   };
 
-  const handleReject = () => {
+  const handleReject = (event) => {
+    event?.preventDefault();
+    event?.stopPropagation();
     setConsent(false);
     setShowBanner(false);
     setShowPreferences(false);
@@ -55,6 +57,7 @@ export default function CookieConsent() {
         <div className="flex items-center gap-3 shrink-0">
           <button
             onClick={handleReject}
+            onPointerDownCapture={handleReject}
             className="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white bg-slate-800 hover:bg-slate-700 rounded-lg transition-colors border border-slate-700"
           >
             Reject All

--- a/src/components/academy/AcademyEmailGate.jsx
+++ b/src/components/academy/AcademyEmailGate.jsx
@@ -2,9 +2,7 @@ import { useEffect, useState } from "react";
 import { trackEvent } from "../../lib/analytics";
 import { checkKnownContact } from "../../lib/hubspotIdentify";
 
-// TEMP — set to 0 for end-to-end testing across all 3 gates. Bump back to
-// 60 * 60 * 1000 (1 hour) once Amir confirms repeat notifications land.
-const REPEAT_NOTIFY_THROTTLE_MS = 0;
+const REPEAT_NOTIFY_THROTTLE_MS = 60 * 60 * 1000;
 
 // Configuration read at build time. The Forms API is CORS-enabled and our
 // CSP already allows api.hsforms.com via the *.hsforms.com entry.

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -14,6 +14,8 @@
 // Any var left unset turns its corresponding integration into a no-op.
 // ===================================================================
 
+import { hasMarketingConsent, subscribeConsent } from './consent';
+
 const GA4_ID = import.meta.env.VITE_GA4_ID;
 const CLARITY_ID = import.meta.env.VITE_CLARITY_ID;
 const HUBSPOT_PORTAL_ID = import.meta.env.VITE_HUBSPOT_PORTAL_ID;
@@ -25,6 +27,7 @@ let initialized = false;
 
 export function initAnalytics() {
   if (initialized || typeof window === "undefined") return;
+  if (!hasMarketingConsent()) return;
   initialized = true;
 
   // ---- Google Analytics 4 (gtag.js) ----
@@ -97,6 +100,7 @@ export function initAnalytics() {
 /** Fire on every route change. Call this from a router listener. */
 export function trackPageView(path) {
   if (typeof window === "undefined") return;
+  if (!hasMarketingConsent()) return;
   if (GA4_ID && window.gtag) {
     window.gtag("event", "page_view", {
       page_path: path,
@@ -118,6 +122,7 @@ export function trackPageView(path) {
  */
 export function trackEvent(name, params = {}) {
   if (typeof window === "undefined") return;
+  if (!hasMarketingConsent()) return;
   if (GA4_ID && window.gtag) {
     window.gtag("event", name, params);
   }
@@ -149,6 +154,7 @@ export function trackEvent(name, params = {}) {
  */
 export function identify(userId, traits = {}) {
   if (typeof window === "undefined") return;
+  if (!hasMarketingConsent()) return;
   if (!userId && !traits.email) {
     if (import.meta.env.DEV) {
       // eslint-disable-next-line no-console

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -14,7 +14,7 @@
 // Any var left unset turns its corresponding integration into a no-op.
 // ===================================================================
 
-import { hasMarketingConsent, subscribeConsent } from './consent';
+import { hasMarketingConsent } from './consent';
 
 const GA4_ID = import.meta.env.VITE_GA4_ID;
 const CLARITY_ID = import.meta.env.VITE_CLARITY_ID;
@@ -25,6 +25,144 @@ const POSTHOG_HOST = import.meta.env.VITE_POSTHOG_HOST || "https://us.i.posthog.
 
 let initialized = false;
 
+const ANALYTICS_LOCAL_STORAGE_KEYS = [
+  "traigent_utms",
+  "traigent_hsutk_check",
+];
+
+const ANALYTICS_COOKIE_NAMES = [
+  "_ga",
+  "_gid",
+  "_gat",
+  "_gcl_au",
+  "_clck",
+  "_clsk",
+  "hubspotutk",
+  "__hstc",
+  "__hssc",
+  "__hssrc",
+  "__hs_cookie_cat_pref",
+  "messagesUtk",
+];
+
+function analyticsCookieMatcher(name) {
+  return (
+    ANALYTICS_COOKIE_NAMES.includes(name) ||
+    name.startsWith("_ga_") ||
+    name.startsWith("_gat_") ||
+    name.startsWith("_gcl_") ||
+    name.startsWith("ph_") ||
+    name.toLowerCase().includes("posthog")
+  );
+}
+
+function analyticsStorageMatcher(key) {
+  const normalized = key.toLowerCase();
+  return (
+    ANALYTICS_LOCAL_STORAGE_KEYS.includes(key) ||
+    key.startsWith("ph_") ||
+    normalized.includes("posthog")
+  );
+}
+
+function clearMatchingStorage(storage) {
+  if (!storage) return;
+  const keys = [];
+  for (let i = 0; i < storage.length; i += 1) {
+    const key = storage.key(i);
+    if (key && analyticsStorageMatcher(key)) keys.push(key);
+  }
+  keys.forEach((key) => storage.removeItem(key));
+}
+
+function cookieDomainCandidates(hostname) {
+  if (!hostname || hostname === "localhost" || /^\d+\.\d+\.\d+\.\d+$/.test(hostname)) {
+    return [""];
+  }
+  const parts = hostname.split(".");
+  const candidates = ["", hostname, `.${hostname}`];
+  for (let i = 1; i < parts.length - 1; i += 1) {
+    candidates.push(`.${parts.slice(i).join(".")}`);
+  }
+  return [...new Set(candidates)];
+}
+
+function expireCookie(name) {
+  if (typeof document === "undefined") return;
+  const hostname = window.location.hostname;
+  const domains = cookieDomainCandidates(hostname);
+  const paths = ["/", window.location.pathname || "/"];
+  const expiry = "Max-Age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+
+  for (const path of paths) {
+    for (const domain of domains) {
+      const domainPart = domain ? `; domain=${domain}` : "";
+      document.cookie = `${name}=; ${expiry}; path=${path}${domainPart}; SameSite=Lax`;
+    }
+  }
+}
+
+function clearAnalyticsCookies() {
+  if (typeof document === "undefined") return;
+  const existingCookieNames = document.cookie
+    .split(";")
+    .map((cookie) => cookie.trim().split("=")[0])
+    .filter(Boolean);
+  const names = new Set([
+    ...ANALYTICS_COOKIE_NAMES,
+    ...existingCookieNames.filter(analyticsCookieMatcher),
+  ]);
+  names.forEach(expireCookie);
+}
+
+function removeInjectedAnalyticsScripts() {
+  const selectors = [
+    'script[src*="googletagmanager.com/gtag/js"]',
+    'script[src*="clarity.ms/tag/"]',
+    'script[id="hs-script-loader"]',
+    'script[src*="hs-scripts.com"]',
+    'script[src*="posthog"][src*="/static/array.js"]',
+  ];
+  selectors.forEach((selector) => {
+    document.querySelectorAll(selector).forEach((script) => script.remove());
+  });
+}
+
+function clearAnalyticsGlobals() {
+  if (GA4_ID) window[`ga-disable-${GA4_ID}`] = true;
+  window.dataLayer = [];
+  window.gtag = undefined;
+  window._hsq = undefined;
+  window.posthog = undefined;
+  window.clarity = undefined;
+}
+
+export function teardownAnalytics({ reload = true } = {}) {
+  if (typeof window === "undefined") return;
+  const shouldReload = initialized && reload;
+
+  if (window.clarity) {
+    try { window.clarity("consent", false); } catch { /* noop */ }
+  }
+
+  if (window.posthog) {
+    try { window.posthog.stopSessionRecording?.(); } catch { /* noop */ }
+    try { window.posthog.opt_out_capturing?.(); } catch { /* noop */ }
+    try { window.posthog.reset?.(true); } catch { /* noop */ }
+  }
+
+  try { clearMatchingStorage(window.localStorage); } catch { /* noop */ }
+  try { clearMatchingStorage(window.sessionStorage); } catch { /* noop */ }
+  clearAnalyticsCookies();
+  removeInjectedAnalyticsScripts();
+  clearAnalyticsGlobals();
+  initialized = false;
+
+  if (shouldReload) {
+    window.location.reload();
+  }
+}
+
 export function initAnalytics() {
   if (initialized || typeof window === "undefined") return;
   if (!hasMarketingConsent()) return;
@@ -32,6 +170,7 @@ export function initAnalytics() {
 
   // ---- Google Analytics 4 (gtag.js) ----
   if (GA4_ID) {
+    window[`ga-disable-${GA4_ID}`] = false;
     const s = document.createElement("script");
     s.async = true;
     s.src = `https://www.googletagmanager.com/gtag/js?id=${GA4_ID}`;
@@ -53,6 +192,7 @@ export function initAnalytics() {
       t.src = "https://www.clarity.ms/tag/" + i;
       y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
     })(window, document, "clarity", "script", CLARITY_ID);
+    try { window.clarity("consent", true); } catch { /* noop */ }
   }
 
   // ---- HubSpot tracking ----

--- a/src/lib/consent.js
+++ b/src/lib/consent.js
@@ -1,0 +1,19 @@
+const CONSENT_KEY = 'traigent_marketing_consent';
+const listeners = new Set();
+
+export function hasMarketingConsent() {
+  if (typeof window === 'undefined') return false;
+  const stored = localStorage.getItem(CONSENT_KEY);
+  return stored === 'true';
+}
+
+export function setConsent(granted) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(CONSENT_KEY, granted ? 'true' : 'false');
+  listeners.forEach(listener => listener(granted));
+}
+
+export function subscribeConsent(listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/src/lib/consent.js
+++ b/src/lib/consent.js
@@ -1,15 +1,49 @@
 const CONSENT_KEY = 'traigent_marketing_consent';
+export const CONSENT_POLICY_REV = '2026-06-06 rev. 4';
 const listeners = new Set();
 
+export function getConsentRecord() {
+  if (typeof window === 'undefined') return null;
+  let stored;
+  try {
+    stored = localStorage.getItem(CONSENT_KEY);
+  } catch {
+    return null;
+  }
+  if (!stored) return null;
+  if (stored === 'true') return { granted: true, ts: null, policyRev: null };
+  if (stored === 'false') return { granted: false, ts: null, policyRev: null };
+  try {
+    const parsed = JSON.parse(stored);
+    if (typeof parsed?.granted !== 'boolean') return null;
+    return {
+      granted: parsed.granted,
+      ts: typeof parsed.ts === 'string' ? parsed.ts : null,
+      policyRev: typeof parsed.policyRev === 'string' ? parsed.policyRev : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export function hasMarketingConsent() {
-  if (typeof window === 'undefined') return false;
-  const stored = localStorage.getItem(CONSENT_KEY);
-  return stored === 'true';
+  return getConsentRecord()?.granted === true;
 }
 
 export function setConsent(granted) {
   if (typeof window === 'undefined') return;
-  localStorage.setItem(CONSENT_KEY, granted ? 'true' : 'false');
+  try {
+    localStorage.setItem(
+      CONSENT_KEY,
+      JSON.stringify({
+        granted: Boolean(granted),
+        ts: new Date().toISOString(),
+        policyRev: CONSENT_POLICY_REV,
+      })
+    );
+  } catch {
+    /* privacy mode / storage disabled — consent remains session-only */
+  }
   listeners.forEach(listener => listener(granted));
 }
 

--- a/src/lib/hubspotIdentify.js
+++ b/src/lib/hubspotIdentify.js
@@ -13,7 +13,10 @@
 // Worker on every page load. A change in identity is rare; an hour stale
 // is fine.
 
+import { hasMarketingConsent } from './consent';
+
 const CHECK_URL = import.meta.env.VITE_HSUTK_CHECK_URL || "";
+const IDENTIFY_ENABLED = import.meta.env.VITE_HSUTK_IDENTIFY_ENABLED === 'true';
 const CACHE_KEY = "traigent_hsutk_check";
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 const REQUEST_TIMEOUT_MS = 1500;
@@ -56,6 +59,8 @@ function writeCache(utk, result) {
  * decide — show the form".
  */
 export async function checkKnownContact() {
+  if (!IDENTIFY_ENABLED) return null;
+  if (!hasMarketingConsent()) return null;
   if (!CHECK_URL) return null;
   const utk = readHubSpotCookie();
   if (!utk) return { known: false };

--- a/src/lib/hubspotIdentify.js
+++ b/src/lib/hubspotIdentify.js
@@ -27,13 +27,22 @@ function readHubSpotCookie() {
   return match ? decodeURIComponent(match[1]) : "";
 }
 
-function readCache(utk) {
+async function cacheKeyForUtk(utk) {
+  if (typeof window === "undefined" || !window.crypto?.subtle) return "";
+  const bytes = new TextEncoder().encode(utk);
+  const digest = await window.crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function readCache(utkHash) {
   if (typeof window === "undefined") return null;
   try {
     const raw = window.localStorage.getItem(CACHE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw);
-    if (parsed.utk !== utk) return null;
+    if (parsed.utkHash !== utkHash) return null;
     if (Date.now() - parsed.ts > CACHE_TTL_MS) return null;
     return parsed.result;
   } catch {
@@ -41,12 +50,12 @@ function readCache(utk) {
   }
 }
 
-function writeCache(utk, result) {
+function writeCache(utkHash, result) {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(
       CACHE_KEY,
-      JSON.stringify({ utk, ts: Date.now(), result })
+      JSON.stringify({ utkHash, ts: Date.now(), result })
     );
   } catch {
     /* private mode / quota — silent */
@@ -65,16 +74,22 @@ export async function checkKnownContact() {
   const utk = readHubSpotCookie();
   if (!utk) return { known: false };
 
-  const cached = readCache(utk);
+  const utkHash = await cacheKeyForUtk(utk);
+  const cached = utkHash ? readCache(utkHash) : null;
   if (cached) return cached;
 
   try {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-    const res = await fetch(
-      `${CHECK_URL}/check?utk=${encodeURIComponent(utk)}`,
-      { signal: controller.signal }
-    );
+    const res = await fetch(`${CHECK_URL}/check`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ utk }),
+      signal: controller.signal,
+      cache: "no-store",
+      credentials: "omit",
+      referrerPolicy: "no-referrer",
+    });
     clearTimeout(timer);
 
     if (!res.ok) return null;
@@ -83,7 +98,7 @@ export async function checkKnownContact() {
     // email?: string }. Anything else, treat as no answer.
     if (typeof result?.known !== "boolean") return null;
 
-    writeCache(utk, result);
+    if (utkHash) writeCache(utkHash, result);
     return result;
   } catch {
     return null;

--- a/src/lib/startNowGate.js
+++ b/src/lib/startNowGate.js
@@ -12,9 +12,7 @@
 
 const STORAGE_KEY = "traigent_start_now_unlocked";
 const TTL_MS = 90 * 24 * 60 * 60 * 1000;
-// TEMP — set to 0 for end-to-end testing across all 3 gates. Bump back to
-// 60 * 60 * 1000 (1 hour) once Amir confirms repeat notifications land.
-const REPEAT_NOTIFY_THROTTLE_MS = 0;
+const REPEAT_NOTIFY_THROTTLE_MS = 60 * 60 * 1000;
 
 function readEntry() {
   if (typeof window === "undefined") return null;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,11 +4,17 @@ import { HashRouter as Router } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import App from './App.jsx'
 import { initAnalytics } from './lib/analytics'
+import { subscribeConsent, hasMarketingConsent } from './lib/consent'
 import './index.css'
 
-// Initialize analytics once at app bootstrap. Becomes a no-op
-// until VITE_GA4_ID / VITE_CLARITY_ID are set in .env.
-initAnalytics()
+// Initialize analytics once at app bootstrap if consent is granted.
+// Otherwise, wait for consent to be granted.
+if (hasMarketingConsent()) {
+  initAnalytics()
+}
+subscribeConsent((granted) => {
+  if (granted) initAnalytics()
+})
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client'
 import { HashRouter as Router } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import App from './App.jsx'
-import { initAnalytics } from './lib/analytics'
+import { initAnalytics, teardownAnalytics } from './lib/analytics'
 import { subscribeConsent, hasMarketingConsent } from './lib/consent'
 import './index.css'
 
@@ -11,9 +11,15 @@ import './index.css'
 // Otherwise, wait for consent to be granted.
 if (hasMarketingConsent()) {
   initAnalytics()
+} else {
+  teardownAnalytics({ reload: false })
 }
 subscribeConsent((granted) => {
-  if (granted) initAnalytics()
+  if (granted) {
+    initAnalytics()
+  } else {
+    teardownAnalytics()
+  }
 })
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary

Adds privacy controls around the known-contact HubSpot identification flow and all marketing analytics before the feature can go live.

Legal/privacy has confirmed the lawful-basis approach for this consent-gated flow. The portal-hosted policy disclosure has merged in TraigentFrontend PR #1100.

## What Changed

- Added a single localStorage-backed marketing consent source of truth, recorded as `{ granted, ts, policyRev }` with backward compatibility for old `true`/`false` values.
- Linked the cookie consent banner to the live Privacy Policy.
- Mounted the cookie consent banner at the App root, not inside Layout, so full-bleed routes such as `/story`, `/knob-explorer`, `/pitch`, `/pitch-full`, and `/pitch-short-2` are covered.
- Gated `checkKnownContact()` behind both explicit marketing consent and `VITE_HSUTK_IDENTIFY_ENABLED`.
- Sends known-contact Worker checks via `POST /check` with JSON body, never `?utk=...`, and caches by SHA-256 hash instead of storing the raw `hubspotutk` in localStorage.
- Gated `initAnalytics()`, `trackPageView()`, `trackEvent()`, and `identify()` so GA4, Microsoft Clarity, HubSpot tracking, PostHog, and first-touch UTM persistence do not run before consent.
- Added analytics withdrawal handling: PostHog opt-out/reset, Clarity consent revoke, tracker script removal, analytics cookie/localStorage/sessionStorage cleanup, and a reload after consent is withdrawn.
- Added startup cleanup when consent is false so stale analytics artifacts from older sessions are purged.
- Reverted the temporary repeat-notify throttle back to `60 * 60 * 1000`.
- Documented `VITE_HSUTK_IDENTIFY_ENABLED=false` and `VITE_HSUTK_CHECK_URL=` in `.env.example`.

## Data Flow

When enabled and consented:

`hubspotutk` cookie -> POST JSON body to Cloudflare Worker (`VITE_HSUTK_CHECK_URL`) -> HubSpot Contacts API -> known email returned to site -> silent HubSpot form submission -> sales/team notification.

Anonymous visitors are not identified by this known-contact flow. Known contacts may be identified by email and reported to Traigent based on the disclosed page visits only after marketing consent is granted.

## Gated Surfaces & Form IDs

- `src/components/StartNowModal.jsx`: `35384a3e-7386-45b0-924e-84e5d6f637e4`
- `src/components/PortalGateModal.jsx`: `692b03aa-e984-411c-8792-2e86baed2614`
- `src/components/TopNav.jsx` portal gate: `692b03aa-e984-411c-8792-2e86baed2614`
- `src/components/academy/AcademyEmailGate.jsx`: `VITE_HUBSPOT_ACADEMY_FORM_ID`
- `src/pages/StoryMovie.jsx`: `3af25090-75c0-4291-8889-3221ea0e3f2d`
- `src/pages/Pricing.jsx`: `57287a7b-6d54-4fcd-8eae-6336100ca57e`
- `src/pages/TTMCalculator.jsx`: `157b3560-f3c7-428e-af44-73d9326d839f`
- `src/pages/ROICalculator.jsx`: `b1a8947a-65bf-4da1-a2a9-7c6748d43d25`
- `src/pages/KnobExplorer.jsx`: `a9bc858e-add8-4094-995a-188ae08fd56e`
- `src/pages/Pitch.jsx`, `src/pages/PitchFull.jsx`, `src/pages/PitchShort2.jsx`: `728ef1b3-0a23-476b-9a3d-bcae6ec6ba64`

## Portal Policy Disclosure

The actual `/privacy`, `/terms`, and `/refund` pages redirect from this repo to `portal.traigent.ai`. The portal-hosted privacy-policy update is in https://github.com/Traigent/TraigentFrontend/pull/1100.

The policy update discloses:

- known HubSpot contact identification via `hubspotutk`;
- the Cloudflare Worker lookup against HubSpot Contacts API;
- returned known-contact email use;
- sales/team notifications for Start Now, Portal access prompts, Academy gates, `/story`, `/pricing`, `/ttm`, `/roi`, `/knob-explorer`, `/pitch`, `/pitch-full`, and `/pitch-short-2`;
- consent as the lawful basis for non-essential marketing analytics and known-contact identification;
- rejection and withdrawal behavior through Cookie Preferences.

## Validation

- `npm ci`
- `npm run build`
- `git diff --check`
- `./node_modules/.bin/eslint src/lib/hubspotIdentify.js --no-eslintrc --env browser,es2022 --parser-options '{\"ecmaVersion\":2022,\"sourceType\":\"module\"}' --rule 'no-unused-vars:error'`
- `./node_modules/.bin/eslint src/lib/consent.js src/components/CookieConsent.jsx --no-eslintrc --env browser,es2022 --parser-options '{\"ecmaVersion\":2022,\"sourceType\":\"module\",\"ecmaFeatures\":{\"jsx\":true}}' --rule 'no-unused-vars:error'`
- Consent helper smoke: JSON consent record includes `granted`, ISO timestamp, and `2026-06-06 rev. 4`; legacy `true`/`false` values still parse correctly.
- Targeted unused-import check:
  - `./node_modules/.bin/eslint src/lib/analytics.js src/components/CookieConsent.jsx --no-eslintrc --env browser,es2022 --parser-options '{"ecmaVersion":2022,"sourceType":"module","ecmaFeatures":{"jsx":true}}' --rule 'no-unused-vars:error'`
- Local browser verification with test analytics env vars:
  - Before consent: no external GA4, Clarity, HubSpot, PostHog, Worker, or `/check?utk` requests; no analytics scripts/globals/cookies/localStorage.
  - After Accept: analytics scripts load as expected.
  - After Reject: analytics scripts removed, `gtag`/`clarity`/`posthog`/`_hsq` globals absent, analytics cookies empty, localStorage only contains `traigent_marketing_consent` with `{ granted: false, ts, policyRev }`, sessionStorage empty.

## Risk Notes

The Worker still returns email for known contacts because the current marketing flow needs email to unlock repeat visitors and submit HubSpot notification forms. CORS origin checks are not cryptographic authentication; moving notification submission fully into the Worker so the browser receives only `{ known: true }` is a larger follow-up design change.

## Worker Source

Worker hardening PR: https://github.com/Traigent/hsutk-check-worker/pull/1

## Deployment Notes

- No Cloudflare Worker deploy was performed in this PR.
- No HubSpot token was handled in this PR.
- `VITE_HSUTK_CHECK_URL` remains unset until the Worker URL is available.
- `VITE_HSUTK_IDENTIFY_ENABLED` remains default-off until the Worker PR is merged/deployed, `VITE_HSUTK_CHECK_URL` is set, and final production enablement is approved.