### PR TITLE
fix(investor-pitch): restore source-deck hyperlinks via invisible <a> overlays

### DIFF
--- a/scripts/extract-investor-deck-hotspots.mjs
+++ b/scripts/extract-investor-deck-hotspots.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------
+// extract-investor-deck-hotspots.mjs
+//
+// Reads the unpacked PPTX at:
+//   <SOURCE_ROOT>\investor-deck-source\pptx-unpacked\ppt\
+// Finds every shape on every slide that contains a hyperlink (either
+// shape-level <a:hlinkClick> on <p:cNvPr> or text-run-level inside <a:rPr>),
+// and emits a JSON manifest at:
+//   src/pages/pitch/investor-hotspots.json
+//
+// The manifest is then used by PitchInvestor.jsx to overlay invisible <a>
+// rectangles on top of the flattened slide PNGs so the source deck's
+// hyperlinks survive the PowerPoint -> PNG export pass.
+//
+// Heuristics:
+//   - Per shape we emit ONE hotspot covering the shape's bounding box.
+//   - If a shape has multiple hyperlinks (e.g. an email + a LinkedIn link in
+//     the same contact-card text line), we use the LAST hyperlink as the
+//     primary target. This matches the convention "click anywhere on the
+//     contact row → LinkedIn" and matches the user's complaint that the
+//     LinkedIn links were the noticeably-missing ones.
+//   - Coordinates are emitted as fractions of slide width/height (0..1) so
+//     the React canvas can multiply by 1280/720 without re-running this
+//     script if the canvas size changes.
+//
+// Re-run after editing the source deck (and after re-exporting slide PNGs):
+//   node scripts/extract-investor-deck-hotspots.mjs
+// ---------------------------------------------------------------------------
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const SOURCE_ROOT = "C:/Users/amirb/Documents/Kingston D drive/2026 job search/TRAIGENT-AI/investor-deck-source/pptx-unpacked/ppt";
+const SLIDE_COUNT = 11;
+const OUT_PATH = resolve(import.meta.dirname, "..", "src", "pages", "pitch", "investor-hotspots.json");
+
+function readXml(path) {
+  if (!existsSync(path)) throw new Error(`Missing: ${path}`);
+  return readFileSync(path, "utf-8");
+}
+
+// Parse the <Relationships> file for a slide → { rId: { type, target } }.
+function parseRels(xml) {
+  const rels = {};
+  // Note: `[^/>]+` would stop at the first `/` inside URLs like
+  // Target="https://..." — match everything up to the self-closing `/>`
+  // instead.
+  const re = /<Relationship\s+([^>]*?)\s*\/>/g;
+  let m;
+  while ((m = re.exec(xml)) !== null) {
+    const attrs = {};
+    for (const attr of m[1].matchAll(/(\w+)="([^"]*)"/g)) {
+      attrs[attr[1]] = attr[2];
+    }
+    if (attrs.Id) rels[attrs.Id] = { type: attrs.Type, target: attrs.Target };
+  }
+  return rels;
+}
+
+// Resolve a hyperlink rels target → final URL. Slides reference internal +
+// external URLs through the same `Target` attribute (TargetMode="External"
+// for external, otherwise relative path) — we just take Target as-is when
+// the rel type is hyperlink.
+function decodeXmlEntities(s) {
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+}
+
+function resolveHref(rels, rId) {
+  const rel = rels[rId];
+  if (!rel) return null;
+  if (!rel.type.endsWith("/hyperlink")) return null;
+  return decodeXmlEntities(rel.target);
+}
+
+// Read the slide-size from presentation.xml (EMUs).
+function getSlideSize() {
+  const presXml = readXml(join(SOURCE_ROOT, "presentation.xml"));
+  const m = /<p:sldSz\s+cy="(\d+)"\s+cx="(\d+)"\/>/.exec(presXml) ||
+            /<p:sldSz\s+cx="(\d+)"\s+cy="(\d+)"\/>/.exec(presXml);
+  if (!m) throw new Error("Could not find <p:sldSz> in presentation.xml");
+  // PPTX is cy-first when CX/CY order varies; both regexes try both orders.
+  // Standard 16:9 is cx=12192000 cy=6858000.
+  const a = parseInt(m[1], 10);
+  const b = parseInt(m[2], 10);
+  const [cx, cy] = a > b ? [a, b] : [b, a];
+  return { cx, cy };
+}
+
+// Walk shapes (<p:sp>, <p:pic>, <p:graphicFrame>) in a slide and pull out
+// each one's bounding box + the hyperlinks referenced inside it.
+function extractShapeHotspots(slideXml, rels, slideSize) {
+  const hotspots = [];
+
+  // Match each top-level shape-ish element. We're tolerant about which tag
+  // (sp/pic/graphicFrame) since position + hyperlinks live the same way in
+  // all of them. Using a non-greedy match between open and close.
+  //
+  // PPTX shapes can nest inside <p:grpSp> — we'd descend into those too,
+  // but the investor deck doesn't use grouped shapes for hyperlinked text
+  // so we keep this flat for now.
+  const shapeRe = /<p:(sp|pic|graphicFrame)\b[^>]*>([\s\S]*?)<\/p:\1>/g;
+  let m;
+  while ((m = shapeRe.exec(slideXml)) !== null) {
+    const inner = m[2];
+
+    // Hyperlinks inside this shape, in document order. Both shape-level
+    // (in <p:nvSpPr><p:cNvPr>) and text-run-level (<a:rPr>) link refs
+    // share the same <a:hlinkClick r:id="rIdN" ...> form.
+    const hlinks = [...inner.matchAll(/<a:hlinkClick\s+[^>]*?r:id="([^"]+)"/g)].map(
+      (h) => h[1],
+    );
+    if (hlinks.length === 0) continue;
+
+    // First <a:xfrm><a:off/><a:ext/> inside the shape is the shape's bbox.
+    // <a:bodyPr> may also contain offsets but we want spPr's xfrm — that's
+    // the one that appears first inside each <p:sp>/<p:pic>/<p:graphicFrame>.
+    const xfrmMatch = /<a:xfrm[^>]*>\s*<a:off\s+x="(\d+)"\s+y="(\d+)"\/>\s*<a:ext\s+cx="(\d+)"\s+cy="(\d+)"\/>\s*<\/a:xfrm>/.exec(
+      inner,
+    );
+    if (!xfrmMatch) continue;
+    const x = parseInt(xfrmMatch[1], 10);
+    const y = parseInt(xfrmMatch[2], 10);
+    const w = parseInt(xfrmMatch[3], 10);
+    const h = parseInt(xfrmMatch[4], 10);
+
+    // Use the LAST link in document order — that's the LinkedIn target on
+    // each contact-card row, the trailing source citation on the market
+    // slide, etc.
+    const primaryRId = hlinks[hlinks.length - 1];
+    const href = resolveHref(rels, primaryRId);
+    if (!href) continue;
+
+    hotspots.push({
+      href,
+      x: +(x / slideSize.cx).toFixed(5),
+      y: +(y / slideSize.cy).toFixed(5),
+      w: +(w / slideSize.cx).toFixed(5),
+      h: +(h / slideSize.cy).toFixed(5),
+    });
+  }
+
+  return hotspots;
+}
+
+function main() {
+  const slideSize = getSlideSize();
+  console.log(`Slide canvas: ${slideSize.cx} x ${slideSize.cy} EMU`);
+
+  const manifest = {};
+  for (let i = 1; i <= SLIDE_COUNT; i++) {
+    const slideXml = readXml(join(SOURCE_ROOT, "slides", `slide${i}.xml`));
+    const relsXml = readXml(join(SOURCE_ROOT, "slides", "_rels", `slide${i}.xml.rels`));
+    const rels = parseRels(relsXml);
+    const hotspots = extractShapeHotspots(slideXml, rels, slideSize);
+    if (hotspots.length > 0) {
+      const key = `slide-${String(i).padStart(2, "0")}.png`;
+      manifest[key] = hotspots;
+      console.log(`Slide ${i}: ${hotspots.length} hotspot(s)`);
+      for (const h of hotspots) {
+        console.log(
+          `  -> ${h.href}  (${(h.x * 100).toFixed(1)}%, ${(h.y * 100).toFixed(1)}%, ${(h.w * 100).toFixed(1)}% x ${(h.h * 100).toFixed(1)}%)`,
+        );
+      }
+    } else {
+      console.log(`Slide ${i}: no hyperlinks`);
+    }
+  }
+
+  writeFileSync(OUT_PATH, JSON.stringify(manifest, null, 2) + "\n", "utf-8");
+  console.log(`\nWrote ${OUT_PATH}`);
+}
+
+main();

--- a/scripts/extract-investor-deck-hotspots.mjs
+++ b/scripts/extract-investor-deck-hotspots.mjs
@@ -79,11 +79,11 @@ function parseRels(xml) {
 // the rel type is hyperlink.
 function decodeXmlEntities(s) {
   return s
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, "&");
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&amp;", "&");
 }
 
 function normalizeHref(target) {
@@ -107,8 +107,8 @@ function getSlideSize() {
   if (!m) throw new Error("Could not find <p:sldSz> in presentation.xml");
   // PPTX is cy-first when CX/CY order varies; both regexes try both orders.
   // Standard 16:9 is cx=12192000 cy=6858000.
-  const a = parseInt(m[1], 10);
-  const b = parseInt(m[2], 10);
+  const a = Number.parseInt(m[1], 10);
+  const b = Number.parseInt(m[2], 10);
   const [cx, cy] = a > b ? [a, b] : [b, a];
   return { cx, cy };
 }
@@ -145,15 +145,15 @@ function extractShapeHotspots(slideXml, rels, slideSize) {
       inner,
     );
     if (!xfrmMatch) continue;
-    const x = parseInt(xfrmMatch[1], 10);
-    const y = parseInt(xfrmMatch[2], 10);
-    const w = parseInt(xfrmMatch[3], 10);
-    const h = parseInt(xfrmMatch[4], 10);
+    const x = Number.parseInt(xfrmMatch[1], 10);
+    const y = Number.parseInt(xfrmMatch[2], 10);
+    const w = Number.parseInt(xfrmMatch[3], 10);
+    const h = Number.parseInt(xfrmMatch[4], 10);
 
     // Use the LAST link in document order — that's the LinkedIn target on
     // each contact-card row, the trailing source citation on the market
     // slide, etc.
-    const primaryRId = hlinks[hlinks.length - 1];
+    const primaryRId = hlinks.at(-1);
     const href = resolveHref(rels, primaryRId);
     if (!href) continue;
 

--- a/scripts/extract-investor-deck-hotspots.mjs
+++ b/scripts/extract-investor-deck-hotspots.mjs
@@ -55,20 +55,74 @@ function readSourceXml(...segments) {
   return readFileSync(path, "utf-8");
 }
 
+function isXmlWhitespace(char) {
+  return char === " " || char === "\n" || char === "\r" || char === "\t";
+}
+
+function parseAttributes(source) {
+  const attrs = {};
+  let index = 0;
+
+  while (index < source.length) {
+    while (index < source.length && isXmlWhitespace(source[index])) index++;
+
+    const nameStart = index;
+    while (
+      index < source.length &&
+      source[index] !== "=" &&
+      !isXmlWhitespace(source[index])
+    ) {
+      index++;
+    }
+    const name = source.slice(nameStart, index);
+    while (index < source.length && isXmlWhitespace(source[index])) index++;
+    if (!name || source[index] !== "=") {
+      index++;
+      continue;
+    }
+
+    index++;
+    while (index < source.length && isXmlWhitespace(source[index])) index++;
+    const quote = source[index];
+    if (quote !== '"' && quote !== "'") {
+      index++;
+      continue;
+    }
+
+    const valueStart = index + 1;
+    const valueEnd = source.indexOf(quote, valueStart);
+    if (valueEnd === -1) break;
+    attrs[name] = source.slice(valueStart, valueEnd);
+    index = valueEnd + 1;
+  }
+
+  return attrs;
+}
+
 // Parse the <Relationships> file for a slide → { rId: { type, target } }.
 function parseRels(xml) {
   const rels = {};
-  // Note: `[^/>]+` would stop at the first `/` inside URLs like
-  // Target="https://..." — match everything up to the self-closing `/>`
-  // instead.
-  const re = /<Relationship\s+([^>]*?)\s*\/>/g;
-  let m;
-  while ((m = re.exec(xml)) !== null) {
-    const attrs = {};
-    for (const attr of m[1].matchAll(/(\w+)="([^"]*)"/g)) {
-      attrs[attr[1]] = attr[2];
+  let index = 0;
+
+  while (index < xml.length) {
+    const start = xml.indexOf("<Relationship", index);
+    if (start === -1) break;
+
+    const tagNameEnd = start + "<Relationship".length;
+    if (!isXmlWhitespace(xml[tagNameEnd]) && xml[tagNameEnd] !== ">") {
+      index = tagNameEnd;
+      continue;
     }
+
+    const openEnd = xml.indexOf(">", tagNameEnd);
+    if (openEnd === -1) break;
+    const rawAttributes = xml.slice(tagNameEnd, openEnd).trimEnd();
+    const attributeSource = rawAttributes.endsWith("/")
+      ? rawAttributes.slice(0, -1)
+      : rawAttributes;
+    const attrs = parseAttributes(attributeSource);
     if (attrs.Id) rels[attrs.Id] = { type: attrs.Type, target: attrs.Target };
+    index = openEnd + 1;
   }
   return rels;
 }
@@ -95,22 +149,101 @@ function normalizeHref(target) {
 function resolveHref(rels, rId) {
   const rel = rels[rId];
   if (!rel) return null;
-  if (!rel.type.endsWith("/hyperlink")) return null;
+  if (!rel.type?.endsWith("/hyperlink")) return null;
   return normalizeHref(rel.target);
 }
 
 // Read the slide-size from presentation.xml (EMUs).
 function getSlideSize() {
   const presXml = readSourceXml("presentation.xml");
-  const m = /<p:sldSz\s+cy="(\d+)"\s+cx="(\d+)"\/>/.exec(presXml) ||
-            /<p:sldSz\s+cx="(\d+)"\s+cy="(\d+)"\/>/.exec(presXml);
-  if (!m) throw new Error("Could not find <p:sldSz> in presentation.xml");
-  // PPTX is cy-first when CX/CY order varies; both regexes try both orders.
+  const sizeStart = presXml.indexOf("<p:sldSz");
+  if (sizeStart === -1) {
+    throw new Error("Could not find <p:sldSz> in presentation.xml");
+  }
+  const sizeEnd = presXml.indexOf(">", sizeStart);
+  if (sizeEnd === -1) {
+    throw new Error("Could not parse <p:sldSz> in presentation.xml");
+  }
+  const attrs = parseAttributes(presXml.slice(sizeStart + "<p:sldSz".length, sizeEnd));
   // Standard 16:9 is cx=12192000 cy=6858000.
-  const a = Number.parseInt(m[1], 10);
-  const b = Number.parseInt(m[2], 10);
-  const [cx, cy] = a > b ? [a, b] : [b, a];
+  const cx = Number.parseInt(attrs.cx, 10);
+  const cy = Number.parseInt(attrs.cy, 10);
+  if (!Number.isFinite(cx) || !Number.isFinite(cy)) {
+    throw new Error("Could not parse slide dimensions in presentation.xml");
+  }
   return { cx, cy };
+}
+
+function shapeBlocks(slideXml) {
+  const tags = ["sp", "pic", "graphicFrame"];
+  const blocks = [];
+  let index = 0;
+
+  while (index < slideXml.length) {
+    let next = null;
+    for (const tag of tags) {
+      const start = slideXml.indexOf(`<p:${tag}`, index);
+      if (start !== -1 && (next === null || start < next.start)) {
+        next = { tag, start };
+      }
+    }
+    if (next === null) break;
+
+    const openEnd = slideXml.indexOf(">", next.start);
+    if (openEnd === -1) break;
+    const closeTag = `</p:${next.tag}>`;
+    const closeStart = slideXml.indexOf(closeTag, openEnd + 1);
+    if (closeStart === -1) {
+      index = openEnd + 1;
+      continue;
+    }
+    blocks.push(slideXml.slice(openEnd + 1, closeStart));
+    index = closeStart + closeTag.length;
+  }
+
+  return blocks;
+}
+
+function hyperlinkIds(innerXml) {
+  const ids = [];
+  let index = 0;
+
+  while (index < innerXml.length) {
+    const start = innerXml.indexOf("<a:hlinkClick", index);
+    if (start === -1) break;
+    const openEnd = innerXml.indexOf(">", start);
+    if (openEnd === -1) break;
+    const attrs = parseAttributes(
+      innerXml.slice(start + "<a:hlinkClick".length, openEnd),
+    );
+    if (attrs["r:id"]) ids.push(attrs["r:id"]);
+    index = openEnd + 1;
+  }
+
+  return ids;
+}
+
+function firstTransform(innerXml) {
+  const xfrmStart = innerXml.indexOf("<a:xfrm");
+  if (xfrmStart === -1) return null;
+  const xfrmEnd = innerXml.indexOf("</a:xfrm>", xfrmStart);
+  if (xfrmEnd === -1) return null;
+  const xfrmXml = innerXml.slice(xfrmStart, xfrmEnd);
+
+  const offStart = xfrmXml.indexOf("<a:off");
+  const offEnd = offStart === -1 ? -1 : xfrmXml.indexOf(">", offStart);
+  const extStart = xfrmXml.indexOf("<a:ext", offEnd);
+  const extEnd = extStart === -1 ? -1 : xfrmXml.indexOf(">", extStart);
+  if (offEnd === -1 || extEnd === -1) return null;
+
+  const off = parseAttributes(xfrmXml.slice(offStart + "<a:off".length, offEnd));
+  const ext = parseAttributes(xfrmXml.slice(extStart + "<a:ext".length, extEnd));
+  const x = Number.parseInt(off.x, 10);
+  const y = Number.parseInt(off.y, 10);
+  const w = Number.parseInt(ext.cx, 10);
+  const h = Number.parseInt(ext.cy, 10);
+  if (![x, y, w, h].every(Number.isFinite)) return null;
+  return { x, y, w, h };
 }
 
 // Walk shapes (<p:sp>, <p:pic>, <p:graphicFrame>) in a slide and pull out
@@ -118,37 +251,21 @@ function getSlideSize() {
 function extractShapeHotspots(slideXml, rels, slideSize) {
   const hotspots = [];
 
-  // Match each top-level shape-ish element. We're tolerant about which tag
-  // (sp/pic/graphicFrame) since position + hyperlinks live the same way in
-  // all of them. Using a non-greedy match between open and close.
-  //
   // PPTX shapes can nest inside <p:grpSp> — we'd descend into those too,
   // but the investor deck doesn't use grouped shapes for hyperlinked text
   // so we keep this flat for now.
-  const shapeRe = /<p:(sp|pic|graphicFrame)\b[^>]*>([\s\S]*?)<\/p:\1>/g;
-  let m;
-  while ((m = shapeRe.exec(slideXml)) !== null) {
-    const inner = m[2];
-
+  for (const inner of shapeBlocks(slideXml)) {
     // Hyperlinks inside this shape, in document order. Both shape-level
     // (in <p:nvSpPr><p:cNvPr>) and text-run-level (<a:rPr>) link refs
     // share the same <a:hlinkClick r:id="rIdN" ...> form.
-    const hlinks = [...inner.matchAll(/<a:hlinkClick\s+[^>]*?r:id="([^"]+)"/g)].map(
-      (h) => h[1],
-    );
+    const hlinks = hyperlinkIds(inner);
     if (hlinks.length === 0) continue;
 
     // First <a:xfrm><a:off/><a:ext/> inside the shape is the shape's bbox.
     // <a:bodyPr> may also contain offsets but we want spPr's xfrm — that's
     // the one that appears first inside each <p:sp>/<p:pic>/<p:graphicFrame>.
-    const xfrmMatch = /<a:xfrm[^>]*>\s*<a:off\s+x="(\d+)"\s+y="(\d+)"\/>\s*<a:ext\s+cx="(\d+)"\s+cy="(\d+)"\/>\s*<\/a:xfrm>/.exec(
-      inner,
-    );
-    if (!xfrmMatch) continue;
-    const x = Number.parseInt(xfrmMatch[1], 10);
-    const y = Number.parseInt(xfrmMatch[2], 10);
-    const w = Number.parseInt(xfrmMatch[3], 10);
-    const h = Number.parseInt(xfrmMatch[4], 10);
+    const transform = firstTransform(inner);
+    if (!transform) continue;
 
     // Use the LAST link in document order — that's the LinkedIn target on
     // each contact-card row, the trailing source citation on the market
@@ -159,10 +276,10 @@ function extractShapeHotspots(slideXml, rels, slideSize) {
 
     hotspots.push({
       href,
-      x: +(x / slideSize.cx).toFixed(5),
-      y: +(y / slideSize.cy).toFixed(5),
-      w: +(w / slideSize.cx).toFixed(5),
-      h: +(h / slideSize.cy).toFixed(5),
+      x: +(transform.x / slideSize.cx).toFixed(5),
+      y: +(transform.y / slideSize.cy).toFixed(5),
+      w: +(transform.w / slideSize.cx).toFixed(5),
+      h: +(transform.h / slideSize.cy).toFixed(5),
     });
   }
 

--- a/scripts/extract-investor-deck-hotspots.mjs
+++ b/scripts/extract-investor-deck-hotspots.mjs
@@ -28,13 +28,29 @@
 //   node scripts/extract-investor-deck-hotspots.mjs
 // ---------------------------------------------------------------------------
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
-import { resolve, join } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 
 const SOURCE_ROOT = "C:/Users/amirb/Documents/Kingston D drive/2026 job search/TRAIGENT-AI/investor-deck-source/pptx-unpacked/ppt";
 const SLIDE_COUNT = 11;
 const OUT_PATH = resolve(import.meta.dirname, "..", "src", "pages", "pitch", "investor-hotspots.json");
 
-function readXml(path) {
+function sourcePath(...segments) {
+  for (const segment of segments) {
+    if (segment.includes("..") || isAbsolute(segment)) {
+      throw new Error(`Invalid source path segment: ${segment}`);
+    }
+  }
+
+  const path = resolve(SOURCE_ROOT, ...segments);
+  const withinSourceRoot = relative(SOURCE_ROOT, path);
+  if (withinSourceRoot.startsWith("..") || isAbsolute(withinSourceRoot)) {
+    throw new Error(`Refusing to read outside source deck root: ${path}`);
+  }
+  return path;
+}
+
+function readSourceXml(...segments) {
+  const path = sourcePath(...segments);
   if (!existsSync(path)) throw new Error(`Missing: ${path}`);
   return readFileSync(path, "utf-8");
 }
@@ -63,23 +79,29 @@ function parseRels(xml) {
 // the rel type is hyperlink.
 function decodeXmlEntities(s) {
   return s
-    .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'");
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function normalizeHref(target) {
+  const href = decodeXmlEntities(target.trim());
+  if (!/^(https?:\/\/|mailto:)/i.test(href)) return null;
+  return href;
 }
 
 function resolveHref(rels, rId) {
   const rel = rels[rId];
   if (!rel) return null;
   if (!rel.type.endsWith("/hyperlink")) return null;
-  return decodeXmlEntities(rel.target);
+  return normalizeHref(rel.target);
 }
 
 // Read the slide-size from presentation.xml (EMUs).
 function getSlideSize() {
-  const presXml = readXml(join(SOURCE_ROOT, "presentation.xml"));
+  const presXml = readSourceXml("presentation.xml");
   const m = /<p:sldSz\s+cy="(\d+)"\s+cx="(\d+)"\/>/.exec(presXml) ||
             /<p:sldSz\s+cx="(\d+)"\s+cy="(\d+)"\/>/.exec(presXml);
   if (!m) throw new Error("Could not find <p:sldSz> in presentation.xml");
@@ -153,8 +175,8 @@ function main() {
 
   const manifest = {};
   for (let i = 1; i <= SLIDE_COUNT; i++) {
-    const slideXml = readXml(join(SOURCE_ROOT, "slides", `slide${i}.xml`));
-    const relsXml = readXml(join(SOURCE_ROOT, "slides", "_rels", `slide${i}.xml.rels`));
+    const slideXml = readSourceXml("slides", `slide${i}.xml`);
+    const relsXml = readSourceXml("slides", "_rels", `slide${i}.xml.rels`);
     const rels = parseRels(relsXml);
     const hotspots = extractShapeHotspots(slideXml, rels, slideSize);
     if (hotspots.length > 0) {

--- a/src/pages/PitchInvestor.jsx
+++ b/src/pages/PitchInvestor.jsx
@@ -36,6 +36,11 @@ import {
   useRemoveHubSpotChatWidget,
   useScrollDeckScale,
 } from "./pitch/scrollCanvas";
+// Hotspot manifest — invisible <a> rectangles overlaid on each flattened
+// slide PNG so the source deck's hyperlinks (LinkedIn, mailto, scholar,
+// source citations, demo video) survive the PowerPoint -> PNG export.
+// Regenerate with: node scripts/extract-investor-deck-hotspots.mjs
+import HOTSPOTS from "./pitch/investor-hotspots.json";
 
 // Slide order is intentionally identical to the source deck.
 // Titles are used only for alt text / aria labels — visible content
@@ -75,25 +80,46 @@ export default function PitchInvestor() {
       </Helmet>
       <style>{SCROLL_DECK_GLOBAL_CSS}</style>
       <div className="bg-[#080808] text-white">
-        {INVESTOR_SLIDES.map((slide, i) => (
-          <ScrollCanvasFrame
-            key={slide.file}
-            index={i}
-            total={INVESTOR_SLIDES.length}
-            scale={scale}
-          >
-            <img
-              src={`${import.meta.env.BASE_URL}investor-deck/slides/${slide.file}`}
-              alt={slide.title}
-              width={SLIDE_W}
-              height={SLIDE_H}
-              loading={i < 2 ? "eager" : "lazy"}
-              decoding="async"
-              className="absolute inset-0 w-full h-full object-contain"
-              draggable={false}
-            />
-          </ScrollCanvasFrame>
-        ))}
+        {INVESTOR_SLIDES.map((slide, i) => {
+          const hotspots = HOTSPOTS[slide.file] || [];
+          return (
+            <ScrollCanvasFrame
+              key={slide.file}
+              index={i}
+              total={INVESTOR_SLIDES.length}
+              scale={scale}
+            >
+              <img
+                src={`${import.meta.env.BASE_URL}investor-deck/slides/${slide.file}`}
+                alt={slide.title}
+                width={SLIDE_W}
+                height={SLIDE_H}
+                loading={i < 2 ? "eager" : "lazy"}
+                decoding="async"
+                className="absolute inset-0 w-full h-full object-contain"
+                draggable={false}
+              />
+              {/* Transparent <a> rectangles overlaid at the source-deck shape
+                  coordinates. Same href targets as the PPTX. */}
+              {hotspots.map((h, hi) => (
+                <a
+                  key={hi}
+                  href={h.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={h.href}
+                  className="absolute z-20 cursor-pointer"
+                  style={{
+                    left: `${h.x * 100}%`,
+                    top: `${h.y * 100}%`,
+                    width: `${h.w * 100}%`,
+                    height: `${h.h * 100}%`,
+                  }}
+                />
+              ))}
+            </ScrollCanvasFrame>
+          );
+        })}
       </div>
     </>
   );

--- a/src/pages/PitchInvestor.jsx
+++ b/src/pages/PitchInvestor.jsx
@@ -103,7 +103,7 @@ export default function PitchInvestor() {
                   coordinates. Same href targets as the PPTX. */}
               {hotspots.map((h, hi) => (
                 <a
-                  key={hi}
+                  key={`${h.href}-${h.x}-${h.y}-${h.w}-${h.h}`}
                   href={h.href}
                   target="_blank"
                   rel="noopener noreferrer"

--- a/src/pages/pitch/investor-hotspots.json
+++ b/src/pages/pitch/investor-hotspots.json
@@ -1,0 +1,61 @@
+{
+  "slide-01.png": [
+    {
+      "href": "https://traigent.ai/",
+      "x": 0.13585,
+      "y": 0.23902,
+      "w": 0.72829,
+      "h": 0.28528
+    }
+  ],
+  "slide-02.png": [
+    {
+      "href": "https://scholar.google.com/citations?hl=en&user=UPlO02gAAAAJ&view_op=list_works&citft=1&citft=2&citft=3&email_for_op=achi%40traigent.ai&sortby=pubdate",
+      "x": 0.04165,
+      "y": 0.57926,
+      "w": 0.27517,
+      "h": 0.24103
+    }
+  ],
+  "slide-06.png": [
+    {
+      "href": "http://drive.google.com/file/d/1SQfgsFA7yEY2n_ozHku5UER__E8yDZpa/view",
+      "x": 0.00486,
+      "y": 0.00486,
+      "w": 0.99028,
+      "h": 0.99028
+    }
+  ],
+  "slide-07.png": [
+    {
+      "href": "https://www.hpcwire.com/aiwire/2024/07/29/idc-reports-rapid-growth-in-ai-platforms-software-market-with-153b-forecast-by-2028/",
+      "x": 0.04766,
+      "y": 0.65127,
+      "w": 0.43957,
+      "h": 0.09965
+    },
+    {
+      "href": "https://www.mordorintelligence.com/industry-reports/agentic-ai-market",
+      "x": 0.5602,
+      "y": 0.4842,
+      "w": 0.39788,
+      "h": 0.13915
+    }
+  ],
+  "slide-11.png": [
+    {
+      "href": "https://www.linkedin.com/in/nimrod-busany-phd-0b938216/",
+      "x": 0.24174,
+      "y": 0.6415,
+      "w": 0.52844,
+      "h": 0.03031
+    },
+    {
+      "href": "https://www.linkedin.com/in/amir-barnea-1aa449/",
+      "x": 0.24174,
+      "y": 0.70109,
+      "w": 0.52844,
+      "h": 0.03031
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

PR #101 made `/investor-pitch` pixel-perfect by exporting source slides to PNG — but flattening lost every hyperlink the source deck carried. User flagged the most visible casualty: the **LinkedIn links on slide 11**.

This fix overlays invisible `<a>` rectangles on top of each slide PNG at the exact shape coordinates from the source PPTX.

### How

- New extractor at \`scripts/extract-investor-deck-hotspots.mjs\` walks each slide's \`<p:sp>\` / \`<p:pic>\` / \`<p:graphicFrame>\`, finds every \`<a:hlinkClick r:id="rIdN"/>\`, resolves the \`rId\` against the slide's \`.rels\` file, and emits shape bounding boxes as fractions of the 12192000×6858000 EMU slide size.
- Committed manifest at \`src/pages/pitch/investor-hotspots.json\` is loaded by \`PitchInvestor.jsx\` and rendered as transparent absolute-positioned anchors inside each \`ScrollCanvasFrame\`.
- Per-shape rule: when a single shape contains multiple hyperlinks (Slide 11 contact rows have email + phone + LinkedIn in one row), the **last** hyperlink wins. That's both the conventional "click anywhere on this contact row → LinkedIn" behaviour and exactly what the user said was missing.

### Hotspots restored

| Slide | Target |
|---|---|
| 1 | \`https://traigent.ai/\` (the logo) |
| 2 | Nimrod's Google Scholar publications page |
| 6 | The demo video on Google Drive |
| 7 | hpcwire IDC source + mordorintelligence source citations |
| 11 | **LinkedIn (Nimrod)** + **LinkedIn (Amir)** |

### Source-deck bug noted but not patched

The PPTX has \`mailto:nimrod@traigent.ai\` wired to Amir's "amir@traigent.ai" text on slide 11 — preserved as-is. The "last link wins" routing surfaces LinkedIn as the row's primary target, so users clicking the row won't hit the wrong mailbox unless they aim precisely.

## Test plan

- [ ] \`npm run dev\` → \`/#/investor-pitch\` → hover slide 11 contact rows — cursor turns to pointer over both Nimrod and Amir rows
- [ ] Click each → opens the correct LinkedIn profile in a new tab
- [ ] Same drill on slide 1 (logo → traigent.ai), slide 2 (Nimrod section → Scholar), slide 6 (image → drive.google), slide 7 (TAM tile → hpcwire, SAM tile → mordorintelligence)
- [ ] Adding a new hyperlink in the source Google Slides + re-exporting PNGs + \`node scripts/extract-investor-deck-hotspots.mjs\` regenerates the manifest cleanly
- [ ] \`npm run build\` — verified locally (✓ built in 17.71s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)