### PR TITLE
fix(investor-pitch): drop duplicated brand-mark overlay + route Amir mailto to his own mailbox

### DIFF
--- a/scripts/extract-investor-deck-hotspots.mjs
+++ b/scripts/extract-investor-deck-hotspots.mjs
@@ -426,6 +426,35 @@ function extractShapeHotspots(slideXml, rels, slideSize) {
   });
 }
 
+// Source-deck bug workarounds applied after extraction. The canonical
+// PPTX wires "amir@traigent.ai" text on slide 11 to mailto:nimrod@traigent.ai
+// — both halves of the email and the surrounding shape. Rather than wait
+// for the source to be fixed, we route any mailto:nimrod@traigent.ai hotspot
+// found in Amir's row (the lower contact-row band on slide 11) to
+// mailto:amir@traigent.ai so the deployed deck does the right thing.
+const HREF_OVERRIDES = [
+  {
+    slide: "slide-11.png",
+    predicate: (h) => h.href === "mailto:nimrod@traigent.ai" && h.y >= 0.67,
+    href: "mailto:amir@traigent.ai",
+    reason: "source-deck bug: Amir's email text wired to Nimrod's mailbox",
+  },
+];
+
+function applyHrefOverrides(slideKey, hotspots) {
+  const overrides = HREF_OVERRIDES.filter((o) => o.slide === slideKey);
+  if (overrides.length === 0) return hotspots;
+  return hotspots.map((h) => {
+    for (const o of overrides) {
+      if (o.predicate(h)) {
+        console.log(`  override: ${h.href} -> ${o.href}  (${o.reason})`);
+        return { ...h, href: o.href };
+      }
+    }
+    return h;
+  });
+}
+
 function main() {
   const slideSize = getSlideSize();
   console.log(`Slide canvas: ${slideSize.cx} x ${slideSize.cy} EMU`);
@@ -435,9 +464,10 @@ function main() {
     const slideXml = readSourceXml("slides", `slide${i}.xml`);
     const relsXml = readSourceXml("slides", "_rels", `slide${i}.xml.rels`);
     const rels = parseRels(relsXml);
-    const hotspots = extractShapeHotspots(slideXml, rels, slideSize);
-    if (hotspots.length > 0) {
+    const rawHotspots = extractShapeHotspots(slideXml, rels, slideSize);
+    if (rawHotspots.length > 0) {
       const key = `slide-${String(i).padStart(2, "0")}.png`;
+      const hotspots = applyHrefOverrides(key, rawHotspots);
       manifest[key] = hotspots;
       console.log(`Slide ${i}: ${hotspots.length} hotspot(s)`);
       for (const h of hotspots) {

--- a/src/pages/PitchInvestor.jsx
+++ b/src/pages/PitchInvestor.jsx
@@ -88,6 +88,7 @@ export default function PitchInvestor() {
               index={i}
               total={INVESTOR_SLIDES.length}
               scale={scale}
+              withBrandMark={false}
             >
               <img
                 src={`${import.meta.env.BASE_URL}investor-deck/slides/${slide.file}`}

--- a/src/pages/pitch/investor-hotspots.json
+++ b/src/pages/pitch/investor-hotspots.json
@@ -79,14 +79,14 @@
       "h": 0.03031
     },
     {
-      "href": "mailto:nimrod@traigent.ai",
+      "href": "mailto:amir@traigent.ai",
       "x": 0.42253,
       "y": 0.70109,
       "w": 0.02781,
       "h": 0.03031
     },
     {
-      "href": "mailto:nimrod@traigent.ai",
+      "href": "mailto:amir@traigent.ai",
       "x": 0.45034,
       "y": 0.70109,
       "w": 0.08344,

--- a/src/pages/pitch/scrollCanvas.jsx
+++ b/src/pages/pitch/scrollCanvas.jsx
@@ -74,12 +74,18 @@ export const SCROLL_DECK_GLOBAL_CSS = `
 // right. The actual slide content goes in `children`. `extraSlideClassName`
 // lets a deck add extra classes to the inner slide element (used by
 // /pitch-short-2 for the one-pager grid override).
+//
+// `withBrandMark` defaults to true. /investor-pitch sets it to false because
+// the investor deck's source slides already carry their own Traigent branding
+// (slide 1 hero logo) — overlaying our chip on top of that doubles the
+// wordmark and looks broken.
 export function ScrollCanvasFrame({
   index,
   total,
   scale,
   children,
   extraSlideClassName = "",
+  withBrandMark = true,
 }) {
   return (
     <section
@@ -102,15 +108,17 @@ export function ScrollCanvasFrame({
             transformOrigin: "top left",
           }}
         >
-          <a
-            href="https://www.traigent.ai/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="absolute top-4 left-4 z-10 hover:opacity-80 transition-opacity"
-            aria-label="Traigent.ai"
-          >
-            <BrandMark size="md" />
-          </a>
+          {withBrandMark && (
+            <a
+              href="https://www.traigent.ai/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="absolute top-4 left-4 z-10 hover:opacity-80 transition-opacity"
+              aria-label="Traigent.ai"
+            >
+              <BrandMark size="md" />
+            </a>
+          )}
 
           {children}
 


### PR DESCRIPTION
## Summary

Two final fixes for /investor-pitch:

1. **Drop the duplicated Traigent.ai brand chip.** Slide 1 in the source PPTX already has the Traigent logo as part of the rendered slide PNG. Stamping our \`<BrandMark>\` chip on top of it (via ScrollCanvasFrame) created a doubled-up wordmark in the top-left that read as broken/misspelled. ScrollCanvasFrame now accepts a \`withBrandMark\` prop (default true to preserve /pitch-short-2 chrome); PitchInvestor passes false.

2. **Route Amir's mailto to Amir's mailbox.** The source Google Slides has a pre-existing bug: every \"amir@traigent.ai\" text run on slide 11 is wired to \`mailto:nimrod@traigent.ai\` (rId7 and rId8 in the rels). Until that's patched at source, the extractor applies an explicit \`HREF_OVERRIDES\` rule that rewrites any mailto-nimrod hotspot landing in the lower contact-row band (y >= 0.67) to \`mailto:amir@traigent.ai\` on emit. Override is documented inline.

## After this lands, slide 11's four contact links work like this:

| Click | Opens |
|---|---|
| Nimrod's email | \`mailto:nimrod@traigent.ai\` ✓ |
| Nimrod's LinkedIn | Nimrod's profile ✓ |
| Amir's \"amir@traigent.ai\" text | \`mailto:amir@traigent.ai\` ✓ (override) |
| Amir's LinkedIn | Amir's profile ✓ |

## Test plan

- [ ] \`npm run dev\` → \`/#/investor-pitch\` slide 1 — no \"Traigent.ai\" chip in top-left, just the source logo
- [ ] Slide 11 — clicking each of the 4 contact regions opens the correct address / profile
- [ ] \`/#/pitch-short-2\` and friends still show the brand chip (default behaviour unchanged)
- [ ] \`npm run build\` — verified locally (✓ built in 13.89s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)