### PR TITLE
feat(get-started): add guided agent prompt selector

### DIFF
--- a/src/data/traigentSkillOnboarding.json
+++ b/src/data/traigentSkillOnboarding.json
@@ -1,0 +1,83 @@
+{
+  "installPresets": {
+    "all": {
+      "label": "Install all Traigent skills",
+      "command": "npx skills add Traigent/traigent-skills --skill '*'",
+      "secondary": "Installs all published user-facing Traigent SDK skills from the dedicated public repo."
+    },
+    "entrypoints": {
+      "label": "Entry points only",
+      "command": "npx skills add Traigent/traigent-skills --skill traigent --skill traigent-quickstart",
+      "secondary": "Useful only when you want the shortest local skill footprint."
+    }
+  },
+  "goals": [
+    {
+      "id": "integrate-decorator",
+      "label": "Integrate the decorator",
+      "skills": ["traigent-decorator-setup"],
+      "promptSteps": [
+        "Inspect my target function and add the @traigent.optimize decorator without changing behavior.",
+        "Define the inputs, objective, and eval data needed for a safe optimization run."
+      ]
+    },
+    {
+      "id": "find-knobs",
+      "label": "Find the knobs that matter",
+      "skills": [
+        "traigent-configuration-space",
+        "traigent-composite-knobs",
+        "show-significant-tuned-variables"
+      ],
+      "promptSteps": [
+        "Map the tunable variables and constraints before running optimization.",
+        "After the run, identify the significant tuned variables and explain which config changed the outcome."
+      ]
+    },
+    {
+      "id": "setup-evaluation",
+      "label": "Set up evaluation",
+      "skills": ["traigent-decorator-setup"],
+      "promptSteps": [
+        "Build or validate an eval dataset and scoring function before any paid run.",
+        "Show me the pass/fail criteria that make the optimization result trustworthy."
+      ]
+    },
+    {
+      "id": "run-optimization",
+      "label": "Run optimization",
+      "skills": ["traigent-run-optimization"],
+      "promptSteps": [
+        "Run the full flow in mock or dry-run mode first, with no API keys and no LLM cost.",
+        "Only after the dry run passes, run the real optimization and track cost, trials, and final score."
+      ]
+    },
+    {
+      "id": "apply-results",
+      "label": "Analyze and apply results",
+      "skills": ["traigent-analyze-results"],
+      "promptSteps": [
+        "Read the optimization results, compare the winning config against baseline, and explain the tradeoffs.",
+        "Apply the selected config as a small code change and add a regression check."
+      ]
+    },
+    {
+      "id": "debug-run",
+      "label": "Debug a run",
+      "skills": ["traigent-debugging"],
+      "promptSteps": [
+        "Inspect the failed run, logs, traces, and config space before changing code.",
+        "Fix the smallest root cause, then rerun the mock path before retrying a real run."
+      ]
+    },
+    {
+      "id": "integrate-framework",
+      "label": "Integrate a framework",
+      "skills": ["traigent-integrations"],
+      "promptSteps": [
+        "Adapt the setup for my framework, such as LangChain, LiteLLM, DSPy, or a direct SDK call.",
+        "Keep the framework wrapper testable so optimization can be validated locally before deployment."
+      ]
+    }
+  ]
+}

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -1,9 +1,10 @@
-﻿import React, { useState, useEffect } from "react";
-import { ArrowLeft, ExternalLink } from "lucide-react";
+﻿import React, { useState, useEffect, useMemo } from "react";
+import { ArrowLeft, Check, Copy, ExternalLink } from "lucide-react";
 import { Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import InstallCommand from "../components/InstallCommand";
 import HubSpotStartNowForm from "../components/HubSpotStartNowForm";
+import skillOnboarding from "../data/traigentSkillOnboarding.json";
 import {
   isUnlocked,
   markUnlocked,
@@ -15,10 +16,13 @@ import { checkKnownContact } from "../lib/hubspotIdentify";
 import { trackEvent } from "../lib/analytics";
 
 const createPageUrl = (path) => path;
-const SDK_SKILL_INSTALL_COMMAND = [
-  "npx skills add Traigent/traigent-skills",
-  "--skill '*'",
-].join(" ");
+const { installPresets, goals: AGENT_GOALS } = skillOnboarding;
+const DEFAULT_AGENT_GOAL_IDS = [
+  "integrate-decorator",
+  "setup-evaluation",
+  "run-optimization",
+];
+const SDK_SKILL_INSTALL_PRESET = installPresets.all;
 const TERMINAL_INSTALL_COMMAND = "curl -fsSL https://traigent.ai/install.sh | sh";
 // Switch these defaults to traigent[recommended] once that extras bundle ships.
 const MANUAL_INSTALL_COMMANDS = [
@@ -27,11 +31,34 @@ const MANUAL_INSTALL_COMMANDS = [
   "pip install 'traigent[recommended]'",
 ];
 
+function uniqueSkills(goals) {
+  return Array.from(new Set(goals.flatMap((goal) => goal.skills)));
+}
+
+function composeAgentPrompt(goals) {
+  const selectedGoals = goals.length > 0 ? goals : AGENT_GOALS.slice(0, 1);
+  const steps = selectedGoals.flatMap((goal) => goal.promptSteps);
+  const skills = uniqueSkills(selectedGoals);
+
+  return [
+    "I've installed the Traigent SDK skills. Help me optimize <describe my target function or workflow>.",
+    "",
+    `Use these Traigent skills when relevant: ${skills.join(", ")}.`,
+    "",
+    "Work in this order:",
+    ...steps.map((step, index) => `${index + 1}. ${step}`),
+    `${steps.length + 1}. Keep the first validation in mock or dry-run mode, then ask before spending on a real optimization run.`,
+    `${steps.length + 2}. Summarize the evidence, the winning config, and any code change before closing.`,
+  ].join("\n");
+}
+
 export default function GetStarted() {
   // Gate the install commands behind the HubSpot form on first visit.
   // Same 90-day localStorage memory as the Start Now modal so a visitor
   // who unlocked there doesn't see the form again here, and vice versa.
   const [unlocked, setUnlocked] = useState(() => isUnlocked());
+  const [selectedGoalIds, setSelectedGoalIds] = useState(DEFAULT_AGENT_GOAL_IDS);
+  const [copiedPrompt, setCopiedPrompt] = useState(false);
 
   // Repeat-visit notification — see StartNowModal for the rationale.
   useEffect(() => {
@@ -65,6 +92,38 @@ export default function GetStarted() {
     markUnlocked(email);
     setUnlocked(true);
     trackEvent("start_now_form_submitted", { location: "get_started_page" });
+  };
+
+  const selectedGoals = useMemo(
+    () => AGENT_GOALS.filter((goal) => selectedGoalIds.includes(goal.id)),
+    [selectedGoalIds]
+  );
+  const selectedSkillNames = useMemo(() => uniqueSkills(selectedGoals), [selectedGoals]);
+  const agentPrompt = useMemo(() => composeAgentPrompt(selectedGoals), [selectedGoals]);
+
+  const toggleGoal = (goalId) => {
+    setSelectedGoalIds((current) => {
+      if (current.includes(goalId)) {
+        return current.length === 1 ? current : current.filter((id) => id !== goalId);
+      }
+      return [...current, goalId];
+    });
+    setCopiedPrompt(false);
+  };
+
+  const copyAgentPrompt = async () => {
+    if (!navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(agentPrompt);
+      setCopiedPrompt(true);
+      setTimeout(() => setCopiedPrompt(false), 2000);
+      trackEvent("agent_prompt_copied", {
+        location: "get_started_page",
+        selected_goals: selectedGoalIds,
+      });
+    } catch {
+      // Clipboard unavailable (insecure context, etc.) — silent fallback.
+    }
   };
 
   return (
@@ -195,10 +254,63 @@ export default function GetStarted() {
           </p>
           {unlocked && (
             <InstallCommand
-              command={SDK_SKILL_INSTALL_COMMAND}
-              secondary="Installs all published user-facing Traigent SDK skills from the dedicated public repo."
+              command={SDK_SKILL_INSTALL_PRESET.command}
+              label={SDK_SKILL_INSTALL_PRESET.label}
+              secondary={SDK_SKILL_INSTALL_PRESET.secondary}
             />
           )}
+          <div className="mt-6 border-t border-slate-800 pt-6">
+            <h3 className="text-lg font-semibold mb-3">Build the prompt for your agent</h3>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-5">
+              {AGENT_GOALS.map((goal) => {
+                const active = selectedGoalIds.includes(goal.id);
+                return (
+                  <button
+                    type="button"
+                    key={goal.id}
+                    onClick={() => toggleGoal(goal.id)}
+                    aria-pressed={active}
+                    className={[
+                      "text-left rounded-lg border px-4 py-3 transition-colors min-h-[76px]",
+                      active
+                        ? "bg-blue-500/15 border-blue-400 text-white"
+                        : "bg-slate-950/50 border-slate-700 text-slate-300 hover:border-slate-500 hover:bg-slate-800/60",
+                    ].join(" ")}
+                  >
+                    <span className="flex items-start gap-2">
+                      <span className={[
+                        "mt-0.5 inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border",
+                        active ? "border-blue-300 bg-blue-400 text-slate-950" : "border-slate-600 text-transparent",
+                      ].join(" ")}>
+                        <Check className="h-3.5 w-3.5" />
+                      </span>
+                      <span className="font-medium leading-5">{goal.label}</span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+            <div className="mb-3 break-words text-xs uppercase text-slate-500">
+              Skills routed: {selectedSkillNames.join(", ")}
+            </div>
+            <div className="relative rounded-lg border border-slate-700 bg-slate-950/70 p-4">
+              <pre className="pr-12 whitespace-pre-wrap break-words text-sm leading-6 text-slate-200 font-mono">
+                {agentPrompt}
+              </pre>
+              <button
+                type="button"
+                onClick={copyAgentPrompt}
+                aria-label={copiedPrompt ? "Copied agent prompt" : "Copy agent prompt"}
+                className="absolute right-3 top-3 inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-600 bg-slate-800 text-slate-200 transition-colors hover:border-slate-500 hover:bg-slate-700"
+              >
+                {copiedPrompt ? (
+                  <Check className="h-4 w-4 text-emerald-400" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+          </div>
         </div>
 
         <div className="mt-12 p-6 rounded-xl bg-gradient-to-br from-indigo-600/20 to-purple-700/20 border border-white/10">


### PR DESCRIPTION
## Summary
- add a manifest-backed Get Started goal selector that composes a copy-paste prompt for coding agents
- preserve the safe install-all command for Traigent skills instead of generating fragile partial installs
- default the prompt to decorator setup, evaluation, and dry-run-first optimization sequencing

Fixes #85

## Verification
- npm ci
- npm run build
- git diff --check
- Playwright preview inspection at http://127.0.0.1:4178/#/get-started on 1440px desktop and 390px mobile

## Caveats
- npm run lint is still blocked by this repo's missing ESLint config; no config change included in this UI packet
- npm ci reports existing moderate npm audit findings; dependency remediation is out of scope