### PR TITLE
Outbound deck/package booking CTAs → amir8/out meeting link

### DIFF
--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -109,6 +109,15 @@ export default function BlogPost({ forcedSlug } = {}) {
 
   if (!post) return <Navigate to="/blog" replace />;
 
+  // The two reading-primers (agent-knobs-101, implementing-agent-knobs) are
+  // reached only via the outbound presentations triangle's top-level aliases,
+  // which mount BlogPost with `forcedSlug`. Those entries book on the outbound
+  // /out scheduling page; genuinely inbound /blog/:slug reads keep the base
+  // link so organic blog readers stay attributed to inbound.
+  const bookingHref = forcedSlug
+    ? "https://meetings-eu1.hubspot.com/amir8/out"
+    : "https://meetings-eu1.hubspot.com/amir8";
+
   const ogDescription = post.summary || "";
 
   return (
@@ -183,7 +192,7 @@ export default function BlogPost({ forcedSlug } = {}) {
           <div className="mt-16 pt-8 border-t border-slate-800 text-center">
             <p className="text-slate-400 mb-4">Ready to see Traigent in action?</p>
             <a
-              href="https://meetings-eu1.hubspot.com/amir8"
+              href={bookingHref}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-block bg-[#1A6BF5] hover:bg-[#4D8EF8] text-white font-medium px-6 py-3 rounded-lg transition-colors"

--- a/src/pages/PitchShort.jsx
+++ b/src/pages/PitchShort.jsx
@@ -477,7 +477,7 @@ function SlideSweepThePack() {
 // Uses the same StartNowModal mounting pattern as TopNav and StoryMovie.
 function SlideInvestorCTA() {
   const [showStartNow, setShowStartNow] = useState(false);
-  const bookingHref = "https://meetings-eu1.hubspot.com/amir8";
+  const bookingHref = "https://meetings-eu1.hubspot.com/amir8/out";
   return (
     <>
       <div className="w-full max-w-[1080px] mx-auto self-stretch flex flex-col items-center justify-center min-h-[600px] text-center">

--- a/src/pages/StoryMovie.jsx
+++ b/src/pages/StoryMovie.jsx
@@ -23,8 +23,10 @@ import { notifyStoryWatched } from "../lib/hubspotForms";
 import { useKnownContactNotify } from "../lib/useKnownContactNotify";
 import { usePageView } from "../lib/usePageView";
 
-// Same CTA URL as the homepage TopNav — HubSpot meeting booking.
-const DEMO_BOOKING_URL = "https://meetings-eu1.hubspot.com/amir8";
+// Outbound HubSpot meeting booking. /story is a deck/presentation surface
+// reached via the presentations triangle, so it uses the /out scheduling page
+// (distinct from the inbound site link) to attribute these bookings to outbound.
+const DEMO_BOOKING_URL = "https://meetings-eu1.hubspot.com/amir8/out";
 
 // =============================================================================
 // Narration component — flattens every sentence into a single list of rows


### PR DESCRIPTION
Routes the booking CTA on outbound surfaces (decks + recipient packages, i.e. everything reachable from the presentations + recipient-packages right-click triangles) to the dedicated outbound HubSpot scheduling page `meetings-eu1.hubspot.com/amir8/out`. The public/inbound site keeps the base `amir8` link, so booked meetings split cleanly into outbound vs inbound.

- **PitchShort `SlideInvestorCTA`** — the closing "Book a demo" slide shared by every PitchShort2 deck and by the recipient packages (slide 29 is in the Bosch/Ness range).
- **StoryMovie** — the `/story` deck.
- **BlogPost** — scoped to `forcedSlug` only, so the two outbound aliases (`/agent-knobs-101`, `/implementing-agent-knobs`) use `/out` while inbound `/blog/:slug` reads stay on the base link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)