### PR TITLE
fix(web): post-release copy — onboard shipped; installer → traigent[recommended]

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -20,10 +20,11 @@ PATH="$HOME/.local/bin:$HOME/.cargo/bin${ORIGINAL_PATH:+:$ORIGINAL_PATH}"
 export PATH
 
 # Keep the installer default aligned with the packaged quickstart dependencies.
-# Switch this to traigent[recommended] once that extras bundle ships.
-PACKAGE="traigent[integrations]"
+# traigent[recommended] shipped in 0.12.0 (= integrations + analytics + hybrid
+# + visualization + bayesian + pydanticai) — the intended onboarding bundle.
+PACKAGE="traigent[recommended]"
 if [ -n "${TRAIGENT_VERSION:-}" ]; then
-  PACKAGE="traigent[integrations]==${TRAIGENT_VERSION}"
+  PACKAGE="traigent[recommended]==${TRAIGENT_VERSION}"
 fi
 
 ATTEMPT_SUMMARY=""

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -29,9 +29,9 @@ const SDK_SKILL_INSTALL_COMMAND = [
 const TERMINAL_INSTALL_COMMAND = "curl -fsSL https://traigent.ai/install.sh | sh";
 // Switch these defaults to traigent[recommended] once that extras bundle ships.
 const MANUAL_INSTALL_COMMANDS = [
-  "uv tool install 'traigent[integrations]'",
-  "pipx install 'traigent[integrations]'",
-  "pip install 'traigent[integrations]'",
+  "uv tool install 'traigent[recommended]'",
+  "pipx install 'traigent[recommended]'",
+  "pip install 'traigent[recommended]'",
 ];
 
 export default function GetStarted() {
@@ -131,7 +131,7 @@ export default function GetStarted() {
           <div className="p-6 rounded-xl bg-slate-900/60 border border-slate-800 flex flex-col">
             <h2 className="text-xl font-semibold mb-2">Traigent SDK</h2>
             <p className="text-slate-300 mb-4">
-              Install the published Python SDK from your terminal. The bootstrap is a thin shell script that installs <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent[integrations]</code>, verifies <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent info</code>, and never prompts for or reads credentials. Today&apos;s SDK uses an API key from <a href="https://portal.traigent.ai" target="_blank" rel="noopener noreferrer" className="text-blue-300 hover:text-blue-200 underline underline-offset-4">portal.traigent.ai</a>; when <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent onboard</code> ships, the installer will detect it.
+              Install the published Python SDK from your terminal. The bootstrap is a thin shell script that installs <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent[recommended]</code>, verifies <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent info</code>, and never prompts for or reads credentials. The installer detects <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent onboard</code> (included in the published SDK) and suggests it next — it sets up device login against <a href="https://portal.traigent.ai" target="_blank" rel="noopener noreferrer" className="text-blue-300 hover:text-blue-200 underline underline-offset-4">portal.traigent.ai</a> and your coding agent.
             </p>
             {unlocked && (
               <>


### PR DESCRIPTION
Post-publish verification sweep (codex + captain adjudication) found one factually stale string and one now-satisfiable TODO:
1. **GetStarted.jsx**: said *'when `traigent onboard` ships, the installer will detect it'* — onboard shipped in 0.12.0 (live on PyPI, verified by fresh-venv install). Copy now describes the real flow.
2. **install.sh**: per its own TODO, switches `traigent[integrations]` → `traigent[recommended]` (shipped in 0.12.0; `pip --dry-run traigent[recommended]==0.12.0` resolves cleanly). This also unifies the installer CTA with the Start Now command, resolving the reviewer-flagged CTA split at the root. Fallback manual commands aligned.

vite build ✓, `sh -n` ✓. Merge = deploy. 🤖 Generated with [Claude Code](https://claude.com/claude-code)