### PR TITLE
Access & Evaluation Agreement clickwrap (StartNow / Portal / Academy)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,7 @@ import OptimizationDemo from './pages/OptimizationDemo'
 import StoryMovie from './pages/StoryMovie'
 import DemoGallery from './pages/DemoGallery'
 import RecipientPackagePage from './pages/RecipientPackagePage'
+import AccessAgreement from './pages/AccessAgreement'
 import RecipientPackageBlankPage from './pages/RecipientPackageBlankPage'
 import Layout from './layout'
 import ExternalRedirect from './components/ExternalRedirect'
@@ -106,6 +107,7 @@ export default function App() {
         <Route path="academy" element={<AcademyIndex />} />
         <Route path="academy/agents-in-production" element={<AgentsInProduction />} />
         <Route path="academy/statistical-se-workshop" element={<StatisticalSEWorkshop />} />
+        <Route path="access-agreement" element={<AccessAgreement />} />
       </Route>
 
       {/* Category-free recipient package route. Kept LAST so every static

--- a/src/components/AgreementCheckbox.jsx
+++ b/src/components/AgreementCheckbox.jsx
@@ -1,0 +1,39 @@
+/* eslint-disable react/prop-types */
+import { AGREEMENT_PATH, AGREEMENT_VERSION } from "../lib/accessAgreement";
+
+/**
+ * Required acceptance checkbox for the Access & Evaluation Agreement —
+ * the IP/no-compete layer shown alongside the GDPR consent checkbox on
+ * every gated surface (Start Now / SDK, Portal, Academy). Controlled:
+ * the parent gates form-mount / submit on `checked`.
+ */
+export default function AgreementCheckbox({ checked, onChange, id = "traigent-agreement-checkbox" }) {
+  return (
+    <label
+      htmlFor={id}
+      className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-slate-700/60 bg-slate-950/40 p-3 text-sm leading-relaxed text-slate-300 transition-colors hover:border-slate-600"
+    >
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        required
+        className="mt-0.5 h-4 w-4 shrink-0 rounded border-slate-600 bg-slate-900 text-[#1A6BF5] focus:ring-1 focus:ring-[#4D8EF8]"
+      />
+      <span>
+        I have read and agree to the{" "}
+        <a
+          href={`/#${AGREEMENT_PATH}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="text-blue-300 underline underline-offset-2 hover:text-blue-200"
+        >
+          Traigent Access &amp; Evaluation Agreement (v{AGREEMENT_VERSION})
+        </a>
+        , including its confidentiality and no-competing-use terms.
+      </span>
+    </label>
+  );
+}

--- a/src/components/AgreementGate.jsx
+++ b/src/components/AgreementGate.jsx
@@ -1,0 +1,55 @@
+/* eslint-disable react/prop-types */
+import { useState } from "react";
+import { FileCheck2 } from "lucide-react";
+import AgreementCheckbox from "./AgreementCheckbox";
+import { markAccepted, AGREEMENT_VERSION } from "../lib/accessAgreement";
+import { notifyAgreementAccepted } from "../lib/hubspotForms";
+import { trackEvent } from "../lib/analytics";
+
+/**
+ * Agreement-only interstitial for visitors who are already email-unlocked
+ * (returning or auto-recognized contacts) but haven't accepted the current
+ * Access & Evaluation Agreement version. One checkbox + one button — they
+ * never re-enter their email.
+ */
+export default function AgreementGate({ email = "", surface = "unknown", onAccepted }) {
+  const [checked, setChecked] = useState(false);
+
+  const accept = () => {
+    markAccepted(email);
+    if (email) {
+      notifyAgreementAccepted({ email, location: surface, version: AGREEMENT_VERSION });
+    }
+    trackEvent("agreement_accepted", { surface, version: AGREEMENT_VERSION });
+    onAccepted();
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-3">
+        <FileCheck2 className="w-5 h-5" style={{ color: "#4D8EF8" }} />
+        <h3 className="text-xl font-bold text-white">One more step</h3>
+      </div>
+      <p className="text-slate-400 text-sm leading-relaxed mb-4">
+        Before accessing Traigent&apos;s materials, please review and accept the
+        Access &amp; Evaluation Agreement — it covers confidentiality and the
+        agreement not to use our materials to build competing products.
+      </p>
+      <div className="mb-4">
+        <AgreementCheckbox
+          id={`agreement-gate-${surface}`}
+          checked={checked}
+          onChange={setChecked}
+        />
+      </div>
+      <button
+        type="button"
+        disabled={!checked}
+        onClick={accept}
+        className="w-full bg-[#1A6BF5] hover:bg-[#4D8EF8] disabled:opacity-60 disabled:cursor-not-allowed text-white px-5 py-3 rounded-lg font-medium transition-colors"
+      >
+        Agree &amp; continue
+      </button>
+    </div>
+  );
+}

--- a/src/components/PortalGateModal.jsx
+++ b/src/components/PortalGateModal.jsx
@@ -10,9 +10,12 @@ import {
   getUnlockedEmail,
   shouldNotifyForGate,
 } from "../lib/startNowGate";
-import { notifyPortalRepeat, PORTAL_FORM_ID } from "../lib/hubspotForms";
+import { notifyPortalRepeat, notifyAgreementAccepted, PORTAL_FORM_ID } from "../lib/hubspotForms";
 import { checkKnownContact } from "../lib/hubspotIdentify";
 import { trackEvent } from "../lib/analytics";
+import { hasAcceptedCurrent, markAccepted, AGREEMENT_VERSION } from "../lib/accessAgreement";
+import AgreementCheckbox from "./AgreementCheckbox";
+import AgreementGate from "./AgreementGate";
 
 const PORTAL_URL = "https://portal.traigent.ai";
 
@@ -32,6 +35,7 @@ const PORTAL_URL = "https://portal.traigent.ai";
  */
 export default function PortalGateModal({ onClose, location = "unknown" }) {
   const [unlocked, setUnlocked] = useState(() => isUnlocked());
+  const [accepted, setAccepted] = useState(() => hasAcceptedCurrent());
   const [checkingIdentity, setCheckingIdentity] = useState(() => !isUnlocked());
 
   useEffect(() => {
@@ -78,6 +82,10 @@ export default function PortalGateModal({ onClose, location = "unknown" }) {
 
   const handleSubmitted = (email) => {
     markUnlocked(email);
+    // The agreement checkbox is required before the form mounts — record it.
+    markAccepted(email);
+    if (email) notifyAgreementAccepted({ email, location: `portal_${location}`, version: AGREEMENT_VERSION });
+    setAccepted(true);
     setUnlocked(true);
     trackEvent("portal_form_submitted", { location });
   };
@@ -112,7 +120,15 @@ export default function PortalGateModal({ onClose, location = "unknown" }) {
         {checkingIdentity ? (
           <CheckingView />
         ) : unlocked ? (
-          <UnlockedView onOpenPortal={handleOpenPortal} />
+          accepted ? (
+            <UnlockedView onOpenPortal={handleOpenPortal} />
+          ) : (
+            <AgreementGate
+              email={getUnlockedEmail()}
+              surface={`portal_${location}`}
+              onAccepted={() => setAccepted(true)}
+            />
+          )
         ) : (
           <LockedView onSubmitted={handleSubmitted} />
         )}
@@ -134,6 +150,7 @@ function CheckingView() {
 
 function LockedView({ onSubmitted }) {
   const [agreed, setAgreed] = useState(false);
+  const [agreedTerms, setAgreedTerms] = useState(false);
   return (
     <>
       <h2 id="portal-gate-title" className="text-2xl font-bold text-white mb-2">
@@ -144,14 +161,21 @@ function LockedView({ onSubmitted }) {
         submit.
       </p>
       <ConsentGate>
-        <div className="mb-4">
+        <div className="mb-3">
           <ConsentCheckbox
             id="portal-gate-consent"
             checked={agreed}
             onChange={setAgreed}
           />
         </div>
-        {agreed ? (
+        <div className="mb-4">
+          <AgreementCheckbox
+            id="portal-gate-agreement"
+            checked={agreedTerms}
+            onChange={setAgreedTerms}
+          />
+        </div>
+        {agreed && agreedTerms ? (
           <HubSpotStartNowForm
             formId={PORTAL_FORM_ID}
             onSuccess={onSubmitted}
@@ -159,7 +183,7 @@ function LockedView({ onSubmitted }) {
           />
         ) : (
           <p className="text-xs text-slate-500">
-            Tick the box above to load the form.
+            Tick both boxes above to load the form.
           </p>
         )}
       </ConsentGate>

--- a/src/components/StartNowModal.jsx
+++ b/src/components/StartNowModal.jsx
@@ -11,9 +11,12 @@ import {
   getUnlockedEmail,
   shouldNotifyForGate,
 } from "../lib/startNowGate";
-import { notifyStartNowRepeat } from "../lib/hubspotForms";
+import { notifyStartNowRepeat, notifyAgreementAccepted } from "../lib/hubspotForms";
 import { checkKnownContact } from "../lib/hubspotIdentify";
 import { trackEvent } from "../lib/analytics";
+import { hasAcceptedCurrent, markAccepted, AGREEMENT_VERSION } from "../lib/accessAgreement";
+import AgreementCheckbox from "./AgreementCheckbox";
+import AgreementGate from "./AgreementGate";
 
 /**
  * Two-state modal:
@@ -28,6 +31,8 @@ import { trackEvent } from "../lib/analytics";
 export default function StartNowModal({ onClose, location = "unknown" }) {
   // Initialize from localStorage so repeat visitors skip the form.
   const [unlocked, setUnlocked] = useState(() => isUnlocked());
+  // Access & Evaluation Agreement acceptance (versioned; re-prompts on bump).
+  const [accepted, setAccepted] = useState(() => hasAcceptedCurrent());
   // Briefly check whether the hubspotutk cookie maps to a known HubSpot
   // contact (Contact Us submitter, meeting booker, BCC'd lead, etc.). If
   // it does, auto-unlock without showing the form.
@@ -84,6 +89,11 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
 
   const handleSubmitted = (email) => {
     markUnlocked(email);
+    // The agreement checkbox is required before the form mounts, so the
+    // submission itself evidences acceptance — record it.
+    markAccepted(email);
+    if (email) notifyAgreementAccepted({ email, location, version: AGREEMENT_VERSION });
+    setAccepted(true);
     setUnlocked(true);
     trackEvent("start_now_form_submitted", { location });
   };
@@ -112,7 +122,15 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
         {checkingIdentity ? (
           <CheckingView />
         ) : unlocked ? (
-          <UnlockedView />
+          accepted ? (
+            <UnlockedView />
+          ) : (
+            <AgreementGate
+              email={getUnlockedEmail()}
+              surface={`start_now_${location}`}
+              onAccepted={() => setAccepted(true)}
+            />
+          )
         ) : (
           <LockedView onSubmitted={handleSubmitted} />
         )}
@@ -134,6 +152,7 @@ function CheckingView() {
 
 function LockedView({ onSubmitted }) {
   const [agreed, setAgreed] = useState(false);
+  const [agreedTerms, setAgreedTerms] = useState(false);
   return (
     <>
       <h2 id="start-now-title" className="text-2xl font-bold text-white mb-2">
@@ -144,18 +163,25 @@ function LockedView({ onSubmitted }) {
         send setup tips — the install command unlocks as soon as you submit.
       </p>
       <ConsentGate>
-        <div className="mb-4">
+        <div className="mb-3">
           <ConsentCheckbox
             id="start-now-consent"
             checked={agreed}
             onChange={setAgreed}
           />
         </div>
-        {agreed ? (
+        <div className="mb-4">
+          <AgreementCheckbox
+            id="start-now-agreement"
+            checked={agreedTerms}
+            onChange={setAgreedTerms}
+          />
+        </div>
+        {agreed && agreedTerms ? (
           <HubSpotStartNowForm onSuccess={onSubmitted} />
         ) : (
           <p className="text-xs text-slate-500">
-            Tick the box above to load the form.
+            Tick both boxes above to load the form.
           </p>
         )}
       </ConsentGate>

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -13,6 +13,7 @@ import {
   shouldNotifyForGate,
 } from "../lib/startNowGate";
 import { notifyPortalRepeat } from "../lib/hubspotForms";
+import { hasAcceptedCurrent } from "../lib/accessAgreement";
 import { checkKnownContact } from "../lib/hubspotIdentify";
 
 const PORTAL_URL = "https://portal.traigent.ai";
@@ -219,7 +220,10 @@ export default function TopNav() {
   // The Worker check is cached for 1h in localStorage so repeat clicks are
   // instant after the first.
   const handleOpenPortal = async (loc) => {
-    if (isUnlocked()) {
+    // Direct open requires BOTH an email unlock AND acceptance of the
+    // current Access & Evaluation Agreement; otherwise the gate modal
+    // handles whichever step is missing.
+    if (isUnlocked() && hasAcceptedCurrent()) {
       const email = getUnlockedEmail();
       if (email && shouldNotifyForGate("portal")) {
         notifyPortalRepeat({ email, location: loc });
@@ -228,14 +232,19 @@ export default function TopNav() {
       window.open(PORTAL_URL, "_blank", "noopener,noreferrer");
       return;
     }
-    const result = await checkKnownContact();
-    if (result && result.known && result.email) {
-      markUnlocked(result.email);
-      if (shouldNotifyForGate("portal")) notifyPortalRepeat({ email: result.email, location: loc });
-      trackEvent("portal_opened", { location: loc });
-      trackEvent("portal_auto_unlocked", { location: loc });
-      window.open(PORTAL_URL, "_blank", "noopener,noreferrer");
-      return;
+    if (!isUnlocked()) {
+      const result = await checkKnownContact();
+      if (result && result.known && result.email) {
+        markUnlocked(result.email);
+        if (shouldNotifyForGate("portal")) notifyPortalRepeat({ email: result.email, location: loc });
+        trackEvent("portal_auto_unlocked", { location: loc });
+        // Fall through to the gate modal if the agreement is still pending.
+        if (hasAcceptedCurrent()) {
+          trackEvent("portal_opened", { location: loc });
+          window.open(PORTAL_URL, "_blank", "noopener,noreferrer");
+          return;
+        }
+      }
     }
     trackEvent("portal_clicked_gated", { location: loc });
     setShowPortalGate(true);

--- a/src/components/academy/AcademyEmailGate.jsx
+++ b/src/components/academy/AcademyEmailGate.jsx
@@ -3,6 +3,9 @@ import { trackEvent } from "../../lib/analytics";
 import { checkKnownContact } from "../../lib/hubspotIdentify";
 import ConsentGate from "../ConsentGate";
 import ConsentCheckbox from "../ConsentCheckbox";
+import AgreementCheckbox from "../AgreementCheckbox";
+import AgreementGate from "../AgreementGate";
+import { hasAcceptedCurrent, markAccepted, AGREEMENT_VERSION } from "../../lib/accessAgreement";
 
 // One notification per visitor per course per 24h. Matches the global
 // gate's throttle window so the inbox volume stays sane in prod.
@@ -138,6 +141,8 @@ const STARTNOW_FALLBACK_FORM_ID = "35384a3e-7386-45b0-924e-84e5d6f637e4";
 export default function AcademyEmailGate({ courseSlug, courseTitle, formId, children }) {
   const effectiveFormId = formId || ACADEMY_FORM_ID || STARTNOW_FALLBACK_FORM_ID;
   const [unlocked, setUnlocked] = useState(() => !!readUnlockEntry(courseSlug));
+  // Access & Evaluation Agreement acceptance (site-wide, versioned).
+  const [acceptedAgreement, setAcceptedAgreement] = useState(() => hasAcceptedCurrent());
 
   // When an already-unlocked visitor reopens a course, silently re-submit
   // their stored email to HubSpot — gives the founder a notification that
@@ -192,10 +197,28 @@ export default function AcademyEmailGate({ courseSlug, courseTitle, formId, chil
   }, []);
   const [email, setEmail] = useState("");
   const [agreed, setAgreed] = useState(false);
+  const [agreedTerms, setAgreedTerms] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
 
-  if (unlocked) return <>{children}</>;
+  if (unlocked && acceptedAgreement) return <>{children}</>;
+
+  // Email-unlocked (returning / auto-recognized) but the current agreement
+  // version hasn't been accepted yet — agreement-only step, no email re-entry.
+  if (unlocked && !acceptedAgreement) {
+    const entry = readUnlockEntry(courseSlug);
+    return (
+      <div className="max-w-2xl mx-auto py-12">
+        <div className="bg-slate-900/60 border border-slate-800 rounded-2xl p-8 md:p-10">
+          <AgreementGate
+            email={(entry && entry.email) || ""}
+            surface={`academy_${courseSlug}`}
+            onAccepted={() => setAcceptedAgreement(true)}
+          />
+        </div>
+      </div>
+    );
+  }
 
   // The form is always shown. If HubSpot env vars / form id are missing in
   // this environment, submissions will surface a friendly error via setError
@@ -211,7 +234,13 @@ export default function AcademyEmailGate({ courseSlug, courseTitle, formId, chil
       if (!isConfigured) {
         throw new Error("HubSpot form not configured");
       }
-      await submitToHubSpot({ email, courseTitle, formId: effectiveFormId });
+      // pageName carries the acceptance record: the agreement checkbox is
+      // required before submit, so this submission evidences acceptance.
+      await submitToHubSpot({
+        email,
+        courseTitle: `${courseTitle} · Access Agreement v${AGREEMENT_VERSION} accepted`,
+        formId: effectiveFormId,
+      });
       writeUnlockEntry(courseSlug, {
         email,
         ts: Date.now(),
@@ -219,6 +248,8 @@ export default function AcademyEmailGate({ courseSlug, courseTitle, formId, chil
         // useEffect doesn't immediately re-fire on the same render cycle.
         lastNotifiedTs: Date.now(),
       });
+      markAccepted(email);
+      setAcceptedAgreement(true);
       trackEvent("academy_email_submitted", { course: courseSlug });
       setUnlocked(true);
     } catch (err) {
@@ -265,9 +296,14 @@ export default function AcademyEmailGate({ courseSlug, courseTitle, formId, chil
               checked={agreed}
               onChange={setAgreed}
             />
+            <AgreementCheckbox
+              id={`academy-agreement-${courseSlug}`}
+              checked={agreedTerms}
+              onChange={setAgreedTerms}
+            />
             <button
               type="submit"
-              disabled={submitting || !email || !agreed}
+              disabled={submitting || !email || !agreed || !agreedTerms}
               className="w-full bg-[#1A6BF5] hover:bg-[#4D8EF8] disabled:opacity-60 disabled:cursor-not-allowed text-white px-5 py-3 rounded-lg font-medium transition-colors"
             >
               {submitting ? "Sending…" : "Send me the access link"}

--- a/src/lib/accessAgreement.js
+++ b/src/lib/accessAgreement.js
@@ -1,0 +1,40 @@
+// Access & Evaluation Agreement acceptance state.
+//
+// Every IP-gated surface (Start Now / SDK, Portal, Academy) requires the
+// visitor to accept the agreement at /access-agreement before entry — in
+// addition to leaving a business email. Acceptance is versioned: bumping
+// AGREEMENT_VERSION re-prompts every visitor on their next gate.
+//
+// Evidence trail: alongside this localStorage stamp, each acceptance fires a
+// HubSpot form submission (see notifyAgreementAccepted in hubspotForms.js)
+// whose pageName records the version + surface — a per-contact, timestamped
+// acceptance record on the CRM side.
+
+export const AGREEMENT_VERSION = "1.0";
+export const AGREEMENT_PATH = "/access-agreement";
+
+const STORAGE_KEY = "traigent_access_agreement";
+
+export function hasAcceptedCurrent() {
+  if (typeof window === "undefined") return false;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw);
+    return parsed && parsed.version === AGREEMENT_VERSION;
+  } catch {
+    return false;
+  }
+}
+
+export function markAccepted(email = "") {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ version: AGREEMENT_VERSION, email, ts: Date.now() }),
+    );
+  } catch {
+    /* private mode — soft-degrade; the gate will just re-prompt */
+  }
+}

--- a/src/lib/hubspotForms.js
+++ b/src/lib/hubspotForms.js
@@ -91,4 +91,18 @@ export function notifyPitchDeckViewed({ email, location }) {
   return notifyRepeatVisit({ email, formId: PITCH_DECK_FORM_ID, location, label: "Slide deck viewed" });
 }
 
+/**
+ * Acceptance-evidence record for the Access & Evaluation Agreement: fires a
+ * silent submission whose pageName carries the version + surface, giving the
+ * contact a timestamped acceptance entry in HubSpot.
+ */
+export function notifyAgreementAccepted({ email, location, version }) {
+  return notifyRepeatVisit({
+    email,
+    formId: STARTNOW_FORM_ID,
+    location,
+    label: `Access Agreement v${version} accepted`,
+  });
+}
+
 export { PORTAL_FORM_ID };

--- a/src/pages/AccessAgreement.jsx
+++ b/src/pages/AccessAgreement.jsx
@@ -1,0 +1,198 @@
+import { Helmet } from "react-helmet-async";
+import { AGREEMENT_VERSION } from "../lib/accessAgreement";
+
+/**
+ * The Access & Evaluation Agreement — the click-through IP/confidentiality
+ * agreement accepted on every gated surface (Start Now / SDK, Portal,
+ * Academy). The gates link here; acceptance is recorded per contact with
+ * version + timestamp. Bump AGREEMENT_VERSION in src/lib/accessAgreement.js
+ * when this text changes materially — every visitor is re-prompted.
+ */
+
+const H2 = ({ children }) => (
+  <h2 className="text-xl font-bold text-white mt-8 mb-3">{children}</h2>
+);
+const P = ({ children }) => (
+  <p className="text-slate-300 leading-relaxed mb-4">{children}</p>
+);
+
+export default function AccessAgreement() {
+  return (
+    <>
+      <Helmet>
+        <title>Access &amp; Evaluation Agreement · Traigent</title>
+        <meta
+          name="description"
+          content="The Traigent Access & Evaluation Agreement governing access to the Traigent Portal, Academy, and gated materials."
+        />
+      </Helmet>
+      <section className="bg-[#080808] text-white min-h-screen py-14 md:py-20">
+        <article className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h1 className="text-3xl md:text-4xl font-bold mb-2">
+            Traigent Access &amp; Evaluation Agreement
+          </h1>
+          <p className="text-sm text-slate-500 mb-8 font-mono">
+            Version {AGREEMENT_VERSION} · Effective upon acceptance · Last updated June 13, 2026
+          </p>
+
+          <P>
+            <strong className="text-white">IMPORTANT — READ BEFORE PROCEEDING.</strong>{" "}
+            By checking the acceptance box and continuing, you (&quot;<strong className="text-white">You</strong>&quot;)
+            enter into this binding agreement with <strong className="text-white">Traigent Ltd.</strong>{" "}
+            (&quot;<strong className="text-white">Traigent</strong>&quot;, &quot;we&quot;). If you are accessing on
+            behalf of a company, you represent that you are authorized to bind that company, and
+            &quot;You&quot; includes it. If you do not agree, do not proceed.
+          </P>
+
+          <H2>1. What this covers (&quot;Materials&quot;)</H2>
+          <P>
+            &quot;<strong className="text-white">Materials</strong>&quot; means everything Traigent makes
+            available through its gated surfaces: the Traigent Portal and its features, outputs, and
+            interfaces; Traigent Academy courses and workshop content; demos, videos, slides,
+            documentation, datasets, benchmarks, prompts, configuration spaces, evaluation
+            methodologies, and quickstart resources; access links, credentials, and access codes; and
+            any non-public information disclosed to You.
+          </P>
+          <P>
+            <strong className="text-white">Open-source carve-out.</strong> Components of the Traigent
+            SDK published under an open-source license (e.g., AGPL-3.0) are governed solely by that
+            license, and nothing in this Agreement limits the rights that license grants You for those
+            components. This Agreement governs everything else.
+          </P>
+
+          <H2>2. Your license</H2>
+          <P>
+            Traigent grants You a <strong className="text-white">limited, personal, non-exclusive,
+            non-transferable, revocable</strong> right to access and use the Materials solely for
+            (a) evaluating Traigent&apos;s products and services for Your internal business purposes,
+            and (b) Your own learning through Traigent Academy. No other rights are granted. All
+            right, title, and interest in the Materials — including all intellectual-property rights —
+            remain exclusively with Traigent. You acknowledge the Materials embody Traigent&apos;s
+            valuable proprietary technology and trade secrets.
+          </P>
+
+          <H2>3. What You agree not to do</H2>
+          <P>
+            Except as expressly permitted in Section 2 or by an applicable open-source license, You
+            will not, and will not permit anyone else to:
+          </P>
+          <ol className="list-decimal list-outside ml-6 space-y-3 text-slate-300 leading-relaxed mb-4">
+            <li>
+              <strong className="text-white">Share or disclose</strong> the Materials, access links,
+              credentials, or access codes with or to any third party (access is individual;
+              colleagues should register themselves);
+            </li>
+            <li>
+              <strong className="text-white">Copy, republish, or redistribute</strong> the Materials,
+              in whole or part, in any medium;
+            </li>
+            <li>
+              <strong className="text-white">Reverse engineer, decompile, or disassemble</strong> any
+              non-open-source software, service, or model made available to You, or attempt to derive
+              its source code, architecture, prompts, weights, scoring logic, or underlying methods,
+              except to the extent this restriction is prohibited by applicable law;
+            </li>
+            <li>
+              <strong className="text-white">Build, train, or improve a competing product or
+              service</strong> using the Materials — including, without limitation, by (i) using the
+              Materials as specifications, prompts, context, or reference for any software
+              development, (ii) <strong className="text-white">providing any Materials to an AI
+              system, LLM, or coding assistant</strong> to generate, assist, or accelerate the
+              development of functionality that competes with Traigent, or (iii) using the Materials
+              to train, fine-tune, or evaluate any machine-learning model;
+            </li>
+            <li>
+              <strong className="text-white">Scrape, crawl, or systematically extract</strong> content
+              or data from the Portal, Academy, or any gated surface, whether manually or by automated
+              means;
+            </li>
+            <li>
+              <strong className="text-white">Benchmark or publish performance comparisons</strong> of
+              the Portal or Traigent services without Traigent&apos;s prior written consent;
+            </li>
+            <li>
+              <strong className="text-white">Circumvent</strong> any access control, gate, code, or
+              technical protection, or access another user&apos;s account or materials;
+            </li>
+            <li>
+              <strong className="text-white">Misrepresent</strong> Your identity, employer, or email
+              address when registering for access.
+            </li>
+          </ol>
+
+          <H2>4. Confidentiality</H2>
+          <P>
+            Materials that are not publicly available are Traigent&apos;s{" "}
+            <strong className="text-white">Confidential Information</strong>. You will protect them
+            with at least the care You use for Your own confidential information (and no less than
+            reasonable care), use them only as permitted here, and not disclose them to anyone except
+            Your employees or advisors who need them for the permitted purpose and are bound by
+            obligations at least as protective. These obligations continue for five (5) years from
+            disclosure; for trade secrets, for as long as they remain trade secrets.
+          </P>
+
+          <H2>5. Access codes and accounts</H2>
+          <P>
+            Access codes and links are generated for, and personal to, the business email You
+            register. You are responsible for activity under Your access. Traigent may revoke,
+            suspend, or condition access at any time, with or without notice, including for suspected
+            breach.
+          </P>
+
+          <H2>6. Feedback</H2>
+          <P>
+            If You give Traigent feedback, suggestions, or ideas, Traigent may use them freely and
+            without obligation; You grant Traigent a perpetual, irrevocable, royalty-free license to
+            do so.
+          </P>
+
+          <H2>7. No warranty</H2>
+          <P>
+            The Materials are provided &quot;<strong className="text-white">AS IS</strong>&quot; for
+            evaluation and education. Traigent disclaims all warranties, express or implied, including
+            merchantability, fitness for a particular purpose, and non-infringement. The Materials may
+            change or be withdrawn at any time.
+          </P>
+
+          <H2>8. Remedies; liability</H2>
+          <P>
+            You acknowledge that breach of Sections 3–5 would cause Traigent{" "}
+            <strong className="text-white">irreparable harm</strong> for which damages are inadequate,
+            and that Traigent is entitled to <strong className="text-white">injunctive relief</strong>{" "}
+            (without posting bond) in addition to all other remedies. Except for Your breach of
+            Sections 3–5 or liability that cannot be limited by law, neither party&apos;s aggregate
+            liability under this Agreement will exceed US $1,000, and neither party is liable for
+            indirect, incidental, special, or consequential damages.
+          </P>
+
+          <H2>9. Term; survival</H2>
+          <P>
+            This Agreement applies from Your acceptance and continues until terminated by either party
+            (You, by ceasing all access and deleting retained Materials; Traigent, by notice or access
+            revocation). Sections 3, 4, 6, 7, 8, 10, and 11 survive termination.
+          </P>
+
+          <H2>10. Governing law; disputes</H2>
+          <P>
+            This Agreement is governed by the laws of the State of Israel, without regard to
+            conflict-of-law rules, and the courts of Tel Aviv have exclusive jurisdiction.
+          </P>
+
+          <H2>11. General</H2>
+          <P>
+            This is the entire agreement regarding gated access and supersedes prior discussions on
+            that subject; it does not replace any separately signed agreement between You and Traigent
+            (which prevails if conflicting). Traigent may update this Agreement prospectively by
+            presenting a new version for acceptance; the version You accepted governs the access made
+            under it. You may not assign this Agreement. If a provision is unenforceable, the
+            remainder stands. Notices to Traigent:{" "}
+            <a href="mailto:amir@traigent.ai" className="text-blue-300 underline underline-offset-2">
+              amir@traigent.ai
+            </a>
+            .
+          </P>
+        </article>
+      </section>
+    </>
+  );
+}

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -11,9 +11,12 @@ import {
   getUnlockedEmail,
   shouldNotifyForGate,
 } from "../lib/startNowGate";
-import { notifyStartNowRepeat } from "../lib/hubspotForms";
+import { notifyStartNowRepeat, notifyAgreementAccepted } from "../lib/hubspotForms";
 import { checkKnownContact } from "../lib/hubspotIdentify";
 import { trackEvent } from "../lib/analytics";
+import { hasAcceptedCurrent, markAccepted, AGREEMENT_VERSION } from "../lib/accessAgreement";
+import AgreementCheckbox from "../components/AgreementCheckbox";
+import AgreementGate from "../components/AgreementGate";
 
 const createPageUrl = (path) => path;
 const { installPresets, goals: AGENT_GOALS } = skillOnboarding;
@@ -57,6 +60,9 @@ export default function GetStarted() {
   // Same 90-day localStorage memory as the Start Now modal so a visitor
   // who unlocked there doesn't see the form again here, and vice versa.
   const [unlocked, setUnlocked] = useState(() => isUnlocked());
+  // Access & Evaluation Agreement acceptance (site-wide, versioned).
+  const [accepted, setAccepted] = useState(() => hasAcceptedCurrent());
+  const [agreedTerms, setAgreedTerms] = useState(false);
   const [selectedGoalIds, setSelectedGoalIds] = useState(DEFAULT_AGENT_GOAL_IDS);
   const [copiedPrompt, setCopiedPrompt] = useState(false);
 
@@ -90,6 +96,10 @@ export default function GetStarted() {
 
   const handleSubmitted = (email) => {
     markUnlocked(email);
+    // The agreement checkbox is required before the form mounts — record it.
+    markAccepted(email);
+    if (email) notifyAgreementAccepted({ email, location: "get_started_page", version: AGREEMENT_VERSION });
+    setAccepted(true);
     setUnlocked(true);
     trackEvent("start_now_form_submitted", { location: "get_started_page" });
   };
@@ -157,7 +167,29 @@ export default function GetStarted() {
               email you more than once a month, and you can unsubscribe with one
               click.
             </p>
-            <HubSpotStartNowForm onSuccess={handleSubmitted} targetId="hs-form-getstarted" />
+            <div className="mb-4 max-w-3xl">
+              <AgreementCheckbox
+                id="get-started-agreement"
+                checked={agreedTerms}
+                onChange={setAgreedTerms}
+              />
+            </div>
+            {agreedTerms ? (
+              <HubSpotStartNowForm onSuccess={handleSubmitted} targetId="hs-form-getstarted" />
+            ) : (
+              <p className="text-xs text-slate-500">
+                Accept the agreement above to load the form.
+              </p>
+            )}
+          </div>
+        )}
+        {unlocked && !accepted && (
+          <div className="mb-10 p-6 rounded-xl bg-slate-900/60 border border-slate-800 max-w-2xl">
+            <AgreementGate
+              email={getUnlockedEmail()}
+              surface="get_started_page"
+              onAccepted={() => setAccepted(true)}
+            />
           </div>
         )}
 
@@ -185,7 +217,7 @@ export default function GetStarted() {
             <p className="text-slate-300 mb-4">
               Install the published Python SDK from your terminal. The bootstrap is a thin shell script that installs <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent[recommended]</code>, verifies <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent info</code>, refuses root/container installs unless <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">TRAIGENT_ALLOW_ROOT=1</code> is explicitly set, and never prompts for or reads credentials. The installer detects <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent onboard</code> (included in the published SDK) and suggests it next — it sets up device login against <a href="https://portal.traigent.ai" target="_blank" rel="noopener noreferrer" className="text-blue-300 hover:text-blue-200 underline underline-offset-4">portal.traigent.ai</a> and your coding agent.
             </p>
-            {unlocked && (
+            {unlocked && accepted && (
               <>
                 <InstallCommand
                   command={TERMINAL_INSTALL_COMMAND}
@@ -252,7 +284,7 @@ export default function GetStarted() {
           <p className="text-slate-300 mb-4 max-w-3xl">
             Claude Code, Cursor, Codex, Gemini CLI and 30+ other agents pick up the Traigent skill bundle automatically. They&apos;ll guide you through dry-run-first setup, generate the eval dataset, and apply the best config — without you leaving your editor. Coding agent? Point it at <a href="/agent.md" className="text-blue-300 hover:text-blue-200 underline underline-offset-4">traigent.ai/agent.md</a>.
           </p>
-          {unlocked && (
+          {unlocked && accepted && (
             <InstallCommand
               command={SDK_SKILL_INSTALL_PRESET.command}
               label={SDK_SKILL_INSTALL_PRESET.label}


### PR DESCRIPTION
Adds the versioned IP/confidentiality click-through agreement in front of the three gated surfaces, on top of the business-email gate:

- **/access-agreement** — the agreement text (v1.0): IP ownership, confidentiality (5y), no reverse engineering, **no competing-product development including via AI/LLM coding assistants**, personal access codes, injunctive relief, AGPL carve-out for the open-source SDK.
- **Required agreement checkbox** on StartNow modal, Portal gate, both Academy gates, and /get-started — forms don't mount/submit without it.
- **AgreementGate interstitial** for already-unlocked visitors (returning/auto-recognized) who haven't accepted the current version — one checkbox, no email re-entry. Portal's TopNav fast-path also requires acceptance.
- **Acceptance evidence**: localStorage version stamp + per-contact HubSpot submission ("Access Agreement v1.0 accepted" + surface). Bumping `AGREEMENT_VERSION` re-prompts every visitor.

Text is founder-approved draft pending counsel review; revisions ship via a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)