### PR TITLE
fix(growth): per-gate throttle + localStorage email fallback for tracking pixels

### DIFF
--- a/src/components/PortalGateModal.jsx
+++ b/src/components/PortalGateModal.jsx
@@ -6,7 +6,7 @@ import {
   isUnlocked,
   markUnlocked,
   getUnlockedEmail,
-  shouldNotifyRepeatVisit,
+  shouldNotifyForGate,
 } from "../lib/startNowGate";
 import { notifyPortalRepeat, PORTAL_FORM_ID } from "../lib/hubspotForms";
 import { checkKnownContact } from "../lib/hubspotIdentify";
@@ -48,7 +48,7 @@ export default function PortalGateModal({ onClose, location = "unknown" }) {
   // so the founder sees "they came back for the portal". Throttled.
   useEffect(() => {
     if (!unlocked) return;
-    if (!shouldNotifyRepeatVisit()) return;
+    if (!shouldNotifyForGate("portal")) return;
     const email = getUnlockedEmail();
     if (!email) return;
     notifyPortalRepeat({ email, location });

--- a/src/components/StartNowModal.jsx
+++ b/src/components/StartNowModal.jsx
@@ -7,7 +7,7 @@ import {
   isUnlocked,
   markUnlocked,
   getUnlockedEmail,
-  shouldNotifyRepeatVisit,
+  shouldNotifyForGate,
 } from "../lib/startNowGate";
 import { notifyStartNowRepeat } from "../lib/hubspotForms";
 import { checkKnownContact } from "../lib/hubspotIdentify";
@@ -49,7 +49,7 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
   // stays sane.
   useEffect(() => {
     if (!unlocked) return;
-    if (!shouldNotifyRepeatVisit()) return;
+    if (!shouldNotifyForGate("startnow")) return;
     const email = getUnlockedEmail();
     if (!email) return;
     notifyStartNowRepeat({ email, location });

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -9,7 +9,7 @@ import {
   isUnlocked,
   markUnlocked,
   getUnlockedEmail,
-  shouldNotifyRepeatVisit,
+  shouldNotifyForGate,
 } from "../lib/startNowGate";
 import { notifyPortalRepeat } from "../lib/hubspotForms";
 import { checkKnownContact } from "../lib/hubspotIdentify";
@@ -214,7 +214,7 @@ export default function TopNav() {
   const handleOpenPortal = async (loc) => {
     if (isUnlocked()) {
       const email = getUnlockedEmail();
-      if (email && shouldNotifyRepeatVisit()) {
+      if (email && shouldNotifyForGate("portal")) {
         notifyPortalRepeat({ email, location: loc });
       }
       trackEvent("portal_opened", { location: loc });
@@ -224,7 +224,7 @@ export default function TopNav() {
     const result = await checkKnownContact();
     if (result && result.known && result.email) {
       markUnlocked(result.email);
-      notifyPortalRepeat({ email: result.email, location: loc });
+      if (shouldNotifyForGate("portal")) notifyPortalRepeat({ email: result.email, location: loc });
       trackEvent("portal_opened", { location: loc });
       trackEvent("portal_auto_unlocked", { location: loc });
       window.open(PORTAL_URL, "_blank", "noopener,noreferrer");

--- a/src/lib/startNowGate.js
+++ b/src/lib/startNowGate.js
@@ -23,12 +23,19 @@ function readEntry() {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
     // Backward compat: old format was a plain timestamp string.
-    if (/^\d+$/.test(raw)) return { ts: Number(raw), email: "", lastNotifiedTs: 0 };
+    if (/^\d+$/.test(raw)) return { ts: Number(raw), email: "", lastNotifiedTs: 0, lastNotifiedByGate: {} };
     const parsed = JSON.parse(raw);
     return {
       ts: Number(parsed.ts) || 0,
       email: typeof parsed.email === "string" ? parsed.email : "",
+      // Legacy single-field throttle from the early per-visitor (not per-gate) design.
       lastNotifiedTs: Number(parsed.lastNotifiedTs) || 0,
+      // New per-gate throttle map: { startnow: ts, portal: ts, pricing: ts, ... }
+      // so a Portal visit doesn't throttle a Start Now visit and vice versa.
+      lastNotifiedByGate:
+        parsed.lastNotifiedByGate && typeof parsed.lastNotifiedByGate === "object"
+          ? parsed.lastNotifiedByGate
+          : {},
     };
   } catch {
     return null;
@@ -51,7 +58,15 @@ export function isUnlocked() {
 }
 
 export function markUnlocked(email = "") {
-  writeEntry({ ts: Date.now(), email, lastNotifiedTs: Date.now() });
+  const prev = readEntry() || {};
+  writeEntry({
+    ts: Date.now(),
+    email,
+    lastNotifiedTs: Date.now(),
+    // Preserve any prior per-gate stamps so a re-submit doesn't reset
+    // throttles on other gates the visitor hit recently.
+    lastNotifiedByGate: prev.lastNotifiedByGate || {},
+  });
 }
 
 export function getUnlockedEmail() {
@@ -59,15 +74,33 @@ export function getUnlockedEmail() {
 }
 
 /**
- * Returns true at most once per 24h. Side effect: stamps the lastNotifiedTs
- * so the next call within the window returns false. Use this to gate the
- * silent re-submit so we don't spam HubSpot on every modal open.
+ * Per-gate throttle. Returns true at most once per hour PER gateKey, so a
+ * Portal visit doesn't block a subsequent Start Now / Pricing / Story
+ * notification (and vice versa). Stamps lastNotifiedByGate[gateKey] on success.
+ *
+ *   shouldNotifyForGate("portal")    // → true (first call this hour)
+ *   shouldNotifyForGate("startnow")  // → true (independent of portal)
+ *   shouldNotifyForGate("portal")    // → false (within the portal throttle)
  */
-export function shouldNotifyRepeatVisit() {
+export function shouldNotifyForGate(gateKey) {
+  if (!gateKey) return false;
   const entry = readEntry();
   if (!entry || !entry.email) return false;
   const now = Date.now();
-  if (now - entry.lastNotifiedTs < REPEAT_NOTIFY_THROTTLE_MS) return false;
-  writeEntry({ ...entry, lastNotifiedTs: now });
+  const stamps = entry.lastNotifiedByGate || {};
+  const lastTs = Number(stamps[gateKey]) || 0;
+  if (now - lastTs < REPEAT_NOTIFY_THROTTLE_MS) return false;
+  writeEntry({
+    ...entry,
+    lastNotifiedByGate: { ...stamps, [gateKey]: now },
+  });
   return true;
+}
+
+/**
+ * Legacy alias kept for any caller that hasn't been migrated to the
+ * per-gate API. New code should use `shouldNotifyForGate(gateKey)`.
+ */
+export function shouldNotifyRepeatVisit() {
+  return shouldNotifyForGate("legacy");
 }

--- a/src/lib/useKnownContactNotify.js
+++ b/src/lib/useKnownContactNotify.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { checkKnownContact } from "./hubspotIdentify";
+import { getUnlockedEmail, shouldNotifyForGate } from "./startNowGate";
 import { trackEvent } from "./analytics";
 
 /**
@@ -7,25 +8,54 @@ import { trackEvent } from "./analytics";
  * should NOT be gated (no email form), but where the founder still wants
  * a HubSpot notification when a *known* contact lands on it.
  *
- * On mount: checks whether the visitor's hubspotutk cookie maps to a
- * known HubSpot contact via the hsutk Worker. If yes, silently submits
- * to the surface's tracking form and fires a PostHog/GA4 event. Fires at
- * most once per page-mount; safe to drop in without UI side effects.
+ * Two paths to "we know who this visitor is":
+ *
+ *   1. localStorage — the visitor previously submitted Start Now /
+ *      Get Started / Portal, so their email is in `traigent_start_now_unlocked`.
+ *      This works WITHOUT the hsutk Worker being deployed.
+ *
+ *   2. hsutk Worker — the visitor's hubspotutk cookie maps to a known
+ *      HubSpot contact via the Cloudflare Worker. Catches contacts who
+ *      came in via Contact Us, meeting bookings, BCC-to-HubSpot, etc.,
+ *      WITHOUT ever touching one of our gates.
+ *
+ * Per-gate throttle (1h) is applied so visiting Pricing twice in a row
+ * doesn't fire two notifications.
  *
  *   useKnownContactNotify({
  *     notify: notifyPricingViewed,
  *     location: "pricing_page",
  *     eventName: "pricing_viewed_known",
+ *     gateKey: "pricing",         // required — used for the per-gate throttle
  *   });
  */
-export function useKnownContactNotify({ notify, location, eventName }) {
+export function useKnownContactNotify({ notify, location, eventName, gateKey }) {
   const firedRef = useRef(false);
   useEffect(() => {
     if (firedRef.current) return;
+    const key = gateKey || location || "unknown_gate";
+
+    // Path 1: localStorage-first — covers the "I'm already a known visitor
+    // on this browser" case without needing the Worker.
+    const localEmail = getUnlockedEmail();
+    if (localEmail) {
+      if (!shouldNotifyForGate(key)) {
+        firedRef.current = true; // avoid Path 2 firing too
+        return;
+      }
+      firedRef.current = true;
+      try { notify({ email: localEmail, location }); } catch { /* noop */ }
+      if (eventName) trackEvent(eventName, { location });
+      return;
+    }
+
+    // Path 2: Worker check — covers known HubSpot contacts who haven't
+    // touched any of our gates on this browser.
     let cancelled = false;
     checkKnownContact().then((result) => {
       if (cancelled) return;
       if (!(result && result.known && result.email)) return;
+      if (!shouldNotifyForGate(key)) return;
       firedRef.current = true;
       try { notify({ email: result.email, location }); } catch { /* noop */ }
       if (eventName) trackEvent(eventName, { location });

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -8,7 +8,7 @@ import {
   isUnlocked,
   markUnlocked,
   getUnlockedEmail,
-  shouldNotifyRepeatVisit,
+  shouldNotifyForGate,
 } from "../lib/startNowGate";
 import { notifyStartNowRepeat } from "../lib/hubspotForms";
 import { checkKnownContact } from "../lib/hubspotIdentify";
@@ -43,7 +43,7 @@ export default function GetStarted() {
   // Repeat-visit notification — see StartNowModal for the rationale.
   useEffect(() => {
     if (!unlocked) return;
-    if (!shouldNotifyRepeatVisit()) return;
+    if (!shouldNotifyForGate("get_started_page")) return;
     const email = getUnlockedEmail();
     if (!email) return;
     notifyStartNowRepeat({ email, location: "get_started_page" });

--- a/src/pages/KnobExplorer.jsx
+++ b/src/pages/KnobExplorer.jsx
@@ -642,6 +642,7 @@ export default function KnobExplorer() {
     notify: notifyKnobExplorerViewed,
     location: "knob_explorer_page",
     eventName: "knob_explorer_viewed_known",
+    gateKey: "knob_explorer",
   });
   // Persist selections + sort preference across reloads / tabs so the user
   // can leave the page and come back to the same configuration.

--- a/src/pages/Pitch.jsx
+++ b/src/pages/Pitch.jsx
@@ -206,6 +206,7 @@ export default function Pitch() {
     notify: notifyPitchDeckViewed,
     location: "pitch",
     eventName: "pitch_deck_viewed_known",
+    gateKey: "pitch_deck",
   });
   const [current, setCurrent] = useState(0);
   const [direction, setDirection] = useState(1);

--- a/src/pages/PitchFull.jsx
+++ b/src/pages/PitchFull.jsx
@@ -1398,6 +1398,7 @@ export default function PitchFull() {
     notify: notifyPitchDeckViewed,
     location: "pitch_full",
     eventName: "pitch_deck_viewed_known",
+    gateKey: "pitch_deck",
   });
   return <PitchDeck slides={FULL_SLIDES} />;
 }

--- a/src/pages/PitchShort2.jsx
+++ b/src/pages/PitchShort2.jsx
@@ -196,6 +196,7 @@ export default function PitchShort2({ forcedPreset } = {}) {
     notify: notifyPitchDeckViewed,
     location: "pitch_short_2",
     eventName: "pitch_deck_viewed_known",
+    gateKey: "pitch_deck",
   });
   const scale = useViewportScale();
   useRemoveChatWidget();

--- a/src/pages/Pricing.jsx
+++ b/src/pages/Pricing.jsx
@@ -247,6 +247,7 @@ export default function Pricing() {
     notify: notifyPricingViewed,
     location: "pricing_page",
     eventName: "pricing_viewed_known",
+    gateKey: "pricing",
   });
   return (
     <div className="bg-[#080808] text-white min-h-screen">

--- a/src/pages/ROICalculator.jsx
+++ b/src/pages/ROICalculator.jsx
@@ -87,6 +87,7 @@ export default function ROICalculator() {
     notify: notifyRoiCalcViewed,
     location: "roi_calculator_page",
     eventName: "roi_calc_viewed_known",
+    gateKey: "roi",
   });
   const [monthlySpend, setMonthlySpend] = useState(DEFAULT_MONTHLY_SPEND);
   // Engineering side is now derived from the TTM Calculator's per-pass figure

--- a/src/pages/StoryMovie.jsx
+++ b/src/pages/StoryMovie.jsx
@@ -19,9 +19,8 @@ import { ArrowLeft, ArrowRight, ChevronDown, ChevronUp, Pause, Play, RotateCcw, 
 import { useRemoveChatWidget } from "../lib/useRemoveChatWidget";
 import ChatKillerStyle from "../lib/ChatKillerStyle";
 import StartNowModal from "../components/StartNowModal";
-import { checkKnownContact } from "../lib/hubspotIdentify";
 import { notifyStoryWatched } from "../lib/hubspotForms";
-import { trackEvent } from "../lib/analytics";
+import { useKnownContactNotify } from "../lib/useKnownContactNotify";
 import { usePageView } from "../lib/usePageView";
 
 // Same CTA URL as the homepage TopNav — HubSpot meeting booking.
@@ -821,20 +820,16 @@ export default function StoryMovie() {
   const advancingRef = useRef(false);
   useRemoveChatWidget();
 
-  // /story is intentionally ungated — no email form. We still want a
-  // notification when a known HubSpot contact watches it (Contact Us
-  // submitter, meeting booker, BCC-linked lead). Identity check fires once
-  // on mount; if known, silently re-submits to the Story-watched form.
-  useEffect(() => {
-    let cancelled = false;
-    checkKnownContact().then((result) => {
-      if (cancelled) return;
-      if (!(result && result.known && result.email)) return;
-      notifyStoryWatched({ email: result.email, location: "story_page" });
-      trackEvent("story_watched_known", { location: "story_page" });
-    });
-    return () => { cancelled = true; };
-  }, []);
+  // /story is intentionally ungated — no email form. The hook below
+  // silently fires a Story-watched notification when a known visitor
+  // lands on the page (localStorage email OR hsutk Worker match). 1h
+  // per-gate throttle.
+  useKnownContactNotify({
+    notify: notifyStoryWatched,
+    location: "story_page",
+    eventName: "story_watched_known",
+    gateKey: "story",
+  });
 
   const start = useCallback(() => {
     advancingRef.current = false;

--- a/src/pages/TTMCalculator.jsx
+++ b/src/pages/TTMCalculator.jsx
@@ -174,6 +174,7 @@ export default function TTMCalculator() {
     notify: notifyTtmCalcViewed,
     location: "ttm_calculator_page",
     eventName: "ttm_calc_viewed_known",
+    gateKey: "ttm",
   });
   const [models, setModels] = useState(6);
   const [prompts, setPrompts] = useState(3);


### PR DESCRIPTION
## Root cause
This morning's test surfaced two bugs in the silent-notify pipeline:

| Gate | Notified? | Why |
|---|---|---|
| Course A | ✓ | Own per-course throttle, localStorage email |
| Course B | ✓ | Same |
| Portal | ✓ | Locally unlocked, throttle empty |
| **Start Now** | ✗ | **Shared throttle field already stamped by Portal — blocked** |
| **Pricing** | ✗ | **Only consults the (not-yet-deployed) hsutk Worker** |
| **Story** | ✗ | **Same — Worker-only** |

## Fix
- **Per-gate throttle.** `shouldNotifyForGate(gateKey)` reads/writes `lastNotifiedByGate[gateKey]` instead of a single shared timestamp. Each surface gets its own 1h counter. Legacy `shouldNotifyRepeatVisit()` kept as an alias.
- **localStorage email fallback.** `useKnownContactNotify` and Story now check `getUnlockedEmail()` first — if a local email is known (the visitor already submitted any commerce-funnel form), fire immediately, skip the Worker call. Falls through to the Worker for visitors who never touched a gate. **Means tracking pixels work TODAY for known visitors** without waiting on the Worker deploy.
- **Story refactored to use `useKnownContactNotify`** instead of an inline checkKnownContact — DRY + per-gate throttle now applies.
- Added `gateKey` to every `useKnownContactNotify` call site.

## Test plan
- Hard-refresh in an incognito with a Start-Now-submitted localStorage
- Hit Start Now → HubSpot Start Now form ticks up
- Hit Portal → HubSpot Portal form ticks up (Start Now didn't block it)
- Hit /story → Story video form ticks up (no Worker needed)
- Hit /pricing → Pricing intent form ticks up (no Worker needed)
- Re-hit any of the above within an hour → no second submission on that form (per-gate throttle)
- Re-hit a different gate immediately → DOES fire (independent gate counter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)