### PR TITLE
feat(decks): per-recipient packages + investor-pitch polish + lead slide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,11 @@ VITE_HUBSPOT_ACADEMY_FORM_ID=
 # (NOT the dashboard URL — the SDK derives the assets CDN from this host).
 VITE_POSTHOG_KEY=
 VITE_POSTHOG_HOST=
+
+# Per-recipient pitch-package registry. Single JSON blob (compact, no newlines)
+# that powers the /vc/:slug, /channel/:slug, /customer/:slug routes and the
+# admin nav's second ▸ menu. Source repo intentionally contains no recipient
+# names — set this in GitHub Actions Variables for prod and in `.env.local`
+# for local dev. Schema and full doc: src/lib/recipientPackages.js
+# Leave unset to render the bland page for every recipient URL.
+VITE_RECIPIENT_PACKAGES_JSON=

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -46,6 +46,12 @@ jobs:
           VITE_POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST }}
           VITE_GA4_ID: ${{ vars.VITE_GA4_ID }}
           VITE_CLARITY_ID: ${{ vars.VITE_CLARITY_ID }}
+          # Per-recipient pitch-package registry. JSON blob baked into the
+          # bundle at build time (visible in the deployed JS, like every
+          # other VITE_* above). Kept in Actions Variables — not Secrets —
+          # because there's no server-side benefit to masking a value that
+          # ships to every visitor's browser. Schema: src/lib/recipientPackages.js
+          VITE_RECIPIENT_PACKAGES_JSON: ${{ vars.VITE_RECIPIENT_PACKAGES_JSON }}
         run: npm run build
 
       - name: Deploy

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,13 @@ venv.bak/
 # Workspace-specific GitHub CLI config
 .gh/
 .envrc
+
+# Local override for recipient-package registry. The file holds real recipient
+# names / slugs / cover copy for local dev; the public repo never sees it.
+# Prod uses VITE_RECIPIENT_PACKAGES_JSON via GitHub Actions Variables instead.
+src/lib/recipientPackages.local.js
+
+# Per-recipient logo assets (Bosch, etc.). The folder is tracked via .gitkeep
+# so the path exists, but its contents stay out of the public repo.
+public/recipient-assets/*
+!public/recipient-assets/.gitkeep

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,8 @@ import KnobExplorer from './pages/KnobExplorer'
 import OptimizationDemo from './pages/OptimizationDemo'
 import StoryMovie from './pages/StoryMovie'
 import DemoGallery from './pages/DemoGallery'
+import RecipientPackagePage from './pages/RecipientPackagePage'
+import RecipientPackageBlankPage from './pages/RecipientPackageBlankPage'
 import Layout from './layout'
 import ExternalRedirect from './components/ExternalRedirect'
 import CookieConsent from './components/CookieConsent'
@@ -49,6 +51,15 @@ export default function App() {
       <Route path="short-summary" element={<PitchShort2 forcedPreset="short-summary" />} />
       <Route path="market-opportunity" element={<PitchShort2 forcedPreset="market-opportunity" />} />
       <Route path="investor-pitch" element={<PitchShort2 forcedPreset="investor-pitch" />} />
+      {/* Per-recipient package routes. The `/:type` (no slug) routes render a
+          bland page so URL-guessers learn nothing about other recipients;
+          `/:type/:slug` resolves the slug via the env-driven registry. */}
+      <Route path="vc" element={<RecipientPackageBlankPage />} />
+      <Route path="vc/:slug" element={<RecipientPackagePage type="vc" />} />
+      <Route path="channel" element={<RecipientPackageBlankPage />} />
+      <Route path="channel/:slug" element={<RecipientPackagePage type="channel" />} />
+      <Route path="customer" element={<RecipientPackageBlankPage />} />
+      <Route path="customer/:slug" element={<RecipientPackagePage type="customer" />} />
       <Route path="knob-explorer" element={<KnobExplorer />} />
       <Route path="demo" element={<OptimizationDemo />} />
       <Route path="story" element={<StoryMovie />} />

--- a/src/components/OptimizationTable.css
+++ b/src/components/OptimizationTable.css
@@ -70,7 +70,14 @@
 }
 
 .opt-embedded .controls {
-  margin-top: 16px;
+  /* Lift the Replay button off the bottom of the table so it isn't
+     clipped by the slide canvas's overflow-hidden wrapper. Absolute
+     positioned inside .opt-container (which is position:relative). */
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  margin-top: 0;
+  z-index: 10;
 }
 
 /* Fullscreen button */
@@ -95,6 +102,34 @@
 }
 
 .fullscreen-btn:hover {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  transform: scale(1.05);
+}
+
+/* Play/Pause button — same shape as the fullscreen button, sits to its left */
+.play-pause-btn {
+  position: absolute;
+  top: 12px;
+  right: 56px;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  font-size: 1.1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  z-index: 10;
+  opacity: 0.6;
+}
+
+.play-pause-btn:hover {
   opacity: 1;
   background: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);

--- a/src/components/OptimizationTable.jsx
+++ b/src/components/OptimizationTable.jsx
@@ -182,11 +182,37 @@ function LegacyOptimizationTable({ autoPlay = true, embedded = false }) {
     )
   );
 
+  // Always-visible transport button (embedded mode only). Sits to the left
+  // of the Fullscreen button and morphs based on state:
+  //   - at SUMMARY frame  -> ↻ Replay  (restarts animation)
+  //   - while playing     -> ⏸ Pause   (calls togglePause)
+  //   - while paused      -> ▶ Play    (calls togglePause)
+  const TransportButton = () => {
+    if (!embedded) return null;
+    const atSummary = frame === FRAMES.SUMMARY;
+    const icon = atSummary ? '↻' : isPlaying ? '⏸' : '▶';
+    const title = atSummary ? 'Replay' : isPlaying ? 'Pause' : 'Play';
+    return (
+      <button
+        className="play-pause-btn"
+        onClick={(e) => {
+          e.stopPropagation();
+          if (atSummary) restart();
+          else togglePause();
+        }}
+        title={title}
+        aria-label={title}
+      >
+        {icon}
+      </button>
+    );
+  };
+
   // Frame 0: Intro - "Most people guess..."
   if (frame === FRAMES.INTRO) {
     return (
       <div ref={containerRef} className={containerClass} onClick={togglePause}>
-        <FullscreenButton />
+        <FullscreenButton /><TransportButton />
         <PauseIndicator />
         <div className="opt-headline">
           <span className="headline-main">Most people guess their</span>
@@ -223,7 +249,7 @@ function LegacyOptimizationTable({ autoPlay = true, embedded = false }) {
   if (frame === FRAMES.STRUGGLE) {
     return (
       <div ref={containerRef} className={containerClass} onClick={togglePause}>
-        <FullscreenButton />
+        <FullscreenButton /><TransportButton />
         <PauseIndicator />
         <div className="opt-headline">
           <span className="headline-main">Then struggle with</span>
@@ -266,7 +292,7 @@ function LegacyOptimizationTable({ autoPlay = true, embedded = false }) {
   if (frame === FRAMES.TABLE_OVERVIEW) {
     return (
       <div ref={containerRef} className={containerClass} onClick={togglePause}>
-        <FullscreenButton />
+        <FullscreenButton /><TransportButton />
         <PauseIndicator />
         <div className="opt-headline">
           <span className="headline-main">There are too many configurations</span>
@@ -315,7 +341,7 @@ function LegacyOptimizationTable({ autoPlay = true, embedded = false }) {
 
     return (
       <div ref={containerRef} className={summaryContainerClass}>
-        <FullscreenButton />
+        <FullscreenButton /><TransportButton />
         <div className="opt-headline">
           <span className="headline-main">Improves AI agent's accuracy, response time, cost,</span>
           <span className="headline-main">or any important business KPI.</span>
@@ -383,7 +409,7 @@ function LegacyOptimizationTable({ autoPlay = true, embedded = false }) {
 
   return (
     <div ref={containerRef} className={containerClass} onClick={togglePause}>
-      <FullscreenButton />
+      <FullscreenButton /><TransportButton />
       <PauseIndicator />
       {/* Animation status message */}
       {frameData && (

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -5,6 +5,7 @@ import StartNowModal from "./StartNowModal";
 import PortalGateModal from "./PortalGateModal";
 import BrandMark from "./BrandMark";
 import { trackEvent } from "../lib/analytics";
+import { listAllForAdmin } from "../lib/recipientPackages";
 import {
   isUnlocked,
   markUnlocked,
@@ -241,6 +242,9 @@ export default function TopNav() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [pitchMenuOpen, setPitchMenuOpen] = useState(false);
   const pitchMenuRef = useRef(null);
+  const [recipientMenuOpen, setRecipientMenuOpen] = useState(false);
+  const recipientMenuRef = useRef(null);
+  const recipientSections = listAllForAdmin();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -262,6 +266,25 @@ export default function TopNav() {
       document.removeEventListener("keydown", onKey);
     };
   }, [pitchMenuOpen]);
+
+  // Same outside-click + Escape behavior for the recipient-packages menu.
+  useEffect(() => {
+    if (!recipientMenuOpen) return;
+    const onDocClick = (e) => {
+      if (recipientMenuRef.current && !recipientMenuRef.current.contains(e.target)) {
+        setRecipientMenuOpen(false);
+      }
+    };
+    const onKey = (e) => {
+      if (e.key === "Escape") setRecipientMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [recipientMenuOpen]);
 
   // Click handler for in-page anchor scrolling.
   // If we're on the homepage, scrollIntoView directly.
@@ -400,44 +423,114 @@ export default function TopNav() {
                   trigger; right-click toggles a small dropdown of decks, each
                   opening in a new tab. Left-click is intentionally a no-op
                   so the surface stays obscure. */}
-              <div className="relative" ref={pitchMenuRef}>
-                <button
-                  type="button"
-                  onClick={(e) => e.preventDefault()}
-                  onContextMenu={(e) => {
-                    e.preventDefault();
-                    setPitchMenuOpen((v) => !v);
-                  }}
-                  aria-label="Presentations menu"
-                  aria-haspopup="menu"
-                  aria-expanded={pitchMenuOpen}
-                  title="Presentations"
-                  className="text-slate-700 hover:text-slate-200 transition-colors text-base leading-none select-none px-1"
-                >
-                  ▸
-                </button>
-                {pitchMenuOpen && (
-                  <div
-                    role="menu"
-                    aria-label="Presentations"
-                    className="absolute top-full right-0 mt-2 w-72 bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-2 z-[60]"
+              <div className="flex flex-col items-center gap-0 leading-none">
+                <div className="relative" ref={pitchMenuRef}>
+                  <button
+                    type="button"
+                    onClick={(e) => e.preventDefault()}
+                    onContextMenu={(e) => {
+                      e.preventDefault();
+                      setPitchMenuOpen((v) => !v);
+                    }}
+                    aria-label="Presentations menu"
+                    aria-haspopup="menu"
+                    aria-expanded={pitchMenuOpen}
+                    title="Presentations"
+                    className="text-slate-700 hover:text-slate-200 transition-colors text-base leading-none select-none px-1"
                   >
-                    {PITCH_DECK_OPTIONS.map((item) => (
-                      <a
-                        key={item.href}
-                        href={item.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        role="menuitem"
-                        onClick={() => setPitchMenuOpen(false)}
-                        className="block px-3 py-2 rounded-lg hover:bg-slate-800 transition-colors"
-                      >
-                        <div className="text-sm text-white font-medium">{item.label}</div>
-                        <div className="text-xs text-slate-400 mt-0.5">{item.desc}</div>
-                      </a>
-                    ))}
-                  </div>
-                )}
+                    ▸
+                  </button>
+                  {pitchMenuOpen && (
+                    <div
+                      role="menu"
+                      aria-label="Presentations"
+                      className="absolute top-full right-0 mt-2 w-72 bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-2 z-[60]"
+                    >
+                      {PITCH_DECK_OPTIONS.map((item) => (
+                        <a
+                          key={item.href}
+                          href={item.href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          role="menuitem"
+                          onClick={() => setPitchMenuOpen(false)}
+                          className="block px-3 py-2 rounded-lg hover:bg-slate-800 transition-colors"
+                        >
+                          <div className="text-sm text-white font-medium">{item.label}</div>
+                          <div className="text-xs text-slate-400 mt-0.5">{item.desc}</div>
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                {/* Second triangle, directly below the first — recipient
+                    packages (VC / Channel / Customer). Same right-click
+                    gesture, same obscure styling. The dropdown only renders
+                    sections that have at least one package in the registry,
+                    so empty sections never advertise their existence. */}
+                <div className="relative" ref={recipientMenuRef}>
+                  <button
+                    type="button"
+                    onClick={(e) => e.preventDefault()}
+                    onContextMenu={(e) => {
+                      e.preventDefault();
+                      setRecipientMenuOpen((v) => !v);
+                    }}
+                    aria-label="Recipient packages menu"
+                    aria-haspopup="menu"
+                    aria-expanded={recipientMenuOpen}
+                    title="Recipient packages"
+                    className="text-slate-700 hover:text-slate-200 transition-colors text-base leading-none select-none px-1"
+                  >
+                    ▸
+                  </button>
+                  {recipientMenuOpen && (
+                    <div
+                      role="menu"
+                      aria-label="Recipient packages"
+                      className="absolute top-full right-0 mt-2 w-80 bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-2 z-[60]"
+                    >
+                      {recipientSections.map((section) => (
+                        <div key={section.type} className="mb-2 last:mb-0">
+                          <div className="px-3 pt-2 pb-1 text-[10px] font-mono uppercase tracking-widest text-slate-500">
+                            {section.label}
+                          </div>
+                          {section.items.length === 0 ? (
+                            <div className="px-3 py-2 text-xs text-slate-600 italic">
+                              No packages yet.
+                            </div>
+                          ) : (
+                            section.items.map((item) => (
+                              <a
+                                key={item.slug}
+                                href={`/#/${section.type}/${item.slug}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                role="menuitem"
+                                onClick={() => setRecipientMenuOpen(false)}
+                                className="block px-3 py-2 rounded-lg hover:bg-slate-800 transition-colors"
+                              >
+                                <div className="text-sm text-white font-medium">
+                                  {item.displayName || item.slug}
+                                </div>
+                                <div className="text-xs text-slate-400 mt-0.5 flex justify-between gap-2">
+                                  <span className="truncate">
+                                    {item.internalLabel || `/${section.type}/${item.slug}`}
+                                  </span>
+                                  {item.dateSent && (
+                                    <span className="font-mono text-slate-500 shrink-0">
+                                      {item.dateSent}
+                                    </span>
+                                  )}
+                                </div>
+                              </a>
+                            ))
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
 

--- a/src/lib/recipientPackages.js
+++ b/src/lib/recipientPackages.js
@@ -1,0 +1,118 @@
+// Recipient-package registry — env-driven so this public repo stays clean.
+//
+// Source of truth: `VITE_RECIPIENT_PACKAGES_JSON` env var, set in GitHub
+// Actions Variables (`gh variable set VITE_RECIPIENT_PACKAGES_JSON …`) for
+// prod and in `.env.local` for local dev. Schema:
+//
+//   {
+//     "vc"      : { "<opaque-slug>": <Package>, ... },
+//     "channel" : { "<opaque-slug>": <Package>, ... },
+//     "customer": { "<opaque-slug>": <Package>, ... }
+//   }
+//
+// Package shape:
+//   {
+//     displayName:   "Bosch Ventures",         // shown in the admin nav
+//     internalLabel: "Bosch corp-discovery",   // Amir-facing label, optional
+//     dateSent:      "2026-06-09",             // ISO yyyy-mm-dd, optional
+//     presetRange:   "24-29",                  // SHORT_SLIDES range to render
+//     cover: {                                 // first slide of the package
+//       kicker:   "For Bosch Ventures",
+//       headline: "...",
+//       subhead:  "...",
+//       bullets:  ["...", "..."],
+//       footerNote: "Sent privately ..."
+//     }
+//   }
+//
+// Privacy posture (public repo):
+//   - No recipient names or slugs live in source. They live in the env var.
+//   - The prod JS bundle still contains every registered package as strings
+//     (visible in devtools). Opaque slugs + no inter-package links are what
+//     keep this useful: a recipient cannot navigate to other recipients'
+//     packages and there is no listing page that enumerates them.
+//   - `/vc`, `/channel`, `/customer` (no slug) render a bland page.
+
+const VALID_TYPES = ["vc", "channel", "customer"];
+
+// Local override for dev: a gitignored file at the same directory can export
+// `packages` and it takes precedence over the env var. This avoids the
+// dotenv quoting / escaping pitfalls when iterating locally. import.meta.glob
+// resolves at build time and returns `{}` if the file doesn't exist, so prod
+// builds (which use the env var instead) still work fine.
+const LOCAL_OVERRIDES = (() => {
+  try {
+    const matches = import.meta.glob("./recipientPackages.local.js", { eager: true });
+    const mod = Object.values(matches)[0];
+    return mod?.packages || null;
+  } catch {
+    return null;
+  }
+})();
+
+function parseRegistry(raw) {
+  if (!raw) {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.info(
+        "[recipientPackages] VITE_RECIPIENT_PACKAGES_JSON is not set; admin nav will show 'No recipient packages registered.'",
+      );
+    }
+    return { vc: {}, channel: {}, customer: {} };
+  }
+  try {
+    const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const out = { vc: {}, channel: {}, customer: {} };
+    for (const type of VALID_TYPES) {
+      const bucket = parsed?.[type];
+      if (bucket && typeof bucket === "object") {
+        for (const [slug, pkg] of Object.entries(bucket)) {
+          if (pkg && typeof pkg === "object" && typeof pkg.presetRange === "string") {
+            out[type][slug] = pkg;
+          }
+        }
+      }
+    }
+    return out;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[recipientPackages] VITE_RECIPIENT_PACKAGES_JSON failed to parse — falling back to empty registry. Raw value start:",
+      typeof raw === "string" ? raw.slice(0, 80) : raw,
+      err,
+    );
+    return { vc: {}, channel: {}, customer: {} };
+  }
+}
+
+// Local override wins over env var when both are present (handy for local
+// iteration without touching GitHub Actions Variables).
+const REGISTRY = LOCAL_OVERRIDES
+  ? parseRegistry(LOCAL_OVERRIDES)
+  : parseRegistry(import.meta.env.VITE_RECIPIENT_PACKAGES_JSON);
+
+export function isValidType(type) {
+  return VALID_TYPES.includes(type);
+}
+
+export function getPackage(type, slug) {
+  if (!isValidType(type) || !slug) return null;
+  return REGISTRY[type]?.[slug] || null;
+}
+
+// For the admin nav: returns all three sections in render order, each with
+// its packages sorted by dateSent (newest first; missing dates sink). Empty
+// sections are returned with an empty `items` array — the nav renders the
+// header anyway so VC / Channel / Customer scaffold is always visible.
+export function listAllForAdmin() {
+  const sectionLabels = { vc: "VC", channel: "Channel", customer: "Customer" };
+  return VALID_TYPES.map((type) => ({
+    type,
+    label: sectionLabels[type],
+    items: Object.entries(REGISTRY[type] || {})
+      .map(([slug, pkg]) => ({ slug, ...pkg }))
+      .sort((a, b) => (b.dateSent || "").localeCompare(a.dateSent || "")),
+  }));
+}
+
+export const TYPE_LABELS = { vc: "VC", channel: "Channel", customer: "Customer" };

--- a/src/pages/PitchShort.jsx
+++ b/src/pages/PitchShort.jsx
@@ -4,13 +4,19 @@
 // rendered through PitchFull's originals with override props for the
 // subtitle / footer; everything else is imported directly. No structural
 // JSX is duplicated from PitchFull.
+import { useState } from "react";
+import { Link } from "react-router-dom";
 import { ArrowRight, ArrowDown, ArrowUp, ChevronsDown, DollarSign, Check, Clock, ShieldCheck, TrendingDown, TrendingUp, X } from "lucide-react";
+import StartNowModal from "../components/StartNowModal";
 
-// Shared optimizer ring — clockwise Learn → Deduce → Test → Repeat loop.
-// Used by slide 1, slide 2 (BEFORE/TRAIGENT/AFTER middle panel), and slide 24
-// (Market Opportunity THE PLAY). Gradient id is parameterized so multiple
-// instances on the same page don't collide.
-function OptimizerRing({ size = 190, gradientId = "ringGrad" }) {
+// Shared optimizer ring — clockwise Learn → Deduce → <thirdLabel> → Repeat
+// loop. Used by slide 1, slide 2 (BEFORE/TRAIGENT/AFTER middle panel — also
+// rendered on the homepage hero), and slide 24 (Market Opportunity THE
+// CURE). `thirdLabel` defaults to "TEST" so the homepage stays unchanged;
+// the /investor-pitch slide 1 passes "EVALUATE" explicitly.
+// Gradient id is parameterized so multiple instances on the same page
+// don't collide.
+function OptimizerRing({ size = 190, gradientId = "ringGrad", thirdLabel = "TEST" }) {
   return (
     <svg viewBox="0 0 240 240" className="flex-shrink-0" style={{ width: size, height: size }} xmlns="http://www.w3.org/2000/svg">
       <defs>
@@ -31,7 +37,7 @@ function OptimizerRing({ size = 190, gradientId = "ringGrad" }) {
       <circle cx="120" cy="120" r="58" fill="#020617" stroke="#334155" strokeWidth="1"/>
       <text x="120" y="101" textAnchor="middle" fill="#cbd5e1" fontSize="13" fontFamily="ui-sans-serif, system-ui" fontWeight="700">LEARN</text>
       <text x="120" y="119" textAnchor="middle" fill="#cbd5e1" fontSize="13" fontFamily="ui-sans-serif, system-ui" fontWeight="700">DEDUCE</text>
-      <text x="120" y="137" textAnchor="middle" fill="#cbd5e1" fontSize="13" fontFamily="ui-sans-serif, system-ui" fontWeight="700">TEST</text>
+      <text x="120" y="137" textAnchor="middle" fill="#cbd5e1" fontSize="13" fontFamily="ui-sans-serif, system-ui" fontWeight="700">{thirdLabel}</text>
       <text x="120" y="155" textAnchor="middle" fill="#cbd5e1" fontSize="13" fontFamily="ui-sans-serif, system-ui" fontWeight="700">REPEAT</text>
     </svg>
   );
@@ -466,13 +472,149 @@ function SlideSweepThePack() {
 // Top section: 3 stat tiles (TAM today, addressable LLM bill 2026, 2030).
 // Middle section: penetration → revenue cascade table.
 // Bottom: comparable-ramp sanity check.
+// Slide: dual-CTA closer for /investor-pitch — Start Now (opens the full
+// HubSpot-gated SDK install modal) + Book a demo (HubSpot meeting link).
+// Uses the same StartNowModal mounting pattern as TopNav and StoryMovie.
+function SlideInvestorCTA() {
+  const [showStartNow, setShowStartNow] = useState(false);
+  const bookingHref = "https://meetings-eu1.hubspot.com/amir8";
+  return (
+    <>
+      <div className="w-full max-w-[1080px] mx-auto self-stretch flex flex-col items-center justify-center min-h-[600px] text-center">
+        <div className="text-xs md:text-sm font-mono uppercase tracking-[0.3em] text-slate-500 mb-6">
+          Pick your path
+        </div>
+        <h2 className="text-4xl md:text-6xl font-bold text-white leading-tight tracking-tight mb-4">
+          Try it. Or talk to us.
+        </h2>
+        <p className="text-lg md:text-xl text-slate-300 max-w-2xl leading-snug mb-12">
+          Both paths land in the same place &mdash; you running Traigent on a
+          real agent of yours.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-3xl mb-6">
+          {/* Option 1 — Start Now (opens the gated modal) */}
+          <div
+            className="bg-slate-900/60 border-2 rounded-2xl p-7 text-left flex flex-col"
+            style={{ borderColor: "#4D8EF8" }}
+          >
+            <div className="text-xs font-mono uppercase tracking-widest mb-3" style={{ color: "#4D8EF8" }}>
+              Option 1 &mdash; Free
+            </div>
+            <h3 className="text-2xl font-bold text-white mb-2">Start Now</h3>
+            <p className="text-slate-300 text-base mb-6 leading-snug">
+              Keyless demo on your laptop in <span className="font-semibold text-white">under a minute</span>. No
+              API keys, no spend, no setup call.
+            </p>
+            <button
+              type="button"
+              onClick={() => setShowStartNow(true)}
+              className="mt-auto inline-flex items-center justify-center gap-2 px-6 py-3.5 rounded-xl text-lg font-bold text-white shadow-xl transition-transform hover:scale-105 active:scale-100"
+              style={{
+                background: "linear-gradient(135deg, #4D8EF8 0%, #1A6BF5 100%)",
+                boxShadow: "0 10px 30px rgba(77, 142, 248, 0.30)",
+              }}
+            >
+              <span className="text-xl leading-none">&#9654;</span>
+              Start Now &mdash; Free
+            </button>
+          </div>
+
+          {/* Option 2 — Book a demo */}
+          <div
+            className="bg-slate-900/60 border-2 rounded-2xl p-7 text-left flex flex-col"
+            style={{ borderColor: "#f59e0b" }}
+          >
+            <div className="text-xs font-mono uppercase tracking-widest mb-3" style={{ color: "#f59e0b" }}>
+              Option 2 &mdash; 15 min
+            </div>
+            <h3 className="text-2xl font-bold text-white mb-2">Book a demo</h3>
+            <p className="text-slate-300 text-base mb-6 leading-snug">
+              We pick one of your agents, run the optimizer live, walk you
+              through the trial table and the convergence.
+            </p>
+            <a
+              href={bookingHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-auto inline-flex items-center justify-center gap-2 px-6 py-3.5 rounded-xl text-lg font-bold text-white shadow-xl transition-transform hover:scale-105 active:scale-100"
+              style={{
+                background: "linear-gradient(135deg, #f59e0b 0%, #d97706 100%)",
+                boxShadow: "0 10px 30px rgba(245, 158, 11, 0.30)",
+              }}
+            >
+              <span className="text-xl leading-none">&#128197;</span>
+              Book a 15-min call
+            </a>
+          </div>
+        </div>
+
+        <div className="text-sm text-slate-400">
+          <span className="font-mono text-slate-300">amir@traigent.ai</span> &middot;{" "}
+          <span className="font-mono text-slate-300">nimrod@traigent.ai</span>
+        </div>
+      </div>
+      {showStartNow && (
+        <StartNowModal
+          onClose={() => setShowStartNow(false)}
+          location="investor_pitch_cta"
+        />
+      )}
+    </>
+  );
+}
+
+// Slide: CTA pointing to /story — the 1-minute narrated agent-optimization
+// arc. Lives near the end of the investor-pitch range so the audience leaves
+// the deck on a "go watch the story" beat. Opens in a new tab so the deck
+// stays where it was.
+function SlideStoryCTA() {
+  return (
+    <div className="w-full max-w-[1080px] mx-auto self-stretch flex flex-col items-center justify-center min-h-[600px] text-center">
+      <div className="text-xs md:text-sm font-mono uppercase tracking-[0.3em] text-slate-500 mb-6">
+        The 1-minute story
+      </div>
+      <h2 className="text-4xl md:text-6xl font-bold text-white leading-tight tracking-tight mb-4">
+        Problem &rarr;{" "}
+        <span style={{ color: "#4D8EF8" }}>Optimizer</span>
+        {" "}&rarr;{" "}
+        <span style={{ color: "#4ade80" }}>The win</span>
+      </h2>
+      <p className="text-lg md:text-xl text-slate-300 max-w-2xl leading-snug mb-12">
+        Narrated walkthrough &mdash; the 25-knob configuration problem, the
+        Traigent loop, and the converged result, all under a minute.
+      </p>
+      <a
+        href="/#/story"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-3 px-9 py-4 rounded-xl text-xl md:text-2xl font-bold text-white shadow-2xl transition-transform hover:scale-105 active:scale-100"
+        style={{
+          background: "linear-gradient(135deg, #4D8EF8 0%, #1A6BF5 100%)",
+          boxShadow: "0 10px 40px rgba(77, 142, 248, 0.35)",
+        }}
+      >
+        <span className="text-2xl md:text-3xl leading-none">&#9654;</span>
+        Watch the 1-minute story
+      </a>
+      <div className="mt-8 text-sm text-slate-400">
+        opens at <span className="font-mono text-slate-300">traigent.ai/#/story</span> in a new tab
+      </div>
+    </div>
+  );
+}
+
 function SlideMarketAndRevenue() {
+  // Customer savings split per Assumption #3:
+  //   Eng saved  = penetrated bill × $0.30   (foundation, accuracy phase, day-1)
+  //   LLM saved  = penetrated bill × $0.50   (scale, cost phase, later)
+  //   ARR        = (eng + LLM) × 5% take rate
   const rows = [
-    { year: "2026", phase: "POCs",          bill: "$21B",  pen: "0.03%", save: "$5M",   rev: "~$0.25M" },
-    { year: "2027", phase: "Early adopt",   bill: "$36B",  pen: "0.3%",  save: "$86M",  rev: "~$4M" },
-    { year: "2028", phase: "Channel + ent", bill: "$56B",  pen: "1.5%",  save: "$672M", rev: "~$34M" },
-    { year: "2029", phase: "Mainstream",    bill: "$86B",  pen: "4%",    save: "$2.8B", rev: "~$138M" },
-    { year: "2030", phase: "Category",      bill: "$128B", pen: "8%",    save: "$8.2B", rev: "~$410M" },
+    { year: "2026", phase: "POCs",          bill: "$21B",  pen: "0.03%", engSave: "$1.9M", llmSave: "$3.2M", rev: "~$0.25M" },
+    { year: "2027", phase: "Early adopt",   bill: "$36B",  pen: "0.3%",  engSave: "$32M",  llmSave: "$54M",  rev: "~$4M" },
+    { year: "2028", phase: "Channel + ent", bill: "$56B",  pen: "1.5%",  engSave: "$252M", llmSave: "$420M", rev: "~$34M" },
+    { year: "2029", phase: "Mainstream",    bill: "$86B",  pen: "4%",    engSave: "$1.0B", llmSave: "$1.7B", rev: "~$138M" },
+    { year: "2030", phase: "Category",      bill: "$128B", pen: "8%",    engSave: "$3.1B", llmSave: "$5.1B", rev: "~$410M" },
   ];
   return (
     <div className="w-full max-w-[1180px] mx-auto text-center self-stretch flex flex-col min-h-[600px]">
@@ -482,7 +624,7 @@ function SlideMarketAndRevenue() {
           Market &amp; Revenue &mdash; <span style={{ color: "#4D8EF8" }}>Non-Vendor Agents</span>
         </h2>
         <p className="text-sm md:text-base text-slate-300 leading-snug">
-          Revenue grounded in <span className="font-bold text-[#4ade80]">5% of customer savings actually delivered</span> &mdash; not a TAM percentage. Customer keeps ~95&cent; of every saved dollar.
+          Revenue grounded in <span className="font-bold text-[#4ade80]">5% of customer savings actually delivered</span> &mdash; not a TAM percentage. <span className="font-bold text-[#4D8EF8]">Engineering savings unlock adoption first</span>; <span className="font-bold text-[#f59e0b]">LLM cost savings drive expansion</span> as production bills grow.
         </p>
       </div>
 
@@ -492,7 +634,13 @@ function SlideMarketAndRevenue() {
         <ol className="text-[12.5px] text-slate-300 leading-snug space-y-1 list-decimal pl-5">
           <li><span className="font-bold text-white">Customers:</span> non-vendor agent companies + enterprise teams on third-party LLM APIs. Excludes foundation-model-vendor agents.</li>
           <li><span className="font-bold text-white">Cost structure:</span> every $1 of customer LLM bill is matched by ~$0.50 of engineering on tuning (6–10 FTE on a $3–5M LLM bill).</li>
-          <li><span className="font-bold text-white">Savings Traigent delivers</span> per $1 of LLM bill: <span className="text-[#f59e0b] font-semibold">50% LLM</span> + <span className="text-[#4D8EF8] font-semibold">60% eng</span> = <span className="text-white font-bold">$0.80 total customer savings</span>.</li>
+          <li><span className="font-bold text-white">Savings Traigent delivers</span> per $1 of LLM bill, <span className="italic">sequenced over the SDLC</span>:
+            <ul className="list-disc pl-5 mt-0.5 space-y-0.5">
+              <li><span className="text-[#4D8EF8] font-semibold">Foundation</span> (accuracy phase, day-1): <span className="text-[#4D8EF8] font-semibold">60% eng saved</span> = <span className="text-white font-bold">$0.30</span> &mdash; adopted before the LLM bill is large enough to optimize.</li>
+              <li><span className="text-[#f59e0b] font-semibold">Scale</span> (cost phase, later): <span className="text-[#f59e0b] font-semibold">50% LLM saved</span> = <span className="text-white font-bold">$0.50</span>.</li>
+              <li>Total: <span className="text-white font-bold">$0.80 customer savings</span>.</li>
+            </ul>
+          </li>
           <li><span className="font-bold text-white">Take rate:</span> <span className="text-[#4ade80] font-bold">5%</span> of total savings &mdash; effective <span className="text-white font-bold">$0.04 of ARR per $1 of penetrated customer LLM bill</span>.</li>
           <li><span className="font-bold text-white">Penetration:</span> share of the non-vendor LLM bill reached by Traigent customers. Revenue is calculated on savings achieved <em>within penetrated markets only</em>.</li>
         </ol>
@@ -510,7 +658,8 @@ function SlideMarketAndRevenue() {
               <th className="py-1.5">Phase</th>
               <th className="py-1.5 text-right">Addressable bill</th>
               <th className="py-1.5 text-right">Penetration</th>
-              <th className="py-1.5 text-right">Total customer savings</th>
+              <th className="py-1.5 text-right" style={{ color: "#4D8EF8" }}>Eng saved</th>
+              <th className="py-1.5 text-right" style={{ color: "#f59e0b" }}>LLM saved</th>
               <th className="py-1.5 text-right">Traigent ARR (5%)</th>
             </tr>
           </thead>
@@ -521,7 +670,8 @@ function SlideMarketAndRevenue() {
                 <td className="py-1.5 text-slate-300">{r.phase}</td>
                 <td className="py-1.5 text-right font-mono text-slate-200">{r.bill}</td>
                 <td className="py-1.5 text-right font-mono text-slate-200">{r.pen}</td>
-                <td className="py-1.5 text-right font-mono text-slate-200">{r.save}</td>
+                <td className="py-1.5 text-right font-mono font-semibold" style={{ color: "#4D8EF8" }}>{r.engSave}</td>
+                <td className="py-1.5 text-right font-mono font-semibold" style={{ color: "#f59e0b" }}>{r.llmSave}</td>
                 <td className="py-1.5 text-right font-mono font-bold" style={{ color: "#4ade80" }}>{r.rev}</td>
               </tr>
             ))}
@@ -557,64 +707,87 @@ function SlideMarketOpportunity() {
         {/* COL 1 — THE WAVE (hockey-stick) */}
         <div className="bg-slate-900/70 border-2 rounded-xl p-5 text-left flex flex-col" style={{ borderColor: "#4D8EF866" }}>
           <div className="text-2xl font-mono font-bold uppercase tracking-widest mb-3 text-center" style={{ color: "#4D8EF8" }}>The Wave</div>
-          <h3 className="text-2xl font-bold text-white leading-tight mb-3">Exponential adoption ahead</h3>
+          <h3 className="text-2xl font-bold text-white leading-tight mb-3">
+            Exponential adoption ahead
+            <span className="block">LLM costs set to explode</span>
+          </h3>
 
           {/* Hockey-stick chart */}
           <svg viewBox="0 0 280 130" className="w-full mb-4 flex-1" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
             <line x1="30" y1="110" x2="270" y2="110" stroke="#475569" strokeWidth="1"/>
-            <line x1="30" y1="20"  x2="30"  y2="110" stroke="#475569" strokeWidth="1"/>
-            <text x="4" y="16" fill="#94a3b8" fontSize="11" fontFamily="ui-sans-serif, system-ui" fontWeight="600">Agent $</text>
-            <text x="50"  y="122" textAnchor="middle" fill="#64748b" fontSize="10" fontFamily="ui-sans-serif, system-ui">2024</text>
-            <text x="110" y="122" textAnchor="middle" fill="#64748b" fontSize="10" fontFamily="ui-sans-serif, system-ui">2025</text>
-            <text x="170" y="122" textAnchor="middle" fill="#64748b" fontSize="10" fontFamily="ui-sans-serif, system-ui">2026</text>
-            <text x="230" y="122" textAnchor="middle" fill="#64748b" fontSize="10" fontFamily="ui-sans-serif, system-ui">2028</text>
-            <line x1="135" y1="20" x2="135" y2="110" stroke="#f59e0b" strokeWidth="1" strokeDasharray="3,2" strokeOpacity="0.7"/>
-            <text x="135" y="34" textAnchor="middle" fill="#f59e0b" fontSize="11" fontFamily="ui-sans-serif, system-ui" fontWeight="700">TODAY</text>
-            <path d="M 30 105 C 70 102, 110 100, 135 95 S 180 75, 210 50 S 255 25, 270 22" stroke="#4D8EF8" strokeWidth="2.5" fill="none"/>
-            <circle cx="50"  cy="104" r="2.5" fill="#475569"/>
-            <circle cx="80"  cy="103" r="2.5" fill="#475569"/>
-            <circle cx="110" cy="101" r="2.5" fill="#475569"/>
-            <circle cx="135" cy="95"  r="4"   fill="#f59e0b"/>
-            <circle cx="180" cy="73"  r="3.5" fill="#4D8EF8"/>
-            <circle cx="230" cy="40"  r="4"   fill="#4D8EF8"/>
-            <circle cx="265" cy="24"  r="4.5" fill="#4D8EF8"/>
+            <line x1="30" y1="14"  x2="30"  y2="110" stroke="#475569" strokeWidth="1"/>
+            {/* Y-axis label — rotated 90° so "Agent LLM costs" fits the narrow gutter. */}
+            <text x="14" y="62" textAnchor="middle" transform="rotate(-90 14 62)" fill="#94a3b8" fontSize="11" fontFamily="ui-sans-serif, system-ui" fontWeight="600">Agent LLM costs</text>
+            {/* X-axis labels — uniform 40px/year so TODAY (mid-2026) lands on the
+                1/3 mark of the plot, leaving 2× the room for the future. */}
+            <text x="40"  y="122" textAnchor="middle" fill="#64748b" fontSize="10" fontFamily="ui-sans-serif, system-ui">2024</text>
+            <text x="110" y="122" textAnchor="middle" fill="#64748b" fontSize="10" fontFamily="ui-sans-serif, system-ui">2026</text>
+            <text x="190" y="122" textAnchor="middle" fill="#64748b" fontSize="10" fontFamily="ui-sans-serif, system-ui">2028</text>
+            <text x="263" y="122" textAnchor="middle" fill="#64748b" fontSize="10" fontFamily="ui-sans-serif, system-ui">2030</text>
+            {/* TODAY marker — mid-2026, sits at the 1/3 mark of the plot. */}
+            <line x1="110" y1="14" x2="110" y2="110" stroke="#f59e0b" strokeWidth="1" strokeDasharray="3,2" strokeOpacity="0.7"/>
+            <text x="110" y="28" textAnchor="middle" fill="#f59e0b" fontSize="11" fontFamily="ui-sans-serif, system-ui" fontWeight="700">TODAY</text>
+            {/* Curve: nearly flat 2024-2026 (left third), inflects at 2026-2027,
+                steep through 2028, plateaus 2028-2030 — classic hockey stick. */}
+            <path d="M 30 108 C 70 107, 95 105, 110 100 C 135 92, 160 75, 180 45 C 205 20, 235 14, 270 13" stroke="#4D8EF8" strokeWidth="2.5" fill="none"/>
+            <circle cx="55"  cy="107" r="2.5" fill="#475569"/>
+            <circle cx="85"  cy="105" r="2.5" fill="#475569"/>
+            <circle cx="110" cy="100" r="4"   fill="#f59e0b"/>
+            <circle cx="150" cy="83"  r="3.5" fill="#4D8EF8"/>
+            <circle cx="185" cy="40"  r="3.5" fill="#4D8EF8"/>
+            <circle cx="225" cy="17"  r="4"   fill="#4D8EF8"/>
+            <circle cx="265" cy="13"  r="4.5" fill="#4D8EF8"/>
           </svg>
 
           <p className="text-lg text-slate-300 leading-snug mt-auto">
-            Few in production today.<br /><span className="font-bold text-white">Massive rollouts 2026–2028.</span>
+            Few in production today.<br /><span className="font-bold text-white">Massive rollouts 2026–2030.</span>
           </p>
         </div>
 
         {/* COL 2 — THE PAIN */}
         <div className="bg-slate-900/70 border-2 rounded-xl p-5 text-left flex flex-col" style={{ borderColor: "#f59e0b66" }}>
           <div className="text-2xl font-mono font-bold uppercase tracking-widest mb-3 text-center" style={{ color: "#f59e0b" }}>The Pain</div>
-          <h3 className="text-2xl font-bold text-white leading-tight mb-4">Sticker shock.<br />Brutal re-tuning cycles.</h3>
-          <ul className="text-lg text-slate-300 leading-snug space-y-4 flex-1 flex flex-col justify-center">
-            <li>
-              <span className="font-bold text-amber-400">Compounding LLM bills</span>
-            </li>
-            <li>
-              <span className="font-bold text-amber-400">Ongoing dev costs</span> every release
-            </li>
-            <li>
-              <span className="font-bold text-[#4D8EF8]">Quality bar keeps rising</span>
-            </li>
-            <li>
-              25+ knob manual re-tune = <span className="font-bold text-red-400">BRUTAL</span>
-            </li>
+          <h3 className="text-2xl font-bold text-white leading-tight mb-6">
+            <span className="text-amber-400">Exponential LLM costs</span><br />
+            Brutal re-tuning cycles
+            <Link
+              to="/knob-explorer"
+              className="block text-base font-medium text-slate-400 hover:text-slate-200 underline underline-offset-4 decoration-slate-500/50 hover:decoration-slate-200 mt-1 transition-colors"
+            >
+              (among thousands of config combos)
+            </Link>
+          </h3>
+          <div className="text-lg leading-snug mb-3">
+            <p className="text-slate-300">
+              Constant re-tuning efforts for cost and accuracy as conditions change:
+            </p>
+          </div>
+          <ul className="text-base text-slate-300 leading-snug space-y-1.5 flex-1 list-disc pl-5">
+            <li>New models drop</li>
+            <li>Prices shift</li>
+            <li>Domain data drifts</li>
+            <li>Latency / SLA tightens</li>
+            <li>New use cases land</li>
+            <li>Failures surface in prod</li>
           </ul>
         </div>
 
-        {/* COL 3 — THE PLAY (Traigent) */}
+        {/* COL 3 — THE CURE (Traigent) */}
         <div className="bg-slate-950 border-2 rounded-xl p-5 text-center flex flex-col" style={{ borderColor: "#4D8EF8" }}>
-          <div className="text-2xl font-mono font-bold uppercase tracking-widest mb-2 text-center" style={{ color: "#4D8EF8" }}>The Play</div>
-          <h3 className="text-2xl font-bold leading-tight mb-2">
-            <span style={{ color: "#4D8EF8" }}>Traigent.ai</span>
+          <div className="text-2xl font-mono font-bold uppercase tracking-widest mb-2 text-center" style={{ color: "#4D8EF8" }}>The Cure</div>
+          <h3 className="text-2xl font-bold leading-tight mb-2 text-white">
+            Automated Optimization
           </h3>
 
-          {/* Optimizer ring */}
-          <div className="flex justify-center mb-2 flex-1 items-center">
-            <OptimizerRing size={170} gradientId="ringGradMarket" />
+          {/* Optimizer ring with Traigent.ai brand to the right */}
+          <div className="flex justify-center mb-2 flex-1 items-center gap-3">
+            <OptimizerRing size={170} gradientId="ringGradMarket" thirdLabel="EVALUATE" />
+            <div
+              className="text-xl font-bold leading-tight tracking-tight whitespace-nowrap"
+              style={{ color: "#4D8EF8" }}
+            >
+              Traigent.ai
+            </div>
           </div>
 
           {/* 3 stacked benefit boxes (matches slide 1, with arrows) */}
@@ -638,7 +811,7 @@ function SlideMarketOpportunity() {
                 <ArrowUp className="w-6 h-6" strokeWidth={3} />
                 <span className="text-2xl font-extrabold tracking-tight leading-none">100%</span>
               </div>
-              <div className="text-xs font-mono uppercase tracking-wider text-slate-300 mt-1">shipment confidence</div>
+              <div className="text-xs font-mono uppercase tracking-wider text-slate-300 mt-1">confidence in what you ship</div>
             </div>
           </div>
         </div>
@@ -843,6 +1016,10 @@ export const SHORT_SLIDES = [
   { title: "Market & Revenue — Non-Vendor Agents", section: "Appendix", component: SlideMarketAndRevenue },
   // ----- LIVE DEMO — appears as last slide of every filtered deck via URL ranges -----
   { title: "Optimization in Action (Video Demo)", section: "Demo", component: SlideOptimizationInActionDemo },
+  // ----- 1-MIN STORY CTA — slide 5 of /investor-pitch (range 24-29) -----
+  { title: "Watch the 1-minute story", section: "Demo", component: SlideStoryCTA },
+  // ----- DUAL-CTA CLOSER — slide 6 of /investor-pitch (Start Now + Book a demo) -----
+  { title: "Investor CTA — Start Now + Book a Demo", section: "Demo", component: SlideInvestorCTA },
 ];
 
 export default function PitchShort() {

--- a/src/pages/PitchShort2.jsx
+++ b/src/pages/PitchShort2.jsx
@@ -20,13 +20,16 @@ import { usePageView } from "../lib/usePageView";
 // matching its menu label. Update both this map and src/components/TopNav.jsx
 // PITCH_DECK_OPTIONS when adding a new preset.
 const PRESETS = {
-  "extended-product-presentation": { exclude: "24-26" },
-  "short-summary":                 { range:   "1-5,27" },
+  // Slide 24 of SHORT_SLIDES (SlideMarketOpportunity — Wave / Pain / Play)
+  // leads every product + investor deck. It's the highest-signal opener and
+  // the slide that immediately frames the market + Traigent's play.
+  "extended-product-presentation": { range:   "24,1-23,27-29" },
+  "short-summary":                 { range:   "24,1-5,27" },
   "market-opportunity":            { range:   "24-27" },
   // Same slide range as market-opportunity for now — kept as a separate
   // preset so /investor-pitch can diverge later without touching the
   // /market-opportunity preset.
-  "investor-pitch":                { range:   "24-27" },
+  "investor-pitch":                { range:   "24-29" },
 };
 
 const SLIDE_W = 1280;
@@ -194,7 +197,7 @@ function resolveSlides(rangeParam, excludeParam, allSlides) {
   return allSlides;
 }
 
-export default function PitchShort2({ forcedPreset } = {}) {
+export default function PitchShort2({ forcedPreset, forcedRange, prependSlides } = {}) {
   usePageView();
   useKnownContactNotify({
     notify: notifyPitchDeckViewed,
@@ -206,23 +209,28 @@ export default function PitchShort2({ forcedPreset } = {}) {
   useRemoveChatWidget();
   // forcedPreset lets App.jsx mount this deck at a short top-level route
   // (e.g. /extended-product-presentation) without the /pitch-short-2/ prefix.
+  // forcedRange + prependSlides are used by RecipientPackagePage to mount a
+  // per-recipient deck (cover slide + a fixed SHORT_SLIDES range) without
+  // having to register a public preset name.
   const { preset: urlPreset } = useParams();
   const preset = forcedPreset || urlPreset;
   const [searchParams] = useSearchParams();
   const slidesToRender = useMemo(() => {
-    // Named preset on the URL path (e.g. /pitch-short-2/short-summary) wins
-    // over raw ?range= / ?exclude= query params. Unknown preset names fall
-    // through to whatever the query params (or full deck) say.
-    if (preset && PRESETS[preset]) {
+    let body;
+    if (forcedRange) {
+      body = resolveSlides(forcedRange, null, SCROLL_SLIDES);
+    } else if (preset && PRESETS[preset]) {
       const { range, exclude } = PRESETS[preset];
-      return resolveSlides(range, exclude, SCROLL_SLIDES);
+      body = resolveSlides(range, exclude, SCROLL_SLIDES);
+    } else {
+      body = resolveSlides(
+        searchParams.get("range"),
+        searchParams.get("exclude"),
+        SCROLL_SLIDES,
+      );
     }
-    return resolveSlides(
-      searchParams.get("range"),
-      searchParams.get("exclude"),
-      SCROLL_SLIDES,
-    );
-  }, [preset, searchParams]);
+    return prependSlides && prependSlides.length ? [...prependSlides, ...body] : body;
+  }, [preset, searchParams, forcedRange, prependSlides]);
 
   return (
     <>

--- a/src/pages/RecipientPackageBlankPage.jsx
+++ b/src/pages/RecipientPackageBlankPage.jsx
@@ -1,0 +1,40 @@
+// Bland page rendered for /vc, /channel, /customer (no slug) and for any
+// recipient URL that doesn't resolve to a registered package. Goal: reveal
+// nothing about other recipients while telling a misdirected visitor they
+// likely need a more specific URL.
+//
+// No <Helmet> title that identifies the section. No links to other
+// recipient packages. No robots indexing.
+import { Helmet } from "react-helmet-async";
+import { Link } from "react-router-dom";
+import BrandMark from "../components/BrandMark";
+
+export default function RecipientPackageBlankPage() {
+  return (
+    <>
+      <Helmet>
+        <title>Traigent</title>
+        <meta name="robots" content="noindex,nofollow" />
+        <meta name="googlebot" content="noindex,nofollow" />
+      </Helmet>
+      <div className="min-h-screen bg-[#080808] text-white flex items-center justify-center px-6">
+        <div className="max-w-md w-full text-center">
+          <Link to="/" className="inline-block mb-8 hover:opacity-80 transition-opacity" aria-label="Traigent">
+            <BrandMark size="lg" />
+          </Link>
+          <p className="text-slate-300 text-base md:text-lg leading-relaxed mb-3">
+            If you&apos;re looking for a specific presentation, please use the
+            full link you were sent.
+          </p>
+          <p className="text-slate-500 text-sm">
+            Otherwise, head back to{" "}
+            <Link to="/" className="text-[#4D8EF8] hover:text-[#7BA8F9] underline underline-offset-4">
+              traigent.ai
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/pages/RecipientPackagePage.jsx
+++ b/src/pages/RecipientPackagePage.jsx
@@ -1,0 +1,114 @@
+// Generic recipient-package page. Resolves /:type/:slug via the env-driven
+// registry in src/lib/recipientPackages.js. On match, renders a cover slide
+// (data-driven from `cover.*` fields) prepended to a SHORT_SLIDES range
+// taken from `presetRange`. On miss, falls through to the bland page so a
+// guessed URL reveals nothing useful.
+//
+// This file is intentionally generic — zero recipient-identifying content
+// lives here. Everything specific (display name, slug, cover copy) flows
+// through VITE_RECIPIENT_PACKAGES_JSON.
+import { useState } from "react";
+import { Helmet } from "react-helmet-async";
+import { useParams } from "react-router-dom";
+import PitchShort2 from "./PitchShort2";
+import RecipientPackageBlankPage from "./RecipientPackageBlankPage";
+import { getPackage, isValidType } from "../lib/recipientPackages";
+
+function CoverSlide({ cover, displayName }) {
+  const {
+    logoSrc,
+    logoAlt,
+    kicker,
+    headline,
+    subhead,
+    bullets = [],
+    footerNote,
+  } = cover || {};
+  // Track whether the logo image loaded. If it errors (e.g. the asset hasn't
+  // been dropped at /recipient-assets/<recipient>.svg yet) we fall back to a
+  // plain typographic wordmark using the recipient's display name. This keeps
+  // the cover from looking broken while the official brand asset is sourced.
+  const [logoFailed, setLogoFailed] = useState(false);
+  const showLogo = logoSrc && !logoFailed;
+  const showWordmark = !showLogo && displayName;
+  return (
+    <div className="w-full max-w-[1080px] mx-auto self-stretch flex flex-col items-center justify-center min-h-[600px] text-center">
+      {showLogo && (
+        <img
+          src={logoSrc}
+          alt={logoAlt || displayName || ""}
+          className="max-h-20 md:max-h-24 w-auto mb-8 select-none"
+          draggable={false}
+          onError={() => setLogoFailed(true)}
+        />
+      )}
+      {showWordmark && (
+        <div
+          className="mb-8 text-3xl md:text-4xl font-extrabold tracking-tight text-slate-200 select-none"
+          aria-label={displayName}
+        >
+          {displayName}
+        </div>
+      )}
+      {kicker && (
+        <div className="text-xs md:text-sm font-mono uppercase tracking-[0.3em] text-slate-500 mb-6">
+          {kicker}
+        </div>
+      )}
+      {headline && (
+        <h2 className="text-4xl md:text-6xl font-bold text-white leading-tight tracking-tight mb-4">
+          {headline}
+        </h2>
+      )}
+      {subhead && (
+        <p className="text-lg md:text-xl text-slate-300 max-w-2xl leading-snug mb-10">
+          {subhead}
+        </p>
+      )}
+      {bullets.length > 0 && (
+        <ul className="text-left max-w-2xl space-y-3 mb-10">
+          {bullets.map((b, i) => (
+            <li key={i} className="flex items-start gap-3 text-slate-200 text-base md:text-lg">
+              <span className="text-[#4D8EF8] font-bold mt-1">&bull;</span>
+              <span>{b}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {footerNote && (
+        <div className="text-xs md:text-sm text-slate-500 italic mt-2">{footerNote}</div>
+      )}
+    </div>
+  );
+}
+
+export default function RecipientPackagePage({ type }) {
+  const { slug } = useParams();
+  const valid = isValidType(type);
+  const pkg = valid ? getPackage(type, slug) : null;
+
+  if (!pkg) {
+    // Unknown slug under a valid type, or invalid type entirely — render the
+    // same bland page as /:type so URL-guessers learn nothing.
+    return <RecipientPackageBlankPage />;
+  }
+
+  const coverSlide = {
+    title: "Recipient Cover",
+    section: "Cover",
+    component: () => (
+      <CoverSlide cover={pkg.cover || {}} displayName={pkg.displayName} />
+    ),
+  };
+
+  return (
+    <>
+      <Helmet>
+        <title>Traigent</title>
+        <meta name="robots" content="noindex,nofollow" />
+        <meta name="googlebot" content="noindex,nofollow" />
+      </Helmet>
+      <PitchShort2 forcedRange={pkg.presetRange} prependSlides={[coverSlide]} />
+    </>
+  );
+}

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "v-Traigent/traigent-web-codex/web58-real-demo-salvage-2026-06-08-21:20",
-  "repo": "Traigent/traigent-web",
-  "branch": "codex/web58-real-demo-salvage",
-  "buildTime": "2026-06-08-21:20"
+  "version": "v-https://github.com/Traigent/traigent-web/-main-2026-06-09-16:50",
+  "repo": "https://github.com/Traigent/traigent-web/",
+  "branch": "main",
+  "buildTime": "2026-06-09-16:50"
 }


### PR DESCRIPTION
## Summary

Two batches of work in one PR — they share enough files (PitchShort2, TopNav) that splitting created more noise than value.

### Per-recipient pitch packages (new)
- New routes: `/vc/:slug`, `/channel/:slug`, `/customer/:slug` for per-recipient deck packages, plus `/vc`, `/channel`, `/customer` rendering a bland fallback page (no listing, no inter-package links, `noindex`).
- Registry source of truth: `VITE_RECIPIENT_PACKAGES_JSON` (GitHub Actions Variables for prod) — schema lives in `src/lib/recipientPackages.js`. Local dev falls back to a gitignored `src/lib/recipientPackages.local.js` via `import.meta.glob` so we don't fight dotenv quoting locally.
- Public repo has zero recipient names / slugs / cover copy — all of that lives in the env var or the gitignored local file. Per-recipient logo assets go under `public/recipient-assets/` which is also gitignored (only `.gitkeep` is tracked).
- `RecipientPackagePage.jsx` renders a data-driven cover slide (logo src + alt, kicker, headline, subhead, bullets, footerNote) prepended to a `SHORT_SLIDES` range from `presetRange`. Missing logo falls back to a typographic wordmark using `displayName`.
- `TopNav.jsx` gets a second `▸` glyph below the existing presentations menu. Right-click opens a recipient menu with VC / Channel / Customer sections always visible (`No packages yet.` under empty sections so the scaffold is obvious).
- `PitchShort2.jsx` gains `forcedRange` + `prependSlides` props so a recipient mount can render a custom cover + range without registering a public preset name.
- Deploy workflow passes `VITE_RECIPIENT_PACKAGES_JSON` through at build time. Kept as a Variable (not a Secret) because the value ships to the public bundle anyway — no benefit to log-masking.

### Investor-pitch deck polish
- Slide 24 (Market Opportunity — Wave / Pain / Play) is now the lead slide of `/extended-product-presentation`, `/short-summary`, and `/investor-pitch` (PRESETS reordered in `PitchShort2.jsx`).
- `SlideMarketOpportunity`: `(among thousands of config combos)` is now a `<Link to=\"/knob-explorer\">`.
- `OptimizerRing` gains a `thirdLabel` prop. `/investor-pitch` slide 24 passes `EVALUATE`; homepage hero stays on the default `TEST`.
- `SHORT_SLIDES` gains `SlideStoryCTA` + `SlideInvestorCTA` (Start Now + Book-a-demo) as closing slides for `/investor-pitch`.
- `OptimizationTable` picks up a Play / Pause / Replay transport button next to the fullscreen button so the demo can be controlled without expanding.

## Privacy posture
- Source repo (public) contains only generic recipient-package infrastructure; no specific recipient is named.
- Prod bundle does contain whatever's in `VITE_RECIPIENT_PACKAGES_JSON` at build time (it ships to every visitor's devtools). Opaque slugs + no inter-package links + bland `/vc`, `/channel`, `/customer` pages are what keep one recipient from discovering another via URL navigation or UI affordance.

## Test plan
- [ ] `/extended-product-presentation`, `/short-summary`, `/investor-pitch` all open with Market Opportunity as slide `1 / N`.
- [ ] `/market-opportunity` unchanged.
- [ ] Homepage hero ring still reads `LEARN → DEDUCE → TEST → REPEAT` (regression-check the `thirdLabel` default).
- [ ] Right-click the new (lower) `▸` glyph → recipient menu shows VC / Channel / Customer headers, with `No packages yet.` under each until a package is registered.
- [ ] `/vc`, `/channel`, `/customer` (no slug) render the bland fallback page.
- [ ] `/vc/<unknown-slug>` also renders the bland fallback (URL guessing reveals nothing).
- [ ] OptimizationTable: Play / Pause / Replay button appears next to the fullscreen button in embedded mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)