### PR TITLE
Category-free /:slug recipient package links (+ Ness channel package)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,9 +51,14 @@ export default function App() {
       <Route path="short-summary" element={<PitchShort2 forcedPreset="short-summary" />} />
       <Route path="market-opportunity" element={<PitchShort2 forcedPreset="market-opportunity" />} />
       <Route path="investor-pitch" element={<PitchShort2 forcedPreset="investor-pitch" />} />
-      {/* Per-recipient package routes. The `/:type` (no slug) routes render a
-          bland page so URL-guessers learn nothing about other recipients;
-          `/:type/:slug` resolves the slug via the env-driven registry. */}
+      {/* Per-recipient package routes. The category-free `/:slug` form is the
+          one we hand out now — it carries no VC/Channel/Customer signal (the
+          recipient's name already lives in the slug). The `/vc|/channel|
+          /customer/:slug` routes are kept as working aliases so links already
+          sent out (e.g. Bosch's /vc/... link) never break; the admin menu in
+          TopNav still groups by category from the registry, independent of the
+          URL. The `/:type` (no slug) routes render a bland page so URL-guessers
+          learn nothing about other recipients. */}
       <Route path="vc" element={<RecipientPackageBlankPage />} />
       <Route path="vc/:slug" element={<RecipientPackagePage type="vc" />} />
       <Route path="channel" element={<RecipientPackageBlankPage />} />
@@ -102,6 +107,13 @@ export default function App() {
         <Route path="academy/agents-in-production" element={<AgentsInProduction />} />
         <Route path="academy/statistical-se-workshop" element={<StatisticalSEWorkshop />} />
       </Route>
+
+      {/* Category-free recipient package route. Kept LAST so every static
+          route above wins by specificity; this only catches single-segment
+          paths that match nothing else. A registered slug renders the package;
+          anything unknown falls through to the bland page inside
+          RecipientPackagePage, revealing nothing. */}
+      <Route path=":slug" element={<RecipientPackagePage />} />
     </Routes>
     </>
   )

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -503,7 +503,7 @@ export default function TopNav() {
                             section.items.map((item) => (
                               <a
                                 key={item.slug}
-                                href={`/#/${section.type}/${item.slug}`}
+                                href={`/#/${item.slug}`}
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 role="menuitem"
@@ -515,7 +515,7 @@ export default function TopNav() {
                                 </div>
                                 <div className="text-xs text-slate-400 mt-0.5 flex justify-between gap-2">
                                   <span className="truncate">
-                                    {item.internalLabel || `/${section.type}/${item.slug}`}
+                                    {item.internalLabel || `/${item.slug}`}
                                   </span>
                                   {item.dateSent && (
                                     <span className="font-mono text-slate-500 shrink-0">

--- a/src/lib/recipientPackages.js
+++ b/src/lib/recipientPackages.js
@@ -100,6 +100,30 @@ export function getPackage(type, slug) {
   return REGISTRY[type]?.[slug] || null;
 }
 
+// Category-free resolution: look a slug up across every type bucket. This
+// powers the bare `/:slug` route so outward-facing links carry no VC/Channel/
+// Customer signal (the recipient's name is already in the slug). Slugs are
+// expected to be globally unique; if the same slug somehow appears under two
+// types we warn and return the first match in VALID_TYPES order.
+export function getPackageBySlug(slug) {
+  if (!slug) return null;
+  let found = null;
+  for (const type of VALID_TYPES) {
+    const pkg = REGISTRY[type]?.[slug];
+    if (pkg) {
+      if (found) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[recipientPackages] slug "${slug}" is registered under multiple types; using the first match.`,
+        );
+        break;
+      }
+      found = pkg;
+    }
+  }
+  return found;
+}
+
 // For the admin nav: returns all three sections in render order, each with
 // its packages sorted by dateSent (newest first; missing dates sink). Empty
 // sections are returned with an empty `items` array — the nav renders the

--- a/src/pages/RecipientPackagePage.jsx
+++ b/src/pages/RecipientPackagePage.jsx
@@ -12,7 +12,7 @@ import { Helmet } from "react-helmet-async";
 import { useParams } from "react-router-dom";
 import PitchShort2 from "./PitchShort2";
 import RecipientPackageBlankPage from "./RecipientPackageBlankPage";
-import { getPackage, isValidType } from "../lib/recipientPackages";
+import { getPackage, getPackageBySlug, isValidType } from "../lib/recipientPackages";
 
 function CoverSlide({ cover, displayName }) {
   const {
@@ -84,8 +84,12 @@ function CoverSlide({ cover, displayName }) {
 
 export default function RecipientPackagePage({ type }) {
   const { slug } = useParams();
-  const valid = isValidType(type);
-  const pkg = valid ? getPackage(type, slug) : null;
+  // Two entry points resolve to this page:
+  //  - bare `/:slug` (no `type` prop) → look the slug up across all buckets so
+  //    the URL leaks no VC/Channel/Customer category.
+  //  - legacy `/vc|/channel|/customer/:slug` (with `type`) → kept as working
+  //    aliases so links already sent out (e.g. Bosch) never break.
+  const pkg = type ? (isValidType(type) ? getPackage(type, slug) : null) : getPackageBySlug(slug);
 
   if (!pkg) {
     // Unknown slug under a valid type, or invalid type entirely — render the


### PR DESCRIPTION
## What

Outward-facing recipient-package links no longer carry the VC/Channel/Customer category in the URL. New links use the bare `/#/<slug>` form; the recipient's name is already in the slug, and the category previously signaled how recipients were bucketed (awkward for a recipient to see).

- `getPackageBySlug()` resolves a slug across all type buckets.
- New `/:slug` route (registered **last** so every static route wins by specificity; unknown slugs fall through to the bland page).
- `/vc|/channel|/customer/:slug` kept as **working aliases** — links already sent (e.g. Bosch's `/#/vc/bosch-dsaj3m`) keep resolving.
- Admin "▸" menu still groups by VC/Channel/Customer from the registry; only the copied link dropped the prefix.

## Registry (prod Actions Variable, not in source)

`VITE_RECIPIENT_PACKAGES_JSON` updated: Bosch `vc` entry preserved unchanged; new `channel` entry `ness-n390eb` (Ness — Israel SI channel-partner package) added, with the Ness logo embedded as a `data:` URI (keeps recipient assets out of the public repo; CSP already allows `data:` images).

## Resulting links

- Ness (new, category-free): `traigent.ai/#/ness-n390eb`
- Bosch (already sent, via alias): `traigent.ai/#/vc/bosch-dsaj3m` — verified still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)