### PR TITLE
feat: add research page

### DIFF
--- a/public/research/index.html
+++ b/public/research/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Research - Traigent</title>
+  <meta name="description" content="Traigent research on governed AI configuration, tuned variables, TVL, and CI/CD-oriented optimization for AI-enabled systems." />
+  <link rel="canonical" href="https://traigent.ai/research" />
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <style>
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:#f8fafc;color:#0f172a;line-height:1.6}
+    header{background:#020617;border-bottom:1px solid #1e293b;padding:1rem 2rem;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem}
+    header a.logo{font-size:1.25rem;font-weight:700;text-decoration:none;color:#fff}
+    header nav{display:flex;gap:1.5rem;flex-wrap:wrap}
+    header nav a{color:#cbd5e1;text-decoration:none;font-size:.9rem}
+    header nav a:hover{color:#fff}
+    .hero{background:#020617;color:#fff}
+    .wrap{max-width:1120px;margin:0 auto;padding:4rem 1.5rem}
+    .kicker{font-size:.75rem;font-weight:700;text-transform:uppercase;letter-spacing:.18em;color:#93c5fd;margin-bottom:1rem}
+    h1{font-size:clamp(2.25rem,5vw,4rem);line-height:1.08;margin-bottom:1rem}
+    h2{font-size:1.75rem;line-height:1.2;margin-bottom:.75rem;color:#0f172a}
+    .hero p{color:#cbd5e1;font-size:1.1rem;max-width:760px}
+    .badges{display:grid;gap:1rem;margin-top:2rem;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+    .badge{border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.05);border-radius:.75rem;padding:1rem;color:#fff;text-decoration:none}
+    .badge span{display:block;color:#94a3b8;font-size:.85rem;margin-top:.25rem}
+    main .wrap{padding-top:3.5rem;padding-bottom:3.5rem}
+    .grid{display:grid;gap:2rem;grid-template-columns:minmax(0,1.2fr) minmax(280px,.8fr)}
+    .card{background:#fff;border:1px solid #e2e8f0;border-radius:.75rem;padding:1.5rem}
+    .muted{color:#475569}
+    .chips{display:flex;flex-wrap:wrap;gap:.5rem;margin:1.25rem 0}
+    .chip{border:1px solid #cbd5e1;border-radius:999px;padding:.25rem .75rem;font-size:.85rem;background:#fff;color:#334155}
+    .button{display:inline-flex;align-items:center;gap:.5rem;margin-top:1rem;border-radius:.5rem;background:#0f172a;color:#fff;padding:.75rem 1rem;text-decoration:none;font-weight:700;font-size:.9rem}
+    .note{font-size:.85rem;color:#64748b;margin-top:2rem}
+    footer{background:#fff;border-top:1px solid #e2e8f0;padding:2rem;text-align:center;color:#64748b;font-size:.875rem}
+    footer a{color:#1d4ed8;text-decoration:none}
+    @media (max-width:760px){.grid{grid-template-columns:1fr}}
+  </style>
+</head>
+<body>
+  <header>
+    <a class="logo" href="/">Traigent</a>
+    <nav>
+      <a href="/#/research">Research</a>
+      <a href="https://tvl-lang.org/">TVL</a>
+      <a href="/#/pricing">Pricing</a>
+      <a href="https://portal.traigent.ai">Try Traigent</a>
+    </nav>
+  </header>
+
+  <section class="hero">
+    <div class="wrap">
+      <p class="kicker">Research-backed AI engineering</p>
+      <h1>Governed agent optimization, grounded in research</h1>
+      <p>Traigent connects product engineering with peer-reviewed work on governed tuned variables, CI/CD evidence, and formal agent specifications.</p>
+      <div class="badges">
+        <a class="badge" href="https://conf.researchr.org/details/cain-2026/cain-2026-call-for-papers/22/Governed-Configuration-for-AI-Enabled-Systems-Maintaining-Tuned-Variables-in-CI-CD">Peer-reviewed research<span>CAIN 2026 Research Track</span></a>
+        <a class="badge" href="https://conf.researchr.org/home/cain-2026">Co-located with ICSE<span>CAIN 2026 / ICSE 2026</span></a>
+        <a class="badge" href="https://tvl-lang.org/">Formal specification<span>TVL language</span></a>
+      </div>
+    </div>
+  </section>
+
+  <main>
+    <div class="wrap grid">
+      <article>
+        <p class="kicker" style="color:#1d4ed8">CAIN 2026 paper</p>
+        <h2>Governed Configuration for AI-Enabled Systems: Maintaining Tuned Variables in CI/CD</h2>
+        <p class="muted">The paper frames tuned variables as governed configuration choices for AI-enabled systems and outlines a CI/CD-oriented lifecycle for evidence, promotion, and rollback.</p>
+        <div class="chips">
+          <span class="chip">Short paper</span>
+          <span class="chip">CAIN 2026 Research Track</span>
+          <span class="chip">Co-located with ICSE 2026</span>
+        </div>
+        <a class="button" href="https://conf.researchr.org/details/cain-2026/cain-2026-call-for-papers/22/Governed-Configuration-for-AI-Enabled-Systems-Maintaining-Tuned-Variables-in-CI-CD">View official CAIN entry</a>
+      </article>
+
+      <aside class="card">
+        <h2>TVL language</h2>
+        <p class="muted">TVL gives teams a machine-checkable way to describe tunables, objectives, constraints, budgets, and promotion policies for agent systems.</p>
+        <a class="button" href="https://tvl-lang.org/">Explore TVL</a>
+      </aside>
+    </div>
+
+    <div class="wrap" style="padding-top:0">
+      <div class="card">
+        <h2>Trademark-safe attribution</h2>
+        <p class="muted">CAIN, ICSE, ACM, and IEEE names are used only for factual identification of venues, programs, and professional service. No sponsorship, endorsement, certification, approval, or partnership is implied.</p>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <p>Traigent Ltd, Hartglas 16, Tel-Aviv, Israel</p>
+    <p><a href="https://portal.traigent.ai/terms">Terms of Service</a> &middot; <a href="https://portal.traigent.ai/privacy">Privacy Policy</a> &middot; <a href="https://portal.traigent.ai/refund">Refund Policy</a></p>
+  </footer>
+</body>
+</html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -11,6 +11,16 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://traigent.ai/research</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://traigent.ai/#/research</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://traigent.ai/#/blog/the-business-case</loc>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import PitchShort from './pages/PitchShort'
 import PitchShort2 from './pages/PitchShort2'
 import Blog from './pages/Blog'
 import BlogPost from './pages/BlogPost'
+import Research from './pages/Research'
 import ROICalculator from './pages/ROICalculator'
 import TTMCalculator from './pages/TTMCalculator'
 import AgentOptimization from './pages/AgentOptimization'
@@ -54,6 +55,7 @@ export default function App() {
         <Route path="value-proposition" element={<ValueProposition />} />
         <Route path="blog" element={<Blog />} />
         <Route path="blog/:slug" element={<BlogPost />} />
+        <Route path="research" element={<Research />} />
         <Route path="roi" element={<ROICalculator />} />
         <Route path="ttm" element={<TTMCalculator />} />
         <Route path="agent-optimization" element={<AgentOptimization />} />

--- a/src/components/ResearchCredibilityStrip.jsx
+++ b/src/components/ResearchCredibilityStrip.jsx
@@ -1,0 +1,112 @@
+import { Braces, ExternalLink, FileText, GraduationCap } from "lucide-react";
+import { Link } from "react-router-dom";
+import { researchLinks, researchPaper, tvlLinks } from "../content/research";
+import { trackEvent } from "../lib/analytics";
+
+const badges = [
+  {
+    label: "Peer-reviewed research",
+    detail: researchPaper.venue,
+    href: researchLinks.cainPaper,
+    icon: FileText,
+  },
+  {
+    label: "Co-located with ICSE",
+    detail: "CAIN 2026 / ICSE 2026",
+    href: researchLinks.cainHome,
+    icon: GraduationCap,
+  },
+  {
+    label: "Formal specification",
+    detail: "TVL language",
+    href: tvlLinks.home,
+    icon: Braces,
+  },
+];
+
+const variantStyles = {
+  dark: {
+    shell: "text-white",
+    eyebrow: "text-blue-300",
+    body: "text-slate-300",
+    card: "border-white/10 bg-slate-950/60 hover:border-blue-400/50 hover:bg-slate-900/80",
+    icon: "bg-blue-500/15 text-blue-300",
+    label: "text-white",
+    detail: "text-slate-400",
+    note: "text-slate-500",
+    cta: "border-white/10 text-slate-200 hover:border-white/25 hover:text-white",
+  },
+  light: {
+    shell: "text-slate-950",
+    eyebrow: "text-blue-700",
+    body: "text-slate-600",
+    card: "border-slate-200 bg-slate-50 hover:border-blue-300 hover:bg-white",
+    icon: "bg-blue-100 text-blue-700",
+    label: "text-slate-950",
+    detail: "text-slate-600",
+    note: "text-slate-500",
+    cta: "border-slate-200 text-slate-700 hover:border-slate-300 hover:text-slate-950",
+  },
+};
+
+export default function ResearchCredibilityStrip({ variant = "light", compact = false }) {
+  const styles = variantStyles[variant] || variantStyles.light;
+
+  return (
+    <section className={`${styles.shell} ${compact ? "py-4" : "py-5 md:py-6"}`}>
+      <div className="grid gap-5 lg:grid-cols-[minmax(0,0.34fr)_minmax(0,0.66fr)] lg:items-center">
+        <div>
+          <p className={`text-xs font-semibold uppercase tracking-[0.18em] ${styles.eyebrow}`}>
+            Research-backed AI engineering
+          </p>
+          <p className={`mt-2 text-sm leading-6 ${styles.body}`}>
+            Traigent connects product engineering with peer-reviewed work on governed tuned
+            variables, CI/CD evidence, and formal agent specifications.
+          </p>
+          {!compact && (
+            <Link
+              to="/research"
+              onClick={() =>
+                trackEvent("research_credibility_strip_click", { destination: "/research" })
+              }
+              className={`mt-4 inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold transition-colors ${styles.cta}`}
+            >
+              See research
+            </Link>
+          )}
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3">
+          {badges.map(({ label, detail, href, icon: Icon }) => (
+            <a
+              key={label}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() =>
+                trackEvent("research_credibility_badge_click", {
+                  label,
+                  destination: href,
+                })
+              }
+              className={`group rounded-lg border p-4 transition-colors ${styles.card}`}
+            >
+              <div className={`mb-3 inline-flex h-9 w-9 items-center justify-center rounded-lg ${styles.icon}`}>
+                <Icon className="h-4 w-4" />
+              </div>
+              <div className={`text-sm font-semibold ${styles.label}`}>{label}</div>
+              <div className={`mt-1 flex items-center gap-1 text-xs leading-5 ${styles.detail}`}>
+                {detail}
+                <ExternalLink className="h-3 w-3 opacity-70 transition-opacity group-hover:opacity-100" />
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+      <p className={`mt-4 text-xs leading-5 ${styles.note}`}>
+        Organization and conference names are used for factual identification only; no endorsement
+        or sponsorship is implied.
+      </p>
+    </section>
+  );
+}

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -77,6 +77,7 @@ const resourcesItems = [
   { label: "TTM Calculator", href: "/ttm", desc: "Engineer-weeks saved per optimization pass" },
   { label: "Compare", href: "/compare", desc: "vs. Langfuse · Arize · Helicone · Braintrust" },
   { label: "FAQ", href: "/faq", desc: "Common questions" },
+  { label: "Research", href: "/research", desc: "CAIN 2026 paper, TVL, and governed optimization" },
   { label: "Docs", href: "https://github.com/Traigent/Traigent", external: true, desc: "SDK on GitHub" },
   { label: "Academy", href: "/academy", desc: "Short courses for teams shipping AI agents" },
   { label: "About", href: "/about", desc: "Team, mission, values" },

--- a/src/content/research.js
+++ b/src/content/research.js
@@ -1,0 +1,22 @@
+export const portalUrl = "https://portal.traigent.ai";
+
+export const tvlLinks = {
+  home: "https://tvl-lang.org/",
+};
+
+export const researchLinks = {
+  cainHome: "https://conf.researchr.org/home/cain-2026",
+  cainProgram: "https://conf.researchr.org/program/cain-2026/program-cain-2026",
+  cainPaper:
+    "https://conf.researchr.org/details/cain-2026/cain-2026-call-for-papers/22/Governed-Configuration-for-AI-Enabled-Systems-Maintaining-Tuned-Variables-in-CI-CD",
+};
+
+export const researchPaper = {
+  title: "Governed Configuration for AI-Enabled Systems: Maintaining Tuned Variables in CI/CD",
+  summary:
+    "The paper frames tuned variables as governed configuration choices for AI-enabled systems and outlines a CI/CD-oriented lifecycle for evidence, promotion, and rollback.",
+  type: "Short paper",
+  venue: "CAIN 2026 Research Track",
+  venueDetail: "Co-located with ICSE 2026",
+  authorLine: "Nimrod Busany, Traigent",
+};

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -655,6 +655,11 @@ def answer_question(question: str) -> str:
                   </Link>
                 </li>
                 <li>
+                  <Link to="/research" className="text-slate-400 hover:text-white transition-colors">
+                    Research
+                  </Link>
+                </li>
+                <li>
                   <a href="https://www.tvl-lang.org/" target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
                     Learn TVL
                   </a>

--- a/src/pages/Research.jsx
+++ b/src/pages/Research.jsx
@@ -1,0 +1,331 @@
+import { ArrowRight, Braces, ExternalLink, FileText, GitBranch, ShieldCheck } from "lucide-react";
+import { Helmet } from "react-helmet-async";
+import { Link } from "react-router-dom";
+import ResearchCredibilityStrip from "../components/ResearchCredibilityStrip";
+import { portalUrl, researchLinks, researchPaper, tvlLinks } from "../content/research";
+import { trackEvent } from "../lib/analytics";
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "ScholarlyArticle",
+  headline: researchPaper.title,
+  author: {
+    "@type": "Person",
+    name: "Nimrod Busany",
+    affiliation: {
+      "@type": "Organization",
+      name: "Traigent",
+    },
+  },
+  isPartOf: {
+    "@type": "PublicationEvent",
+    name: "CAIN 2026 Research Track",
+    url: researchLinks.cainHome,
+  },
+  url: researchLinks.cainPaper,
+};
+
+const evidenceItems = [
+  {
+    title: "Peer-reviewed framing",
+    body: "The CAIN paper makes tuned variables explicit as governed configuration decisions, not ad hoc prompt tweaks.",
+    icon: FileText,
+  },
+  {
+    title: "CI/CD-oriented operation",
+    body: "The lifecycle emphasizes evidence, promotion, rollback, and maintainable operation as model behavior and costs change.",
+    icon: GitBranch,
+  },
+  {
+    title: "Formal specification path",
+    body: "TVL extends the same idea into machine-checkable objectives, constraints, tunables, and rollout policies.",
+    icon: Braces,
+  },
+  {
+    title: "Governance-first product",
+    body: "Traigent turns those ideas into operational workflows for measuring, optimizing, approving, and applying agent configurations.",
+    icon: ShieldCheck,
+  },
+];
+
+export default function Research() {
+  return (
+    <div className="min-h-screen bg-white text-slate-950">
+      <Helmet>
+        <title>Research - Traigent</title>
+        <meta
+          name="description"
+          content="Traigent research on governed AI configuration, tuned variables, TVL, and CI/CD-oriented optimization for AI-enabled systems."
+        />
+        <link rel="canonical" href="https://traigent.ai/research" />
+        <meta property="og:title" content="Research - Traigent" />
+        <meta
+          property="og:description"
+          content="Peer-reviewed work and specifications behind Traigent's governed agent optimization platform."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://traigent.ai/research" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="Research - Traigent" />
+        <meta
+          name="twitter:description"
+          content="Governed agent optimization, grounded in research and formal specification."
+        />
+        <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
+      </Helmet>
+      <section className="bg-slate-950 text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+          <div className="max-w-4xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-blue-300">
+              Research and specifications
+            </p>
+            <h1 className="mt-4 text-3xl font-bold leading-tight tracking-normal sm:text-4xl md:text-6xl">
+              Governed agent optimization, grounded in research
+            </h1>
+            <p className="mt-6 max-w-3xl text-base leading-7 text-slate-300 sm:text-lg sm:leading-8">
+              Traigent is built around a simple engineering thesis: agent behavior should be
+              specified, measured, optimized, promoted, and rolled back with the same discipline as
+              production software.
+            </p>
+          </div>
+
+          <div className="mt-10">
+            <ResearchCredibilityStrip variant="dark" compact />
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-slate-200 bg-slate-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14">
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,0.58fr)_minmax(320px,0.42fr)]">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.18em] text-blue-700">
+                CAIN 2026 paper
+              </p>
+              <h2 className="mt-3 text-2xl font-bold tracking-normal text-slate-950 sm:text-3xl md:text-4xl">
+                {researchPaper.title}
+              </h2>
+              <p className="mt-4 text-lg leading-8 text-slate-700">{researchPaper.summary}</p>
+              <div className="mt-6 flex flex-wrap gap-3 text-sm">
+                <span className="rounded-full border border-slate-300 bg-white px-3 py-1 font-medium text-slate-700">
+                  {researchPaper.type}
+                </span>
+                <span className="rounded-full border border-slate-300 bg-white px-3 py-1 font-medium text-slate-700">
+                  {researchPaper.venue}
+                </span>
+                <span className="rounded-full border border-slate-300 bg-white px-3 py-1 font-medium text-slate-700">
+                  {researchPaper.venueDetail}
+                </span>
+              </div>
+              <div className="mt-8 flex flex-wrap gap-3">
+                <a
+                  href={researchLinks.cainPaper}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() =>
+                    trackEvent("research_page_cain_paper_click", {
+                      destination: researchLinks.cainPaper,
+                    })
+                  }
+                  className="inline-flex items-center gap-2 rounded-lg bg-slate-950 px-5 py-3 text-sm font-semibold text-white hover:bg-slate-800"
+                >
+                  View official CAIN entry
+                  <ExternalLink className="h-4 w-4" />
+                </a>
+                <a
+                  href={researchLinks.cainProgram}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() =>
+                    trackEvent("research_page_cain_program_click", {
+                      destination: researchLinks.cainProgram,
+                    })
+                  }
+                  className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-950 hover:border-slate-400"
+                >
+                  See CAIN program
+                  <ExternalLink className="h-4 w-4" />
+                </a>
+              </div>
+            </div>
+
+            <aside className="rounded-lg border border-slate-200 bg-white p-6">
+              <div className="border-b border-slate-200 pb-5">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-blue-700">
+                  Peer-reviewed research
+                </p>
+                <div className="mt-3 text-2xl font-bold text-slate-950">CAIN 2026</div>
+                <p className="mt-2 text-sm leading-6 text-slate-700">
+                  International Conference on AI Engineering, co-located with ICSE 2026.
+                </p>
+              </div>
+              <dl className="mt-6 space-y-4 text-sm">
+                <div>
+                  <dt className="font-semibold text-slate-950">Author</dt>
+                  <dd className="mt-1 text-slate-600">{researchPaper.authorLine}</dd>
+                </div>
+                <div>
+                  <dt className="font-semibold text-slate-950">Session</dt>
+                  <dd className="mt-1 text-slate-600">Governance and Compliance</dd>
+                </div>
+                <div>
+                  <dt className="font-semibold text-slate-950">Product connection</dt>
+                  <dd className="mt-1 text-slate-600">
+                    Tuned-variable governance, evidence-backed promotion, rollback, and
+                    cost-aware operation.
+                  </dd>
+                </div>
+              </dl>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          {evidenceItems.map(({ title, body, icon: Icon }) => (
+            <div key={title} className="rounded-lg border border-slate-200 bg-white p-6">
+              <div className="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-slate-950 text-white">
+                <Icon className="h-5 w-5" />
+              </div>
+              <h3 className="text-lg font-semibold text-slate-950">{title}</h3>
+              <p className="mt-2 text-sm leading-6 text-slate-600">{body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-slate-950 text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+          <div className="grid gap-10 lg:grid-cols-[minmax(0,0.56fr)_minmax(320px,0.44fr)] lg:items-center">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.18em] text-blue-300">
+                TVL language
+              </p>
+              <h2 className="mt-3 text-3xl font-bold tracking-normal md:text-4xl">
+                The specification layer for tunable agent systems
+              </h2>
+              <p className="mt-4 text-lg leading-8 text-slate-300">
+                TVL gives teams a machine-checkable way to describe the decisions Traigent can
+                explore: models, prompts, retrieval, tools, budgets, constraints, objectives, and
+                promotion policies.
+              </p>
+              <div className="mt-8 flex flex-wrap gap-3">
+                <a
+                  href={tvlLinks.home}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() =>
+                    trackEvent("research_page_tvl_home_click", { destination: tvlLinks.home })
+                  }
+                  className="inline-flex items-center gap-2 rounded-lg bg-white px-5 py-3 text-sm font-semibold text-slate-950 hover:bg-slate-100"
+                >
+                  Explore TVL
+                  <ExternalLink className="h-4 w-4" />
+                </a>
+                <Link
+                  to="/get-started"
+                  onClick={() =>
+                    trackEvent("research_page_get_started_click", { destination: "/get-started" })
+                  }
+                  className="inline-flex items-center gap-2 rounded-lg border border-white/15 px-5 py-3 text-sm font-semibold text-slate-200 hover:border-white/30 hover:text-white"
+                >
+                  Start with SDK or TVL
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-white/10 bg-white/[0.04] p-6 font-mono text-sm text-slate-300">
+              <div className="mb-4 text-xs uppercase tracking-[0.18em] text-slate-500">
+                agent.tvl.yml
+              </div>
+              <pre className="overflow-x-auto">
+{`configuration_space:
+  model: ["gpt-4o-mini", "gpt-4o"]
+  retrieval_top_k: [2, 4, 8]
+
+objectives:
+  - name: answer_quality
+    direction: maximize
+  - name: cost
+    direction: minimize
+
+constraints:
+  - latency_ms <= 1200
+  - monthly_spend_usd <= budget`}
+              </pre>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-slate-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <div className="rounded-lg border border-slate-200 bg-white p-6">
+            <h2 className="text-lg font-semibold text-slate-950">Trademark-safe attribution</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              CAIN, ICSE, ACM, and IEEE names are used on this page only for factual identification
+              of venues, programs, and professional service. No sponsorship, endorsement,
+              certification, approval, or partnership is implied.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14">
+          <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-2xl font-bold tracking-normal text-slate-950">
+                Turn research into governed agent operations
+              </h2>
+              <p className="mt-2 text-slate-600">
+                Use Traigent to specify, evaluate, optimize, and promote AI agent configurations.
+              </p>
+            </div>
+            <a
+              href={portalUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() =>
+                trackEvent("portal_sign_up_cta_click", { location: "research_final_cta" })
+              }
+              className="inline-flex items-center gap-2 rounded-lg bg-slate-950 px-5 py-3 text-sm font-semibold text-white hover:bg-slate-800"
+            >
+              Try Traigent
+              <ArrowRight className="h-4 w-4" />
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <footer className="bg-slate-950 text-white py-12">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+            <div>
+              <div className="text-xl font-bold">Traigent</div>
+              <p className="mt-2 max-w-md text-sm text-slate-400">
+                Agent Optimization Platform. Wrap. Optimize. Converge. Re-optimize.
+              </p>
+              <p className="mt-4 text-xs text-slate-500">
+                Traigent Ltd, Hartglas 16, Tel-Aviv, Israel
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-x-5 gap-y-2 text-sm text-slate-400">
+              <a href={`${portalUrl}/privacy`} className="hover:text-white transition-colors">
+                Privacy Policy
+              </a>
+              <a href={`${portalUrl}/terms`} className="hover:text-white transition-colors">
+                Terms of Service
+              </a>
+              <a href={`${portalUrl}/refund`} className="hover:text-white transition-colors">
+                Refund Policy
+              </a>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a Research page for the CAIN 2026 paper, TVL, and governed agent optimization positioning.
- Add a shared research content module plus credibility strip component.
- Wire the page into App routes, Resources nav, homepage footer, sitemap, and a direct public /research fallback page.

## Validation
- npm run build
- git diff --check
- Headless Chrome screenshot smoke for http://127.0.0.1:5178/#/research

## Notes
- npm run lint is not currently usable in this checkout because the repo has no ESLint config file; the command fails before linting source.
- Left unrelated local artifacts unstaged: .greptile/, .playwright-cli/, output/, public/slack-workspace-icon.png.