### PR TITLE
polish(naming): disambiguate /story (narrated walkthrough) from /demo (engine)

### DIFF
--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -43,13 +43,13 @@ const PITCH_DECK_OPTIONS = [
     href: "/#/knob-explorer",
   },
   {
-    label: "Live optimization demo",
-    desc: "5-scene scripted demo — search space → convergence → 10× cheaper",
+    label: "Optimization Engine (no narration)",
+    desc: "Accuracy/Cost Optimization (2-step)",
     href: "/#/demo",
   },
   {
-    label: "Traigent in action (1-min video)",
-    desc: "Problem → search space → solution → the win",
+    label: "Agent Optimization Demo (1-min)",
+    desc: "Narrated walkthrough · problem → solution → the win",
     href: "/#/story",
   },
   {

--- a/src/content/blog/agent-knobs-101.md
+++ b/src/content/blog/agent-knobs-101.md
@@ -13,7 +13,7 @@ order: 0
 
 **TL;DR.** Every agent has a few dozen settings — what we call *knobs* — that change how it answers and what it costs. Most teams hardcode them and never look again. The right combination can swing accuracy 10–30 points and cost 10× or more on the same workload. Below: three concrete knobs, what they actually look like, and what they actually do.
 
-**See it in action:** [▶ Traigent in action · 1-min video](/#/story) · [Explore the configuration space →](/#/knob-explorer)
+**See it in action:** [▶ Agent Optimization Demo · 1-min](/#/story) · [Explore the configuration space →](/#/knob-explorer)
 
 ---
 

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -159,7 +159,7 @@ export default function Homepage() {
                 thousands possible
               </Link>
             </motion.p>
-            {/* "Traigent in action" — 2-minute narrated walkthrough CTA, with a
+            {/* "Agent Optimization Demo" — 1-minute narrated walkthrough CTA, with a
                 prominent play button so it reads as "watch video" at a glance. */}
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -176,7 +176,7 @@ export default function Homepage() {
                   <Play className="w-4 h-4 text-white fill-white ml-0.5" />
                 </span>
                 <span className="text-base md:text-lg font-medium text-slate-100">
-                  Traigent in action <span className="text-slate-500 mx-1">·</span> <span className="text-slate-400 font-normal">1-min video</span>
+                  Agent Optimization Demo <span className="text-slate-500 mx-1">·</span> <span className="text-slate-400 font-normal">1-min</span>
                 </span>
               </Link>
             </motion.div>


### PR DESCRIPTION
## Before
- /demo: "Live optimization demo" — "5-scene scripted demo — search space → convergence → 10× cheaper"
- /story: "Traigent in action (1-min video)" — "Problem → search space → solution → the win"
- Hero: "Traigent in action · 1-min video"

Both pages were describing themselves as a "5-scene scripted" thing → confusing.

## After
- /demo: "Optimization Engine (no narration)" — "Accuracy/Cost Optimization (2-step)"
- /story: "Agent Optimization Demo (1-min)" — "Narrated walkthrough · problem → solution → the win"
- Hero: "Agent Optimization Demo · 1-min"

URLs unchanged (/story and /demo) — existing shared links still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)