### PR TITLE
fix(web): align pricing savings claims

### DIFF
--- a/src/content/blog/observability-is-not-enough.md
+++ b/src/content/blog/observability-is-not-enough.md
@@ -100,7 +100,7 @@ But if your reasoning is *"we have observability, so we don't need Traigent,"* y
 
 ## The cost of stopping at observability
 
-For a modest agent doing 1M calls/month, the gap between *current configuration* and *optimal configuration* is typically **30–60% in cost** at comparable accuracy, or several accuracy points at comparable cost. On a $20k/month bill, that's $6,000–$12,000/month — every month, indefinitely — flowing to a frontier-model provider when a cheaper configuration would have served the same workload.
+For a modest agent doing 1M calls/month, the gap between *current configuration* and *optimal configuration* can be **20–60% in cost** at comparable accuracy, or several accuracy points at comparable cost. On a $20k/month bill, that's $4,000–$12,000/month — every month, indefinitely — flowing to a frontier-model provider when a cheaper configuration would have served the same workload. The actual number still needs pilot validation against your workload.
 
 Observability tells you exactly how that money is being spent. It doesn't recover any of it. Recovery requires the optimization loop.
 

--- a/src/content/blog/the-business-case.md
+++ b/src/content/blog/the-business-case.md
@@ -38,11 +38,11 @@ For ~3–5 dimensions, yes — slowly. The full configuration space has 10+ dime
 
 **Q: How much can teams typically save?**
 
-30–60% LLM cost reduction at the same accuracy. On a representative $20k/month agent, that's **$6–12k/month — $72k–$144k/year — recurring.** Plus reclaimed engineer time. → [See the math ↓](#the-math) · Or plug your own numbers into the [ROI Calculator →](/roi)
+20–60% potential LLM cost reduction at the same accuracy, subject to pilot validation. On a representative $20k/month agent, that's **$4–12k/month — $48k–$144k/year — recurring.** Plus reclaimed engineer time. → [See the math ↓](#the-math) · Or plug your own numbers into the [ROI Calculator →](/roi)
 
 **Q: Does this make sense for a small team or low monthly spend?**
 
-Yes, in most cases. With Traigent Starter at **$99/month flat**, the breakeven on Traigent cost alone is roughly **$330/month** of LLM spend (at the conservative 30% savings rate). Below that, the **Free POC** is the right starting point — zero risk, no Traigent investment, and even reaching a better accuracy/latency point without spending more is a net engineering win. → [When this pays off ↓](#when-this-pays-off)
+Yes, in most cases. With Traigent Starter at **$99/month flat**, the breakeven on Traigent cost alone is roughly **$495/month** of LLM spend (at the conservative 20% savings rate). Below that, the **Free POC** is the right starting point — zero risk, no Traigent investment, and even reaching a better accuracy/latency point without spending more is a net engineering win. → [When this pays off ↓](#when-this-pays-off)
 
 **Q: We already use Langfuse / Arize / Helicone for observability. Isn't that enough?**
 
@@ -74,8 +74,8 @@ This is the heart of the **model myth**: the assumption that picking a better mo
 
 | Outcome | Monthly savings | Annual savings |
 |---|---|---|
-| 30% reduction (conservative) | $6,000 | **$72,000** |
-| 45% reduction (typical) | $9,000 | **$108,000** |
+| 20% reduction (conservative) | $4,000 | **$48,000** |
+| 40% reduction (typical) | $8,000 | **$96,000** |
 | 60% reduction (achievable) | $12,000 | **$144,000** |
 
 Recurring — every month, indefinitely. A two-year deployment captures 24× the annualized number.
@@ -83,7 +83,7 @@ Recurring — every month, indefinitely. A two-year deployment captures 24× the
 Add engineering time savings (senior ML engineer hours freed from tuning):
 - 4 hours/week × $150/hr × 52 weeks ≈ **$31k/year per agent** in reclaimed time
 
-**Total economic value on a single $20k/month agent: $100k–$175k per year.** For multi-agent teams, multiply by the agent count.
+**Total economic value on a single $20k/month agent: $79k–$175k per year.** For multi-agent teams, multiply by the agent count.
 
 → **Plug your own numbers in**: the [ROI Calculator](/roi) lets you dial in your monthly spend, engineer hourly rate, and Traigent tier to see your projected 12-month savings (net of Traigent cost).
 
@@ -105,7 +105,7 @@ The economics of that workflow are bad on two axes:
 
 → **Quantify it on your own search space**: the [TTM Calculator](/ttm) shows the FTE weeks and dollars Traigent saves per optimization pass, given your dimensions and engineering parameters.
 
-**Axis 2: Inference cost.** Because manual tuning explores 5–20 configurations out of millions, the shipped configuration is almost certainly **30–60% more expensive than the optimum** for the same accuracy. That delta then runs in production forever — multiplied by every query, every customer, every month.
+**Axis 2: Inference cost.** Because manual tuning explores 5–20 configurations out of millions, the shipped configuration can be **20–60% more expensive than the optimum** for the same accuracy. That delta then runs in production forever — multiplied by every query, every customer, every month.
 
 The status quo isn't free. It's a recurring tax. Most teams don't see it because there's no line item called *"cost of un-optimized configuration."* The cost is invisible — but it shows up monthly.
 
@@ -113,7 +113,7 @@ The status quo isn't free. It's a recurring tax. Most teams don't see it because
 
 Across early Traigent deployments and the published literature on configuration optimization, typical outcomes look like:
 
-- **30–60% cost reduction** at the same accuracy
+- **20–60% potential cost reduction** at the same accuracy, confirmed by pilot
 - **OR** several accuracy points of lift at the same cost
 - **OR** a meaningful latency improvement (relevant for real-time agents)
 
@@ -149,7 +149,7 @@ A modern agent has 10–15+ tunable dimensions: model, temperature, top-p, max t
 
 A senior engineer can hold 3–5 dimensions in working memory simultaneously. The other 7–10 dimensions get fixed at defaults and ignored.
 
-This is why manual *"tuning sprints"* produce small improvements (10–15%) instead of large ones (30–60%) — the engineer is searching one slice of the space, not the space. → [See the FTE-weeks math on your own space ↗](/ttm)
+This is why manual *"tuning sprints"* produce small improvements (10–15%) instead of larger 20–60% opportunities — the engineer is searching one slice of the space, not the space. → [See the FTE-weeks math on your own space ↗](/ttm)
 
 And even if a semi-annual sprint catches some drift, **9–10 months out of every 12 are spent overpaying** for a configuration that was selected against an obsolete environment.
 
@@ -169,11 +169,11 @@ The pivot is from *"optimization as a project"* (multi-week, expensive, infreque
 
 Automated cost-performance optimization makes economic sense any time the recurring LLM spend exceeds the Traigent tier cost — which, at current pricing, is a low bar:
 
-| Traigent tier | Annual cost | Breakeven LLM spend (at 30% conservative savings) |
+| Traigent tier | Annual cost | Breakeven LLM spend (at 20% conservative savings) |
 |---|---|---|
 | **Free POC** | $0 | Any production agent — even zero-cost savings + engineering time saved is net positive |
-| **Starter** ($99/mo) | $1,188 | ~$330/month of LLM spend |
-| **Pro** ($249/mo) | $2,988 | ~$830/month of LLM spend |
+| **Starter** ($99/mo) | $1,188 | ~$495/month of LLM spend |
+| **Pro** ($249/mo) | $2,988 | ~$1,245/month of LLM spend |
 | **Enterprise** | Custom | Negotiated against your specific spend profile |
 
 The investment is **less compelling** for:
@@ -189,7 +189,7 @@ Production AI agents are recurring-cost products. Their configuration is the sin
 
 The dominant assumption that makes this acceptable is the **model myth**: the belief that "pick a better model" is the answer. It isn't. Configuration choices across prompt, retrieval, tokens, and sampling routinely move cost and accuracy more than the model itself does.
 
-Automated cost-performance optimization replaces the one-shot guess with a system that **searches the full configuration space, converges fast, and re-optimizes as the world moves**. The first capture is typically 30–60% cost reduction. The compounding capture is keeping the agent near the optimum for its entire production lifetime.
+Automated cost-performance optimization replaces the one-shot guess with a system that **searches the full configuration space, converges fast, and re-optimizes as the world moves**. The modeled first capture is typically in the 20–60% potential cost-reduction range, with the actual number confirmed by pilot. The compounding capture is keeping the agent near the optimum for its entire production lifetime.
 
 The cost of automation is small. The savings are recurring. The math is mechanical.
 

--- a/src/pages/OnePager.jsx
+++ b/src/pages/OnePager.jsx
@@ -234,7 +234,7 @@ function SlideSolution() {
         <div className="grid grid-cols-3 gap-4">
           <SolutionStat value="1 hr" label="One-time setup effort" color={BLUE_LIGHT} />
           <SolutionStat value="up to 8 wks" label="Engineering time reclaimed per pass" color={BLUE_LIGHT} />
-          <SolutionStat value="20%+" label="LLM cost reduction at same accuracy" color={AMBER} />
+          <SolutionStat value="20–60%" label="Potential LLM cost reduction at same accuracy" color={AMBER} />
         </div>
 
         {/* Two audience columns */}
@@ -275,7 +275,7 @@ function SlideSolution() {
               </h3>
             </div>
             <ul className="space-y-2.5">
-              <BenefitItem><span className="text-white font-semibold">20%+ LLM cost reduction</span> at the same accuracy</BenefitItem>
+              <BenefitItem><span className="text-white font-semibold">20–60% potential LLM cost reduction</span> at the same accuracy, confirmed by pilot</BenefitItem>
               <BenefitItem><span className="text-white font-semibold">ROI is almost immediate</span></BenefitItem>
               <BenefitItem>Recurring savings <span className="text-white font-semibold">for the agent's lifetime</span></BenefitItem>
               <BenefitItem>Tier-based pricing <span className="text-white font-semibold">scales with agent volume</span></BenefitItem>

--- a/src/pages/Pricing.jsx
+++ b/src/pages/Pricing.jsx
@@ -558,7 +558,7 @@ export default function Pricing() {
               },
               {
                 q: "What if I outgrow Pro's 10 users?",
-                a: "Talk to sales. Enterprise has unlimited users and a few features Pro doesn't (SSO, audit logs, SLA). Pricing is negotiated.",
+                a: "Talk to sales. Enterprise has custom user limits and a few features Pro doesn't (SSO, audit logs, SLA). Pricing is negotiated against your usage, retention, and deployment requirements.",
               },
               {
                 q: "Do you offer outcome-based pricing?",

--- a/src/pages/ROICalculator.jsx
+++ b/src/pages/ROICalculator.jsx
@@ -151,7 +151,7 @@ export default function ROICalculator() {
       annualEngineerHoursSaved,
       derivedMonthlyHours,
       grossChosen,
-      // Kept for the floor-vs-bonus block which still anchors on the typical 45%.
+      // Kept for older references; typical now follows the published 40% midpoint.
       grossTypical: llm.typical + engineering,
       traigentAnnual,
       netChosen,
@@ -613,14 +613,14 @@ export default function ROICalculator() {
             </p>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <Stat
-                label="Conservative · 30% [1]"
+                label="Conservative · 20% [1]"
                 value={formatUSD(results.llm.conservative)}
                 sublabel="matches prompt-compression studies"
                 icon={TrendingDown}
                 accent="#94a3b8"
               />
               <Stat
-                label="Typical · 45% [2]"
+                label="Typical · 40% [2]"
                 value={formatUSD(results.llm.typical)}
                 sublabel="in line with model-routing results"
                 icon={TrendingDown}


### PR DESCRIPTION
## Summary
- align ROI labels with the actual 20/40/60 calculator assumptions
- standardize public savings copy around 20-60% potential reduction with pilot validation
- keep Enterprise pricing language custom-scoped instead of unlimited-user phrasing

## Verification
- node node_modules/vite/bin/vite.js build ✅
- git diff --check ✅
- pricing drift scan for old 30-60/45/unlimited wording ✅ (only matched a SHA string)

## Caveat
- npm run lint is blocked by the repo's existing missing ESLint config; no ESLint config file exists in this repo, so ESLint exits before linting source.

Fixes #17