### PR TITLE
Knob Explorer: collapse-by-default + work-email access gate

### DIFF
--- a/src/components/KnobExplorerGate.jsx
+++ b/src/components/KnobExplorerGate.jsx
@@ -1,0 +1,71 @@
+/* eslint-disable react/prop-types */
+import { useState } from "react";
+import { Lock } from "lucide-react";
+import { Link } from "react-router-dom";
+import ConsentGate from "./ConsentGate";
+import ConsentCheckbox from "./ConsentCheckbox";
+import HubSpotStartNowForm from "./HubSpotStartNowForm";
+import { markUnlocked } from "../lib/startNowGate";
+import { trackEvent } from "../lib/analytics";
+
+// Knob Explorer lead-capture form. Configured in HubSpot to block free /
+// personal email domains, so the "work email" requirement is enforced
+// server-side on submit — no client-side domain check needed here.
+const KNOB_EXPLORER_FORM_ID = "a9bc858e-add8-4094-995a-188ae08fd56e";
+
+/**
+ * Full-page blocking gate shown in place of the Knob Explorer for visitors
+ * we don't already know. Submitting a (work) email unlocks the tool for this
+ * browser for 90 days (see startNowGate). `onUnlock(email)` lets the page
+ * swap in the explorer immediately without a reload.
+ */
+export default function KnobExplorerGate({ onUnlock }) {
+  const [agreed, setAgreed] = useState(false);
+
+  const handleSubmitted = (email) => {
+    if (email) markUnlocked(email);
+    trackEvent("knob_explorer_unlocked", { location: "knob_explorer_gate" });
+    onUnlock(email || "");
+  };
+
+  return (
+    <div className="min-h-[100svh] bg-[#080808] text-white flex items-center justify-center px-4 py-10">
+      <div className="max-w-lg w-full bg-slate-900/70 border border-slate-700 rounded-2xl p-8 shadow-2xl">
+        <div className="w-12 h-12 rounded-xl bg-blue-500/10 border border-blue-500/30 flex items-center justify-center mb-5">
+          <Lock className="w-6 h-6" style={{ color: "#4D8EF8" }} />
+        </div>
+        <div className="text-[11px] font-mono uppercase tracking-widest text-slate-500 mb-2">
+          Knob Explorer
+        </div>
+        <h1 className="text-2xl md:text-3xl font-bold mb-2">Explore the search space</h1>
+        <p className="text-slate-400 text-sm leading-relaxed mb-6">
+          An interactive tool for mapping an AI agent's tuning space — models,
+          knobs, and the combinatorics that make optimization hard. Enter your
+          work email to get access.
+        </p>
+        <ConsentGate>
+          <div className="mb-4">
+            <ConsentCheckbox
+              id="knob-explorer-consent"
+              checked={agreed}
+              onChange={setAgreed}
+            />
+          </div>
+          {agreed ? (
+            <HubSpotStartNowForm
+              onSuccess={handleSubmitted}
+              targetId="hs-knob-explorer-form"
+              formId={KNOB_EXPLORER_FORM_ID}
+            />
+          ) : (
+            <p className="text-xs text-slate-500">Tick the box above to load the form.</p>
+          )}
+        </ConsentGate>
+        <p className="text-[11px] text-slate-600 mt-5">
+          A work email is required. Already shared it with us?{" "}
+          <Link to="/" className="text-slate-400 underline hover:text-white">Back to traigent.ai</Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/startNowGate.js
+++ b/src/lib/startNowGate.js
@@ -82,14 +82,14 @@ export function getUnlockedEmail() {
  *   shouldNotifyForGate("startnow")  // → true (independent of portal)
  *   shouldNotifyForGate("portal")    // → false (within the portal throttle)
  */
-export function shouldNotifyForGate(gateKey) {
+export function shouldNotifyForGate(gateKey, throttleMs = REPEAT_NOTIFY_THROTTLE_MS) {
   if (!gateKey) return false;
   const entry = readEntry();
   if (!entry || !entry.email) return false;
   const now = Date.now();
   const stamps = entry.lastNotifiedByGate || {};
   const lastTs = Number(stamps[gateKey]) || 0;
-  if (now - lastTs < REPEAT_NOTIFY_THROTTLE_MS) return false;
+  if (now - lastTs < throttleMs) return false;
   writeEntry({
     ...entry,
     lastNotifiedByGate: { ...stamps, [gateKey]: now },

--- a/src/pages/KnobExplorer.jsx
+++ b/src/pages/KnobExplorer.jsx
@@ -5,7 +5,7 @@
 // color-coded pills so the user can see which knobs are worth tuning.
 //
 // Reachable via the hidden ▸ menu in TopNav.
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { motion } from "framer-motion";
@@ -13,7 +13,10 @@ import { ArrowLeft, ArrowRight, ChevronDown, ChevronUp, Clock, DollarSign, Spark
 import { useSharedSetting } from "../lib/useSharedSetting";
 import { useCustomSearchSpace } from "../lib/useCustomSearchSpace";
 import { useRemoveChatWidget } from "../lib/useRemoveChatWidget";
-import { useKnownContactNotify } from "../lib/useKnownContactNotify";
+import { isUnlocked, markUnlocked, getUnlockedEmail, shouldNotifyForGate } from "../lib/startNowGate";
+import { checkKnownContact } from "../lib/hubspotIdentify";
+import { trackEvent } from "../lib/analytics";
+import KnobExplorerGate from "../components/KnobExplorerGate";
 import { notifyKnobExplorerViewed } from "../lib/hubspotForms";
 import { usePageView } from "../lib/usePageView";
 import ChatKillerStyle from "../lib/ChatKillerStyle";
@@ -740,14 +743,12 @@ function sortKnobsByImpact(knobs, metric) {
   });
 }
 
+// Founder notification throttle for the knob explorer — at most once per
+// visitor per 24h, so repeat loads don't spam the inbox.
+const KNOB_NOTIFY_THROTTLE_MS = 24 * 60 * 60 * 1000;
+
 export default function KnobExplorer() {
   usePageView();
-  useKnownContactNotify({
-    notify: notifyKnobExplorerViewed,
-    location: "knob_explorer_page",
-    eventName: "knob_explorer_viewed_known",
-    gateKey: "knob_explorer",
-  });
   // Persist selections + sort preference across reloads / tabs so the user
   // can leave the page and come back to the same configuration.
   const [selectedModels, setSelectedModels] = useSharedSetting(
@@ -774,6 +775,63 @@ export default function KnobExplorer() {
   const chromeHidden = searchParams.get("chrome") === "hidden";
   const showFinal = searchParams.get("final") === "1";
   useRemoveChatWidget();
+
+  // ---- Access gate -------------------------------------------------------
+  // Standalone /knob-explorer requires a (work) email before use, and fires a
+  // notification on EVERY visit for a known/unlocked contact. The story embeds
+  // this page with ?chrome=hidden — that surface is intentionally NOT gated
+  // and does not notify here (the story has its own tracking).
+  const embedded = chromeHidden;
+  const [unlocked, setUnlocked] = useState(() => embedded || isUnlocked());
+  const [checkingAccess, setCheckingAccess] = useState(
+    () => !(embedded || isUnlocked()),
+  );
+  const notifiedRef = useRef(false);
+  // Collapse everything on a normal visit; the guided tour (story) keeps its
+  // expanded defaults so the walkthrough still works.
+  const startCollapsed = !guided;
+
+  useEffect(() => {
+    if (embedded) return; // story embed: never gated, never notified here
+    if (notifiedRef.current) return;
+    // Notify the founder when a known/unlocked contact opens the explorer,
+    // throttled to once per visitor per 24h so repeat loads don't spam.
+    const maybeNotify = (email) => {
+      trackEvent("knob_explorer_viewed", { location: "knob_explorer_page" });
+      if (shouldNotifyForGate("knob_explorer", KNOB_NOTIFY_THROTTLE_MS)) {
+        notifyKnobExplorerViewed({ email, location: "knob_explorer_page" });
+      }
+    };
+    const local = getUnlockedEmail();
+    if (local) {
+      notifiedRef.current = true;
+      maybeNotify(local);
+      return;
+    }
+    // Not unlocked on this browser — see if the hubspotutk cookie maps to a
+    // known HubSpot contact; if so, auto-unlock + notify.
+    let cancelled = false;
+    checkKnownContact().then((res) => {
+      if (cancelled) return;
+      if (res && res.known && res.email) {
+        markUnlocked(res.email);
+        setUnlocked(true);
+        notifiedRef.current = true;
+        maybeNotify(res.email);
+      }
+      setCheckingAccess(false);
+    });
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleUnlock = useCallback(() => {
+    notifiedRef.current = true;
+    setUnlocked(true);
+    // The gate's form submission already notified HubSpot; stamp the 24h
+    // throttle so the next load within 24h doesn't double-notify.
+    shouldNotifyForGate("knob_explorer", KNOB_NOTIFY_THROTTLE_MS);
+  }, []);
 
   // STABLE callback for GuidedTour — an inline arrow here would change every
   // render. GuidedTour's effect depends on onComplete identity, and the tour
@@ -894,6 +952,18 @@ export default function KnobExplorer() {
   const specificTotal = selectedModels.reduce((sum, m) => {
     return sum + (SPECIFIC_MODEL_KNOBS[m] || []).length;
   }, 0);
+
+  // Gate: unknown visitors must provide a work email before the explorer
+  // renders. Embedded (story) and already-unlocked/known visitors pass through.
+  if (!embedded && !unlocked) {
+    return checkingAccess ? (
+      <div className="min-h-[100svh] bg-[#080808] text-white flex items-center justify-center">
+        <p className="text-slate-400 animate-pulse">Checking access…</p>
+      </div>
+    ) : (
+      <KnobExplorerGate onUnlock={handleUnlock} />
+    );
+  }
 
   return (
     <>
@@ -1088,7 +1158,7 @@ export default function KnobExplorer() {
             </div>
 
             {/* Models — vendors render as a compact grid; click one to expand */}
-            <Section title="Models" count={selectedModels.length} total={MODELS.length}>
+            <Section title="Models" count={selectedModels.length} total={MODELS.length} defaultOpen={!startCollapsed}>
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
                 {VENDOR_ORDER.map((vendor) => {
                   const models = MODELS.filter((m) => m.provider === vendor);
@@ -1120,7 +1190,7 @@ export default function KnobExplorer() {
               count={enabledAgentCount}
               total={AGENT_KNOBS.length}
               variant="super"
-              defaultOpen={true}
+              defaultOpen={!startCollapsed}
             >
               {AGENT_KNOB_GROUPS.map((group) => {
                 const enabledInGroup = group.knobs.filter((k) => knobValues[k.id]).length;
@@ -1130,7 +1200,7 @@ export default function KnobExplorer() {
                     title={group.title}
                     count={enabledInGroup}
                     total={group.knobs.length}
-                    defaultOpen={group.defaultOpen}
+                    defaultOpen={startCollapsed ? false : group.defaultOpen}
                   >
                     <KnobList
                       knobs={group.knobs}
@@ -1152,10 +1222,10 @@ export default function KnobExplorer() {
               count={enabledCommonCount + enabledSpecificCount}
               total={COMMON_MODEL_KNOBS.length + specificTotal}
               variant="super"
-              defaultOpen={true}
+              defaultOpen={!startCollapsed}
             >
               {/* Common model knobs */}
-              <Section title="Common model knobs" count={enabledCommonCount} total={COMMON_MODEL_KNOBS.length}>
+              <Section title="Common model knobs" count={enabledCommonCount} total={COMMON_MODEL_KNOBS.length} defaultOpen={!startCollapsed}>
                 <KnobList
                   knobs={COMMON_MODEL_KNOBS}
                   sortBy={sortBy}
@@ -1166,7 +1236,7 @@ export default function KnobExplorer() {
               </Section>
 
               {/* Specific model knobs */}
-              <Section title="Specific model knobs" count={enabledSpecificCount} total={specificTotal}>
+              <Section title="Specific model knobs" count={enabledSpecificCount} total={specificTotal} defaultOpen={!startCollapsed}>
               {selectedModels.length === 0 ? (
                 <div className="text-sm text-slate-500 italic bg-slate-900/30 border border-slate-800/60 rounded-xl p-4">
                   Pick at least one model above to reveal its model-specific knobs.


### PR DESCRIPTION
## Folding
Normal visits open **fully collapsed**; unfolding a section reveals only its immediate (collapsed) children. The guided tour (`?guided`, used by the story) keeps its expanded defaults.

## Access gate
- **Unknown visitor** → blocking work-email form (`KnobExplorerGate`, reusing the consent + HubSpot embed pattern). The HubSpot knob-explorer form rejects free/personal domains, so "work email" is enforced server-side. Submitting unlocks for this browser (90-day memory) + creates/notifies the contact.
- **Already-unlocked / known** (`hubspotutk` → HubSpot contact) → straight through, auto-unlocked.
- **Story exception** → the iframe loads `?chrome=hidden`, treated as ungated, so Act 2 is never blocked.

## Notification
`notifyKnobExplorerViewed` for known/unlocked visitors, **throttled to once per visitor / 24h** (`shouldNotifyForGate` gained an optional window arg; default stays 1h elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)