### PR TITLE
Remove BIRD replay table from homepage hero

### DIFF
--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -14,12 +14,10 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 import versionInfo from "../version.json";
 import { Helmet } from "react-helmet-async";
-import OptimizationTable from "../components/OptimizationTable";
 import StartNowModal from "../components/StartNowModal";
 import ContactSection from "../components/ContactSection";
 import BlogHighlights from "../components/BlogHighlights";
 import { trackEvent } from "../lib/analytics";
-import { birdDemo, replayColumns } from "../data/demoArtifacts/replays";
 
 // Placeholder for the Button component
 const Button = ({ children, className, onClick, size }) => (
@@ -265,22 +263,6 @@ export default function Homepage() {
                 </ul>
               </div>
             </motion.div>
-
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: 0.24 }}
-              className="mt-8 mb-8"
-            >
-              <OptimizationTable
-                dataset={birdDemo.dataset}
-                columns={replayColumns(birdDemo.dataset)}
-                demoLabel={birdDemo.label}
-                autoPlay={true}
-                embedded={true}
-              />
-            </motion.div>
-
 
             {/* Design Partners & Early Adopters */}
             <motion.div


### PR DESCRIPTION
## Summary
- Removes the `<OptimizationTable dataset={birdDemo.dataset} ... />` block that was rendering on the homepage between the hero copy and the Customers strip (added in #107).
- Also removes the now-unused `OptimizationTable` and `{ birdDemo, replayColumns }` imports.
- The full 3-benchmark replay gallery (BIRD/Spider/HotpotQA) at `/#/demos` is preserved, as is the `OptimizationTable` component itself.

## Why
Amir flagged the BIRD section as off-message on the main page. Preservation requested via the gallery, not the hero.

## Test plan
- [ ] Visit `/` — no BIRD/Isolation/Search/Held-out table between hero and Customers.
- [ ] Visit `/#/demos` — gallery still works (BIRD + Spider + HotpotQA replays render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)