### PR TITLE
feat(outreach): short shareable URLs for hidden-menu deck + blog items

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,10 @@ export default function App() {
       <Route path="pitch-short" element={<PitchShort />} />
       <Route path="pitch-short-2" element={<PitchShort2 />} />
       <Route path="pitch-short-2/:preset" element={<PitchShort2 />} />
+      {/* Short, shareable aliases for outreach (no /pitch-short-2/ prefix) */}
+      <Route path="extended-product-presentation" element={<PitchShort2 forcedPreset="extended-product-presentation" />} />
+      <Route path="short-summary" element={<PitchShort2 forcedPreset="short-summary" />} />
+      <Route path="market-opportunity" element={<PitchShort2 forcedPreset="market-opportunity" />} />
       <Route path="knob-explorer" element={<KnobExplorer />} />
       <Route path="demo" element={<OptimizationDemo />} />
       <Route path="story" element={<StoryMovie />} />
@@ -55,6 +59,9 @@ export default function App() {
         <Route path="value-proposition" element={<ValueProposition />} />
         <Route path="blog" element={<Blog />} />
         <Route path="blog/:slug" element={<BlogPost />} />
+        {/* Short, shareable aliases for outreach (no /blog/ prefix) */}
+        <Route path="agent-knobs-101" element={<BlogPost forcedSlug="agent-knobs-101" />} />
+        <Route path="implementing-agent-knobs" element={<BlogPost forcedSlug="implementing-agent-knobs" />} />
         <Route path="research" element={<Research />} />
         <Route path="roi" element={<ROICalculator />} />
         <Route path="ttm" element={<TTMCalculator />} />

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -25,17 +25,17 @@ const PITCH_DECK_OPTIONS = [
   {
     label: "Extended product presentation",
     desc: "Full product deck + live demo (no investor section)",
-    href: "/#/pitch-short-2/extended-product-presentation",
+    href: "/#/extended-product-presentation",
   },
   {
     label: "Short summary",
     desc: "Slides 1–5 + live demo — the headline arc",
-    href: "/#/pitch-short-2/short-summary",
+    href: "/#/short-summary",
   },
   {
     label: "Market opportunity",
     desc: "Investor section + live demo",
-    href: "/#/pitch-short-2/market-opportunity",
+    href: "/#/market-opportunity",
   },
   {
     label: "Knob explorer",
@@ -55,12 +55,12 @@ const PITCH_DECK_OPTIONS = [
   {
     label: "Agent Knobs 101 (3-min read)",
     desc: "Primer · three concrete knobs, what they do, why they matter",
-    href: "/#/blog/agent-knobs-101",
+    href: "/#/agent-knobs-101",
   },
   {
     label: "Implementing Agent Knobs (18-min read)",
     desc: "Reference · every knob with effect + code you can paste in",
-    href: "/#/blog/implementing-agent-knobs",
+    href: "/#/implementing-agent-knobs",
   },
 ];
 

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -100,8 +100,11 @@ const mdComponents = {
   ),
 };
 
-export default function BlogPost() {
-  const { slug } = useParams();
+export default function BlogPost({ forcedSlug } = {}) {
+  const { slug: urlSlug } = useParams();
+  // forcedSlug lets App.jsx mount a BlogPost at a short top-level route
+  // (/agent-knobs-101) without needing the /blog/ prefix in the URL.
+  const slug = forcedSlug || urlSlug;
   const post = getPostBySlug(slug);
 
   if (!post) return <Navigate to="/blog" replace />;

--- a/src/pages/PitchShort2.jsx
+++ b/src/pages/PitchShort2.jsx
@@ -190,7 +190,7 @@ function resolveSlides(rangeParam, excludeParam, allSlides) {
   return allSlides;
 }
 
-export default function PitchShort2() {
+export default function PitchShort2({ forcedPreset } = {}) {
   usePageView();
   useKnownContactNotify({
     notify: notifyPitchDeckViewed,
@@ -199,7 +199,10 @@ export default function PitchShort2() {
   });
   const scale = useViewportScale();
   useRemoveChatWidget();
-  const { preset } = useParams();
+  // forcedPreset lets App.jsx mount this deck at a short top-level route
+  // (e.g. /extended-product-presentation) without the /pitch-short-2/ prefix.
+  const { preset: urlPreset } = useParams();
+  const preset = forcedPreset || urlPreset;
   const [searchParams] = useSearchParams();
   const slidesToRender = useMemo(() => {
     // Named preset on the URL path (e.g. /pitch-short-2/short-summary) wins


### PR DESCRIPTION
## Before
```
traigent.ai/#/pitch-short-2/extended-product-presentation
traigent.ai/#/pitch-short-2/short-summary
traigent.ai/#/pitch-short-2/market-opportunity
traigent.ai/#/blog/agent-knobs-101
traigent.ai/#/blog/implementing-agent-knobs
```

## After
```
traigent.ai/#/extended-product-presentation
traigent.ai/#/short-summary
traigent.ai/#/market-opportunity
traigent.ai/#/agent-knobs-101
traigent.ai/#/implementing-agent-knobs
```

Five aliased top-level routes. PitchShort2 + BlogPost accept optional `forcedPreset` / `forcedSlug` props so the App.jsx routes can mount them directly without the /pitch-short-2/ or /blog/ prefix in the URL. Existing long routes preserved for backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)