### PR TITLE
feat(consent): cookie-reject blocks gated forms + required GDPR checkbox before submit

### DIFF
--- a/src/components/ConsentCheckbox.jsx
+++ b/src/components/ConsentCheckbox.jsx
@@ -1,0 +1,49 @@
+/* eslint-disable react/prop-types */
+const PRIVACY_URL = 'https://portal.traigent.ai/privacy';
+
+/**
+ * Required GDPR consent checkbox for any email-capture form. Controlled —
+ * the parent owns the `checked` state and decides what to gate on it
+ * (e.g. only mounting the HubSpot embed after this is checked, or
+ * disabling a hand-rolled submit button until it is).
+ *
+ * Props:
+ *   checked   boolean
+ *   onChange  (boolean) => void
+ *   id        DOM id  — defaults to "traigent-consent-checkbox"
+ */
+export default function ConsentCheckbox({
+  checked,
+  onChange,
+  id = 'traigent-consent-checkbox',
+}) {
+  return (
+    <label
+      htmlFor={id}
+      className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-slate-700/60 bg-slate-950/40 p-3 text-sm leading-relaxed text-slate-300 transition-colors hover:border-slate-600"
+    >
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        required
+        className="mt-0.5 h-4 w-4 shrink-0 rounded border-slate-600 bg-slate-900 text-[#1A6BF5] focus:ring-1 focus:ring-[#4D8EF8]"
+      />
+      <span>
+        I agree to receive communications from Traigent about the product I'm
+        signing up for, and I accept the{' '}
+        <a
+          href={PRIVACY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="text-blue-300 underline underline-offset-2 hover:text-blue-200"
+        >
+          Privacy Policy
+        </a>
+        .
+      </span>
+    </label>
+  );
+}

--- a/src/components/ConsentGate.jsx
+++ b/src/components/ConsentGate.jsx
@@ -1,0 +1,73 @@
+/* eslint-disable react/prop-types */
+import { useEffect, useState } from 'react';
+import { Cookie } from 'lucide-react';
+import {
+  getConsentRecord,
+  hasRejectedConsent,
+  openCookieBanner,
+  subscribeConsent,
+} from '../lib/consent';
+
+const PRIVACY_URL = 'https://portal.traigent.ai/privacy';
+
+/**
+ * Wraps any gated form. Behaviour:
+ *
+ *   - Cookies explicitly REJECTED -> show a "Cookies required" block instead
+ *     of the form, with a button that re-opens the cookie banner.
+ *   - Cookies ACCEPTED or undecided -> render children. (Undecided means the
+ *     cookie banner is already on screen blocking the page, so there is no
+ *     point also blocking the form.)
+ *
+ * Subscribes to consent changes so flipping Reject -> Accept inside the
+ * cookie banner immediately reveals the wrapped form.
+ */
+export default function ConsentGate({ children }) {
+  const [rejected, setRejected] = useState(() => hasRejectedConsent());
+
+  useEffect(() => {
+    setRejected(hasRejectedConsent());
+    return subscribeConsent(() => setRejected(hasRejectedConsent()));
+  }, []);
+
+  if (!rejected) return children;
+  return <CookiesRequiredBlock />;
+}
+
+function CookiesRequiredBlock() {
+  return (
+    <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-6 text-center">
+      <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-amber-500/10 text-amber-300">
+        <Cookie className="h-5 w-5" />
+      </div>
+      <h3 className="mb-2 text-lg font-semibold text-white">
+        Cookie consent required
+      </h3>
+      <p className="mb-5 text-sm leading-relaxed text-slate-300">
+        You previously chose <span className="font-semibold text-white">Reject</span> on
+        our cookie banner. We need your consent before we can share contact
+        details with you or send you anything by email — submission is gated
+        behind that choice.
+      </p>
+      <button
+        type="button"
+        onClick={openCookieBanner}
+        className="inline-flex items-center rounded-lg bg-[#1A6BF5] px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-[#4D8EF8]"
+      >
+        Review cookie preferences
+      </button>
+      <p className="mt-4 text-xs text-slate-500">
+        See our{' '}
+        <a
+          href={PRIVACY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2 hover:text-slate-300"
+        >
+          Privacy Policy
+        </a>
+        {' '}for what we collect and why.
+      </p>
+    </div>
+  );
+}

--- a/src/components/ContactSection.jsx
+++ b/src/components/ContactSection.jsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { Send } from "lucide-react";
 import { trackEvent } from "../lib/analytics";
+import ConsentGate from "./ConsentGate";
+import ConsentCheckbox from "./ConsentCheckbox";
 
 // HubSpot Forms API config — values from the embed snippet in HubSpot.
 // These are PUBLIC (already in the public embed code), so it's fine to inline.
@@ -62,6 +64,7 @@ function validateBusinessEmail(email) {
 export default function ContactSection() {
   const sectionRef = useRef(null);
   const [form, setForm] = useState({ firstname: "", lastname: "", email: "", message: "" });
+  const [agreed, setAgreed] = useState(false);
   const [emailError, setEmailError] = useState("");
   const [submitError, setSubmitError] = useState("");
   const [sending, setSending] = useState(false);
@@ -87,6 +90,13 @@ export default function ContactSection() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    // Belt-and-suspenders: the GDPR checkbox already disables the submit
+    // button, but reject any submit that slips through (autofill, JS poke,
+    // browser extension) so we never POST a lead without consent on file.
+    if (!agreed) {
+      trackEvent("contact_form_validation_failed", { reason: "no_consent" });
+      return;
+    }
     const err = validateBusinessEmail(form.email);
     if (err) {
       setEmailError(err);
@@ -181,6 +191,7 @@ export default function ContactSection() {
             </button>
           </motion.div>
         ) : (
+          <ConsentGate>
           <motion.form
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
@@ -263,13 +274,19 @@ export default function ContactSection() {
               </div>
             )}
 
+            <ConsentCheckbox
+              id="contact-consent"
+              checked={agreed}
+              onChange={setAgreed}
+            />
+
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 pt-2">
               <p className="text-xs text-slate-500">
                 {sending ? "Sending..." : "Submissions land in our HubSpot CRM."}
               </p>
               <button
                 type="submit"
-                disabled={sending}
+                disabled={sending || !agreed}
                 className="inline-flex items-center justify-center bg-[#1A6BF5] hover:bg-[#4D8EF8] disabled:bg-slate-700 disabled:cursor-not-allowed text-white font-medium px-6 py-2.5 rounded-lg text-sm transition-colors whitespace-nowrap"
               >
                 <Send className="w-4 h-4 mr-2" />
@@ -277,6 +294,7 @@ export default function ContactSection() {
               </button>
             </div>
           </motion.form>
+          </ConsentGate>
         )}
       </div>
     </section>

--- a/src/components/CookieConsent.jsx
+++ b/src/components/CookieConsent.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { getConsentRecord, setConsent } from '../lib/consent';
+import { getConsentRecord, setConsent, OPEN_BANNER_EVENT } from '../lib/consent';
 
 export default function CookieConsent() {
   const [showBanner, setShowBanner] = useState(false);
@@ -12,6 +12,16 @@ export default function CookieConsent() {
         setShowBanner(true);
       }
     }
+  }, []);
+
+  // Any other UI surface (e.g. a gated form's "Cookies required" block) can
+  // re-open the banner by dispatching OPEN_BANNER_EVENT — see
+  // openCookieBanner() in src/lib/consent.js.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onOpen = () => setShowBanner(true);
+    window.addEventListener(OPEN_BANNER_EVENT, onOpen);
+    return () => window.removeEventListener(OPEN_BANNER_EVENT, onOpen);
   }, []);
 
   const handleAccept = () => {

--- a/src/components/PortalGateModal.jsx
+++ b/src/components/PortalGateModal.jsx
@@ -2,6 +2,8 @@
 import { useEffect, useState } from "react";
 import { X, ExternalLink } from "lucide-react";
 import HubSpotStartNowForm from "./HubSpotStartNowForm";
+import ConsentGate from "./ConsentGate";
+import ConsentCheckbox from "./ConsentCheckbox";
 import {
   isUnlocked,
   markUnlocked,
@@ -131,6 +133,7 @@ function CheckingView() {
 }
 
 function LockedView({ onSubmitted }) {
+  const [agreed, setAgreed] = useState(false);
   return (
     <>
       <h2 id="portal-gate-title" className="text-2xl font-bold text-white mb-2">
@@ -140,11 +143,26 @@ function LockedView({ onSubmitted }) {
         Tell us where to send setup tips — the portal opens as soon as you
         submit.
       </p>
-      <HubSpotStartNowForm
-        formId={PORTAL_FORM_ID}
-        onSuccess={onSubmitted}
-        targetId="hs-portal-gate-form"
-      />
+      <ConsentGate>
+        <div className="mb-4">
+          <ConsentCheckbox
+            id="portal-gate-consent"
+            checked={agreed}
+            onChange={setAgreed}
+          />
+        </div>
+        {agreed ? (
+          <HubSpotStartNowForm
+            formId={PORTAL_FORM_ID}
+            onSuccess={onSubmitted}
+            targetId="hs-portal-gate-form"
+          />
+        ) : (
+          <p className="text-xs text-slate-500">
+            Tick the box above to load the form.
+          </p>
+        )}
+      </ConsentGate>
     </>
   );
 }

--- a/src/components/StartNowModal.jsx
+++ b/src/components/StartNowModal.jsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from "react";
 import { X, ArrowRight, Github } from "lucide-react";
 import InstallCommand from "./InstallCommand";
 import HubSpotStartNowForm from "./HubSpotStartNowForm";
+import ConsentGate from "./ConsentGate";
+import ConsentCheckbox from "./ConsentCheckbox";
 import {
   isUnlocked,
   markUnlocked,
@@ -131,6 +133,7 @@ function CheckingView() {
 }
 
 function LockedView({ onSubmitted }) {
+  const [agreed, setAgreed] = useState(false);
   return (
     <>
       <h2 id="start-now-title" className="text-2xl font-bold text-white mb-2">
@@ -140,7 +143,22 @@ function LockedView({ onSubmitted }) {
         Run the keyless demo on your laptop in under a minute. Tell us where to
         send setup tips — the install command unlocks as soon as you submit.
       </p>
-      <HubSpotStartNowForm onSuccess={onSubmitted} />
+      <ConsentGate>
+        <div className="mb-4">
+          <ConsentCheckbox
+            id="start-now-consent"
+            checked={agreed}
+            onChange={setAgreed}
+          />
+        </div>
+        {agreed ? (
+          <HubSpotStartNowForm onSuccess={onSubmitted} />
+        ) : (
+          <p className="text-xs text-slate-500">
+            Tick the box above to load the form.
+          </p>
+        )}
+      </ConsentGate>
     </>
   );
 }

--- a/src/components/academy/AcademyEmailGate.jsx
+++ b/src/components/academy/AcademyEmailGate.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { trackEvent } from "../../lib/analytics";
 import { checkKnownContact } from "../../lib/hubspotIdentify";
+import ConsentGate from "../ConsentGate";
+import ConsentCheckbox from "../ConsentCheckbox";
 
 // One notification per visitor per course per hour. Matches the global
 // gate's throttle window so the inbox volume stays sane in prod.
@@ -182,6 +184,7 @@ export default function AcademyEmailGate({ courseSlug, courseTitle, formId, chil
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const [email, setEmail] = useState("");
+  const [agreed, setAgreed] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
 
@@ -235,28 +238,35 @@ export default function AcademyEmailGate({ courseSlug, courseTitle, formId, chil
           Drop your work email below to get the access link. We'll send it to
           your inbox right away — no spam, just the link back to this course.
         </p>
-        <form onSubmit={onSubmit} className="space-y-3">
-          <label htmlFor={`academy-email-${courseSlug}`} className="sr-only">
-            Email address
-          </label>
-          <input
-            id={`academy-email-${courseSlug}`}
-            type="email"
-            required
-            placeholder="you@yourcompany.com"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            disabled={submitting}
-            className="w-full px-4 py-3 rounded-lg bg-slate-950/60 border border-slate-700 text-white placeholder-slate-500 focus:outline-none focus:border-[#4D8EF8] transition-colors"
-          />
-          <button
-            type="submit"
-            disabled={submitting || !email}
-            className="w-full bg-[#1A6BF5] hover:bg-[#4D8EF8] disabled:opacity-60 disabled:cursor-not-allowed text-white px-5 py-3 rounded-lg font-medium transition-colors"
-          >
-            {submitting ? "Sending…" : "Send me the access link"}
-          </button>
-        </form>
+        <ConsentGate>
+          <form onSubmit={onSubmit} className="space-y-3">
+            <label htmlFor={`academy-email-${courseSlug}`} className="sr-only">
+              Email address
+            </label>
+            <input
+              id={`academy-email-${courseSlug}`}
+              type="email"
+              required
+              placeholder="you@yourcompany.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              disabled={submitting}
+              className="w-full px-4 py-3 rounded-lg bg-slate-950/60 border border-slate-700 text-white placeholder-slate-500 focus:outline-none focus:border-[#4D8EF8] transition-colors"
+            />
+            <ConsentCheckbox
+              id={`academy-consent-${courseSlug}`}
+              checked={agreed}
+              onChange={setAgreed}
+            />
+            <button
+              type="submit"
+              disabled={submitting || !email || !agreed}
+              className="w-full bg-[#1A6BF5] hover:bg-[#4D8EF8] disabled:opacity-60 disabled:cursor-not-allowed text-white px-5 py-3 rounded-lg font-medium transition-colors"
+            >
+              {submitting ? "Sending…" : "Send me the access link"}
+            </button>
+          </form>
+        </ConsentGate>
         {error === "business_email" && (
           <p className="text-amber-400 text-sm mt-4" role="alert">
             Please enter your <u>business</u> email

--- a/src/lib/consent.js
+++ b/src/lib/consent.js
@@ -2,6 +2,12 @@ const CONSENT_KEY = 'traigent_marketing_consent';
 export const CONSENT_POLICY_REV = '2026-06-06 rev. 4';
 const listeners = new Set();
 
+// Window CustomEvent name dispatched when any UI surface wants the cookie
+// banner re-opened (e.g. a "Cookies required" block on a gated form whose
+// visitor previously chose Reject and now wants to revisit that choice).
+// CookieConsent.jsx listens for it.
+export const OPEN_BANNER_EVENT = 'traigent:open-cookie-banner';
+
 export function getConsentRecord() {
   if (typeof window === 'undefined') return null;
   let stored;
@@ -28,6 +34,21 @@ export function getConsentRecord() {
 
 export function hasMarketingConsent() {
   return getConsentRecord()?.granted === true;
+}
+
+// True only when the visitor explicitly chose Reject. Distinct from "no
+// decision yet" — undecided returns false here so the cookie banner (not
+// the rejection-block UI) is what they see first.
+export function hasRejectedConsent() {
+  return getConsentRecord()?.granted === false;
+}
+
+// Re-open the cookie banner from anywhere (e.g. the "Review cookie
+// preferences" button on a gated-form rejection block). CookieConsent.jsx
+// subscribes to OPEN_BANNER_EVENT and flips its banner state on.
+export function openCookieBanner() {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(OPEN_BANNER_EVENT));
 }
 
 export function setConsent(granted) {


### PR DESCRIPTION
## Summary

Three connected changes, per the consent UX discussion:

1. **ConsentGate** — wraps every gated lead-capture surface. If the visitor explicitly chose **Reject** on the cookie banner, the form is replaced with a "Cookie consent required" block that re-opens the banner. Undecided -> pass through (the banner is already covering the page).
2. **ConsentCheckbox** — required GDPR consent checkbox above each submit. *"I agree to receive communications from Traigent and accept the [Privacy Policy]."* Submit is gated on the checkbox.
3. **Re-opening the banner from anywhere** — \`OPEN_BANNER_EVENT\` + \`openCookieBanner()\` in \`src/lib/consent.js\`. The rejection-block button in \`ConsentGate\` dispatches it so the visitor can flip Reject -> Accept without hunting for the floating preferences chip.

### Forms covered

- \`StartNowModal\`
- \`PortalGateModal\`
- \`AcademyEmailGate\` (all academy course gates)

### Stickiness of \"Accept\"

Already lives in \`consent.js\` (localStorage JSON with \`ts\` + \`policyRev\`). Survives hard refresh — no change required.

## Test plan

- [ ] First visit -> cookie banner appears. Click **Reject** -> open Start Now / Open Portal / any Academy course -> form is replaced with the rejection block. Click *Review cookie preferences* -> banner re-opens -> click Accept -> form appears.
- [ ] With cookies accepted, the GDPR checkbox renders above the form. Submit is disabled until it's checked. Checking it loads / enables the form.
- [ ] Hard-refresh after Accept -> banner does NOT reappear; form shows the checkbox.
- [ ] Existing Academy course-gate localStorage unlock flow unchanged.
- [ ] \`npm run build\` — verified locally (✓ built in 6.62s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)