### PR TITLE
Email-gate all code/SDK/GitHub/course access paths

### DIFF
--- a/generate-pdf.bat
+++ b/generate-pdf.bat
@@ -1,0 +1,58 @@
+@echo off
+REM Generate one-pager PDF
+REM This script will:
+REM 1. Install puppeteer if not already installed
+REM 2. Start the dev server in the background
+REM 3. Generate the PDF
+REM 4. Save it to D:\2026 job search\TRAIGENT-AI\One-pager\
+
+echo.
+echo === Traigent One-Pager PDF Generator ===
+echo.
+
+REM Check if puppeteer is installed
+npm list puppeteer >nul 2>&1
+if errorlevel 1 (
+    echo Installing puppeteer...
+    call npm install puppeteer
+    if errorlevel 1 (
+        echo ERROR: Failed to install puppeteer
+        exit /b 1
+    )
+)
+
+echo.
+echo Starting dev server...
+echo.
+
+REM Start dev server in background
+start /B npm run dev >nul 2>&1
+
+REM Wait for server to start
+timeout /t 5 /nobreak
+
+REM Run the PDF generation script
+echo Generating PDF from one-pager-2...
+echo.
+
+node scripts/generate-one-pager-pdf.js
+
+REM Capture the exit code
+set PDF_EXIT_CODE=%errorlevel%
+
+REM Kill the dev server
+taskkill /F /IM node.exe >nul 2>&1
+
+if %PDF_EXIT_CODE% equ 0 (
+    echo.
+    echo === SUCCESS ===
+    echo PDF saved to: D:\2026 job search\TRAIGENT-AI\One-pager\traigent-one-pager.pdf
+    echo.
+) else (
+    echo.
+    echo === FAILED ===
+    echo There was an error generating the PDF.
+    echo.
+)
+
+exit /b %PDF_EXIT_CODE%

--- a/scripts/generate-one-pager-pdf.js
+++ b/scripts/generate-one-pager-pdf.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+/**
+ * Generate PDF from the one-pager-2 page
+ * Run with: node scripts/generate-one-pager-pdf.js
+ */
+
+const puppeteer = require('puppeteer');
+const path = require('path');
+const fs = require('fs');
+
+const OUTPUT_PATH = 'D:\\2026 job search\\TRAIGENT-AI\\One-pager\\traigent-one-pager.pdf';
+
+async function generatePDF() {
+  let browser;
+  try {
+    // Launch browser
+    browser = await puppeteer.launch({
+      headless: 'new',
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+
+    const page = await browser.newPage();
+    
+    // Set viewport to match A4 landscape
+    await page.setViewport({
+      width: 1280,
+      height: 720,
+      deviceScaleFactor: 2,
+    });
+
+    // Navigate to the one-pager-2 page
+    // For local dev: http://localhost:5173/#/one-pager-2
+    // For production: https://www.traigent.ai/#/one-pager-2
+    const url = 'http://localhost:5173/#/one-pager-2';
+    
+    console.log(`Navigating to ${url}...`);
+    await page.goto(url, { 
+      waitUntil: 'networkidle2',
+      timeout: 30000 
+    });
+
+    // Wait for the one-pager content to render
+    await page.waitForSelector('section', { timeout: 10000 });
+    
+    // Give animations time to settle
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    // Ensure output directory exists
+    const outputDir = path.dirname(OUTPUT_PATH);
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+      console.log(`Created directory: ${outputDir}`);
+    }
+
+    // Generate PDF with A4 landscape dimensions
+    await page.pdf({
+      path: OUTPUT_PATH,
+      format: 'A4',
+      landscape: true,
+      margin: { top: 0, right: 0, bottom: 0, left: 0 },
+      printBackground: true,
+    });
+
+    console.log(`✓ PDF generated successfully: ${OUTPUT_PATH}`);
+    await browser.close();
+    process.exit(0);
+    
+  } catch (error) {
+    console.error('Error generating PDF:', error.message);
+    if (browser) await browser.close();
+    process.exit(1);
+  }
+}
+
+generatePDF();

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -17,7 +17,6 @@ import { checkKnownContact } from "../lib/hubspotIdentify";
 
 const PORTAL_URL = "https://portal.traigent.ai";
 const DEMO_URL = "https://meetings-eu1.hubspot.com/amir8";
-const GITHUB_URL = "https://github.com/Traigent/Traigent";
 
 // Hidden access point: presentations menu behind the obscure ▸ glyph in the
 // far-right of the nav. Each item opens the scroll-mode deck in a new tab
@@ -84,7 +83,9 @@ const resourcesItems = [
   { label: "Compare", href: "/compare", desc: "vs. Langfuse · Arize · Helicone · Braintrust" },
   { label: "FAQ", href: "/faq", desc: "Common questions" },
   { label: "Research", href: "/research", desc: "CAIN 2026 paper, TVL, and governed optimization" },
-  { label: "Docs", href: "https://github.com/Traigent/Traigent", external: true, desc: "SDK on GitHub" },
+  // Code access is email-gated: Docs routes through /get-started (unlocks the
+  // GitHub repo + install command after the visitor leaves an email).
+  { label: "Docs", href: "/get-started", desc: "SDK install + GitHub — unlocks with your email" },
   { label: "Academy", href: "/academy", desc: "Short courses for teams shipping AI agents" },
   { label: "About", href: "/about", desc: "Team, mission, values" },
   { label: "Get Started", href: "/get-started" },
@@ -383,17 +384,21 @@ export default function TopNav() {
 
             {/* Desktop CTAs */}
             <div className="hidden lg:flex items-center gap-3 sm:gap-4">
-              <a
-                href={GITHUB_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackEvent("github_clicked", { location: "topnav" })}
+              {/* Code access is email-gated: the GitHub icon opens the Start
+                  Now modal (unlocked visitors see the repo + install command
+                  immediately; unknown visitors leave an email first). */}
+              <button
+                type="button"
+                onClick={() => {
+                  trackEvent("github_gate_opened", { location: "topnav" });
+                  setShowStartNow(true);
+                }}
                 className="text-slate-400 hover:text-white transition-colors"
-                title="GitHub"
-                aria-label="GitHub"
+                title="Get the SDK (GitHub)"
+                aria-label="Get the SDK (GitHub)"
               >
                 <Github className="w-5 h-5" />
-              </a>
+              </button>
               <button
                 type="button"
                 onClick={() => handleOpenPortal("topnav")}
@@ -649,16 +654,14 @@ export default function TopNav() {
               >
                 Book a demo
               </a>
-              <a
-                href={GITHUB_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => { trackEvent("github_clicked", { location: "topnav_mobile" }); closeMobile(); }}
+              <button
+                type="button"
+                onClick={() => { trackEvent("github_gate_opened", { location: "topnav_mobile" }); closeMobile(); setShowStartNow(true); }}
                 className="inline-flex items-center justify-center gap-2 text-xs text-slate-500 hover:text-white pt-2 transition-colors"
               >
                 <Github className="w-4 h-4" />
-                <span>View on GitHub</span>
-              </a>
+                <span>Get the SDK (GitHub)</span>
+              </button>
             </div>
           </div>
         </div>

--- a/src/components/academy/AcademyEmailGate.jsx
+++ b/src/components/academy/AcademyEmailGate.jsx
@@ -4,9 +4,9 @@ import { checkKnownContact } from "../../lib/hubspotIdentify";
 import ConsentGate from "../ConsentGate";
 import ConsentCheckbox from "../ConsentCheckbox";
 
-// One notification per visitor per course per hour. Matches the global
+// One notification per visitor per course per 24h. Matches the global
 // gate's throttle window so the inbox volume stays sane in prod.
-const REPEAT_NOTIFY_THROTTLE_MS = 60 * 60 * 1000;
+const REPEAT_NOTIFY_THROTTLE_MS = 24 * 60 * 60 * 1000;
 
 // Configuration read at build time. The Forms API is CORS-enabled and our
 // CSP already allows api.hsforms.com via the *.hsforms.com entry.
@@ -128,8 +128,15 @@ function isBlockedEmailDomainError(status, body) {
  *     <CourseContent />
  *   </AcademyEmailGate>
  */
+// Final fallback: the Start Now form (always configured, always notifies).
+// Guarantees a course page can never ship "dead-bolted" (gate shown but
+// submissions failing) if neither a per-course formId nor the academy env
+// var is set. The submission's pageName carries the course title, so
+// attribution survives even on the shared form.
+const STARTNOW_FALLBACK_FORM_ID = "35384a3e-7386-45b0-924e-84e5d6f637e4";
+
 export default function AcademyEmailGate({ courseSlug, courseTitle, formId, children }) {
-  const effectiveFormId = formId || ACADEMY_FORM_ID;
+  const effectiveFormId = formId || ACADEMY_FORM_ID || STARTNOW_FALLBACK_FORM_ID;
   const [unlocked, setUnlocked] = useState(() => !!readUnlockEntry(courseSlug));
 
   // When an already-unlocked visitor reopens a course, silently re-submit

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -663,9 +663,18 @@ def answer_question(question: str) -> str:
                   </a>
                 </li>
                 <li>
-                  <a href="https://github.com/Traigent/Traigent" target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+                  {/* Email-gated: opens the Start Now modal (repo + install
+                      command unlock after the visitor leaves an email). */}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      trackEvent("github_gate_opened", { location: "homepage_footer" });
+                      setShowStartNow(true);
+                    }}
+                    className="text-slate-400 hover:text-white transition-colors"
+                  >
                     Try out our SDK - it's free!
-                  </a>
+                  </button>
                 </li>
                 <li>
                   <Link to="/one-pager" className="text-slate-400 hover:text-white transition-colors">

--- a/src/pages/Pitch.jsx
+++ b/src/pages/Pitch.jsx
@@ -2,6 +2,7 @@
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronLeft, ChevronRight, Home, Maximize2 } from "lucide-react";
 import { Link } from "react-router-dom";
+import StartNowModal from "../components/StartNowModal";
 import { Helmet } from "react-helmet-async";
 import { ConvergenceDiagram, KillerStatsGrid, ThreeProductsGrid } from "./pitch/shared";
 import { useKnownContactNotify } from "../lib/useKnownContactNotify";
@@ -143,8 +144,14 @@ function SlideThreeProducts() {
 // Slide 6 — CTA / Next step
 // ===================================================================
 function SlideCTA() {
+  // Code/SDK access is email-gated: the install command is revealed via the
+  // Start Now modal (form first for unknown visitors; instant for known ones).
+  const [showStartNow, setShowStartNow] = useState(false);
   return (
     <div className="text-center max-w-5xl mx-auto">
+      {showStartNow && (
+        <StartNowModal onClose={() => setShowStartNow(false)} location="pitch_cta" />
+      )}
       <h2 className="text-4xl md:text-5xl font-bold text-white mb-4">
         Two Ways to See It in 15 Minutes
       </h2>
@@ -155,11 +162,14 @@ function SlideCTA() {
           <div className="text-sm font-mono text-slate-500 mb-3">OPTION 1</div>
           <h3 className="text-2xl font-bold text-white mb-4">Run the keyless demo</h3>
           <p className="text-slate-400 mb-5 text-sm">No API keys. No spend. ~6 seconds to a real result.</p>
-          <div className="bg-slate-950 border border-slate-700 rounded-lg px-4 py-3 font-mono text-sm text-slate-200 break-all">
-            <span className="text-slate-500">$ </span>
-            uv tool install "traigent[recommended]" &&<br/>
-            <span className="ml-4">traigent quickstart</span>
-          </div>
+          <button
+            type="button"
+            onClick={() => setShowStartNow(true)}
+            className="w-full bg-slate-950 border border-slate-700 hover:border-blue-500/60 rounded-lg px-4 py-3 font-mono text-sm text-slate-200 text-left transition-colors"
+          >
+            <span className="text-slate-500">$ </span>uv tool install "traigent[…]"
+            <span className="block mt-1 text-xs text-slate-500 font-sans">Click to get the full command →</span>
+          </button>
         </div>
         <div className="bg-slate-900/60 border-2 rounded-2xl p-8 text-left" style={{ borderColor: BLUE }}>
           <div className="text-sm font-mono mb-3" style={{ color: BLUE }}>OPTION 2</div>

--- a/src/pages/PitchFull.jsx
+++ b/src/pages/PitchFull.jsx
@@ -6,6 +6,7 @@ import { Helmet } from "react-helmet-async";
 import { ConvergenceDiagram, KillerStatsGrid, ThreeProductsGrid } from "./pitch/shared";
 import { OnePager2Slide } from "./OnePager2";
 import BrandMark from "../components/BrandMark";
+import StartNowModal from "../components/StartNowModal";
 import { useKnownContactNotify } from "../lib/useKnownContactNotify";
 import { notifyPitchDeckViewed } from "../lib/hubspotForms";
 import { usePageView } from "../lib/usePageView";
@@ -930,8 +931,14 @@ export function Slide19EngineerFirst() {
 // 20 — Get Started
 // ===================================================================
 export function Slide20GetStarted({ bookingHref = "https://meetings-eu1.hubspot.com/amir8" } = {}) {
+  // Code/SDK access is email-gated: the install command is revealed via the
+  // Start Now modal (form first for unknown visitors; instant for known ones).
+  const [showStartNow, setShowStartNow] = useState(false);
   return (
     <div className="text-center max-w-5xl mx-auto">
+      {showStartNow && (
+        <StartNowModal onClose={() => setShowStartNow(false)} location="pitch_slide20" />
+      )}
       <h2 className="text-5xl md:text-6xl font-bold text-white mb-4">Get Started</h2>
       <p className="text-xl text-slate-400 mb-12">Low risk. Fast result. Pick your path.</p>
       <div className="grid md:grid-cols-2 gap-6 mb-12">
@@ -939,9 +946,14 @@ export function Slide20GetStarted({ bookingHref = "https://meetings-eu1.hubspot.
           <div className="text-sm font-mono text-slate-500 mb-3">OPTION 1</div>
           <h3 className="text-2xl font-bold text-white mb-3">Run the keyless demo</h3>
           <p className="text-slate-400 mb-5 text-sm">No API keys. No spend. ~6 seconds to a real result on your laptop.</p>
-          <div className="bg-slate-950 border border-slate-700 rounded-lg px-4 py-3 font-mono text-sm text-slate-200 break-all">
-            <span className="text-slate-500">$ </span>uv tool install <span style={{ color: AMBER }}>"traigent[recommended]"</span> && traigent quickstart
-          </div>
+          <button
+            type="button"
+            onClick={() => setShowStartNow(true)}
+            className="w-full bg-slate-950 border border-slate-700 hover:border-blue-500/60 rounded-lg px-4 py-3 font-mono text-sm text-slate-200 text-left transition-colors"
+          >
+            <span className="text-slate-500">$ </span>uv tool install <span style={{ color: AMBER }}>"traigent[…]"</span>
+            <span className="block mt-1 text-xs text-slate-500 font-sans">Click to get the full command →</span>
+          </button>
         </div>
         <div className="bg-slate-900/60 border-2 rounded-2xl p-8 text-left" style={{ borderColor: BLUE }}>
           <div className="text-sm font-mono mb-3" style={{ color: BLUE }}>OPTION 2</div>

--- a/src/pages/PitchShort3.jsx
+++ b/src/pages/PitchShort3.jsx
@@ -1,0 +1,153 @@
+// /pitch-short-3 — iPhone-landscape friendly version of /pitch-short-2.
+// Each slide is rendered inside a fixed 1280x720 canvas, then the entire
+// canvas is scaled to fit the viewport. This preserves the desktop slide
+// proportions on narrow/short landscape phones without clipping content.
+import { useEffect, useState } from "react";
+import { Helmet } from "react-helmet-async";
+import { SHORT_SLIDES } from "./PitchShort";
+import { OnePager2Slide } from "./OnePager2";
+
+const SLIDE_W = 1280;
+const SLIDE_H = 720;
+const VIEWPORT_MARGIN = 16;
+
+function getScale() {
+  if (typeof window === "undefined") return 1;
+  const availableW = Math.max(320, window.innerWidth - VIEWPORT_MARGIN);
+  const availableH = Math.max(240, window.innerHeight - VIEWPORT_MARGIN);
+  return Math.min(1, availableW / SLIDE_W, availableH / SLIDE_H);
+}
+
+function useViewportScale() {
+  const [scale, setScale] = useState(getScale);
+
+  useEffect(() => {
+    const update = () => setScale(getScale());
+    window.addEventListener("resize", update);
+    window.addEventListener("orientationchange", update);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("orientationchange", update);
+    };
+  }, []);
+
+  return scale;
+}
+
+function useRemoveChatWidget() {
+  useEffect(() => {
+    const removeChat = () => {
+      window.HubSpotConversations?.widget?.remove?.();
+      document.querySelectorAll(
+        [
+          "#hubspot-messages-iframe-container",
+          "#hubspot-conversations-iframe",
+          ".hs-shadow-container",
+          "iframe[src*='conversations-visitor']",
+        ].join(",")
+      ).forEach((node) => node.remove());
+    };
+
+    removeChat();
+    const observer = new MutationObserver(removeChat);
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, []);
+}
+
+function ScrollOnePagerOpener() {
+  return <OnePager2Slide showHeader={false} showFooter={false} />;
+}
+
+const SCROLL_SLIDES = SHORT_SLIDES.map((s, i) =>
+  i === 0 ? { ...s, component: ScrollOnePagerOpener } : s
+);
+
+function SlideCanvas({ slide, index, total, scale }) {
+  const Slide = slide.component;
+
+  return (
+    <section
+      className="min-h-[100svh] flex items-center justify-center bg-[#080808] border-b border-slate-900/70 last:border-b-0"
+      style={{ padding: `${VIEWPORT_MARGIN / 2}px` }}
+    >
+      <div
+        className="relative shrink-0"
+        style={{
+          width: SLIDE_W * scale,
+          height: SLIDE_H * scale,
+        }}
+      >
+        <div
+          className="relative bg-[#080808] text-white overflow-hidden border border-slate-600"
+          style={{
+            width: SLIDE_W,
+            height: SLIDE_H,
+            transform: `scale(${scale})`,
+            transformOrigin: "top left",
+          }}
+        >
+          <a
+            href="https://www.traigent.ai/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="absolute top-4 left-4 z-10 flex items-center gap-2 hover:opacity-80 transition-opacity"
+            aria-label="Traigent.ai"
+          >
+            <img src="/images/traigent-logo-icon.png" alt="" aria-hidden="true" className="h-6 w-auto" />
+            <span className="text-white text-lg font-bold tracking-tight">Traigent.ai</span>
+          </a>
+
+          <div
+            className={`h-full w-full flex items-center justify-center ${
+              index === 0 ? "" : "px-10 pt-16 pb-12"
+            }`}
+          >
+            <Slide />
+          </div>
+
+          <span className="absolute bottom-3 right-4 text-slate-500 text-sm font-mono">
+            {index + 1} / {total}
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function PitchShort3() {
+  const scale = useViewportScale();
+  useRemoveChatWidget();
+
+  return (
+    <>
+      <Helmet>
+        <title>Traigent — Pitch (Mobile Landscape)</title>
+      </Helmet>
+      <style>{`
+        #hubspot-messages-iframe-container,
+        #hubspot-conversations-iframe,
+        .hs-shadow-container,
+        iframe[src*="conversations-visitor"],
+        .hs-banner-iframe,
+        #hs-eu-cookie-confirmation,
+        #hs-eu-cookie-confirmation-inner { display: none !important; }
+        @supports (height: 100svh) {
+          html, body, #root { min-height: 100svh; }
+        }
+      `}</style>
+      <div className="bg-[#080808] text-white">
+        {SCROLL_SLIDES.map((slide, i) => (
+          <SlideCanvas
+            key={`${i}-${slide.title}`}
+            slide={slide}
+            index={i}
+            total={SCROLL_SLIDES.length}
+            scale={scale}
+          />
+        ))}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Closes every bypass found in a full audit of access to the SDK/repo/courses:

| Surface | Before | After |
|---|---|---|
| TopNav GitHub icon (desktop+mobile) | direct repo link | opens Start Now gate |
| TopNav Docs menu | direct repo link | routes to gated /get-started |
| Homepage footer "Try out our SDK" | direct repo link | opens Start Now gate |
| /pitch + /pitch-full Get-Started slides (incl. recipient decks) | full install command printed | teaser button → Start Now gate |
| Academy courses | gated, but 1h notify throttle | 24h throttle + form-id fallback hardening |

Verified already compliant: Start Now modal, /get-started, Portal gate, Knob Explorer. All gates notify via HubSpot form submissions; known contacts auto-unlock + notify (24h throttle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)