### PR TITLE
fix(story): underline 'the' not 'optimum' in Act 1

### DIFF
--- a/src/pages/StoryMovie.jsx
+++ b/src/pages/StoryMovie.jsx
@@ -760,7 +760,7 @@ const ACT_1_SENTENCES = [
     "Trial and Error consumes Time and Effort",
     {
       text: "May not find the optimum",
-      render: <>May not find the <span className="underline underline-offset-4 decoration-current">optimum</span></>,
+      render: <>May not find <span className="underline underline-offset-4 decoration-current">the</span> optimum</>,
     },
     "Does not reduce LLM costs",
   ],


### PR DESCRIPTION
Misread the original instruction — emphasis belongs on 'the' (= THE optimum, not just any optimum), not on 'optimum' itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)