### PR TITLE
Agreement v1.1 (personal capacity, own-PC) — Start Now scope only

### DIFF
--- a/src/components/AgreementText.jsx
+++ b/src/components/AgreementText.jsx
@@ -29,9 +29,10 @@ export default function AgreementText({ compact = false }) {
         <strong className="text-white">IMPORTANT — READ BEFORE PROCEEDING.</strong>{" "}
         By checking the acceptance box and continuing, you (&quot;<strong className="text-white">You</strong>&quot;)
         enter into this binding agreement with <strong className="text-white">Traigent Ltd.</strong>{" "}
-        (&quot;<strong className="text-white">Traigent</strong>&quot;, &quot;we&quot;). If you are accessing on
-        behalf of a company, you represent that you are authorized to bind that company, and
-        &quot;You&quot; includes it. If you do not agree, do not proceed.
+        (&quot;<strong className="text-white">Traigent</strong>&quot;, &quot;we&quot;).{" "}
+        <strong className="text-white">You accept this Agreement in Your personal, individual
+        capacity</strong>: it binds You personally, and access is granted to You alone — not to
+        Your employer or any other person or company. If you do not agree, do not proceed.
       </p>
 
       <h2 className={h}>1. What this covers (&quot;Materials&quot;)</h2>
@@ -54,11 +55,15 @@ export default function AgreementText({ compact = false }) {
       <p className={p}>
         Traigent grants You a <strong className="text-white">limited, personal, non-exclusive,
         non-transferable, revocable</strong> right to access and use the Materials solely for
-        (a) evaluating Traigent&apos;s products and services for Your internal business purposes,
-        and (b) Your own learning through Traigent Academy. No other rights are granted. All
-        right, title, and interest in the Materials — including all intellectual-property rights —
-        remain exclusively with Traigent. You acknowledge the Materials embody Traigent&apos;s
-        valuable proprietary technology and trade secrets.
+        (a) Your own evaluation of Traigent&apos;s products and services, and (b) Your own
+        learning through Traigent Academy — in each case{" "}
+        <strong className="text-white">by You alone, on a personal computer under Your sole
+        control</strong>. Your access may not be shared with, transferred to, or exercised on
+        behalf of anyone else, and the Materials may not be placed on shared, public, or
+        third-party systems. No other rights are granted. All right, title, and interest in the
+        Materials — including all intellectual-property rights — remain exclusively with Traigent.
+        You acknowledge the Materials embody Traigent&apos;s valuable proprietary technology and
+        trade secrets.
       </p>
 
       <h2 className={h}>3. What You agree not to do</h2>
@@ -69,8 +74,9 @@ export default function AgreementText({ compact = false }) {
       <ol className={ol}>
         <li>
           <strong className="text-white">Share or disclose</strong> the Materials, access links,
-          credentials, or access codes with or to any third party (access is individual;
-          colleagues should register themselves);
+          credentials, or access codes with or to <strong className="text-white">anyone
+          else</strong> — colleagues, employers, or any third party (access is strictly
+          individual; each person must register and accept this Agreement themselves);
         </li>
         <li>
           <strong className="text-white">Copy, republish, or redistribute</strong> the Materials,
@@ -115,18 +121,19 @@ export default function AgreementText({ compact = false }) {
         Materials that are not publicly available are Traigent&apos;s{" "}
         <strong className="text-white">Confidential Information</strong>. You will protect them
         with at least the care You use for Your own confidential information (and no less than
-        reasonable care), use them only as permitted here, and not disclose them to anyone except
-        Your employees or advisors who need them for the permitted purpose and are bound by
-        obligations at least as protective. These obligations continue for five (5) years from
-        disclosure; for trade secrets, for as long as they remain trade secrets.
+        reasonable care), use them only as permitted here, and{" "}
+        <strong className="text-white">not disclose them to anyone</strong>. These obligations
+        continue for five (5) years from disclosure; for trade secrets, for as long as they
+        remain trade secrets.
       </p>
 
       <h2 className={h}>5. Access codes and accounts</h2>
       <p className={p}>
         Access codes and links are generated for, and personal to, the business email You
-        register. You are responsible for activity under Your access. Traigent may revoke,
-        suspend, or condition access at any time, with or without notice, including for suspected
-        breach.
+        register, and may be used <strong className="text-white">only by You, on Your own
+        computer</strong>. You are responsible for activity under Your access. Traigent may
+        revoke, suspend, or condition access at any time, with or without notice, including for
+        suspected breach.
       </p>
 
       <h2 className={h}>6. Feedback</h2>

--- a/src/components/PortalGateModal.jsx
+++ b/src/components/PortalGateModal.jsx
@@ -10,12 +10,9 @@ import {
   getUnlockedEmail,
   shouldNotifyForGate,
 } from "../lib/startNowGate";
-import { notifyPortalRepeat, notifyAgreementAccepted, PORTAL_FORM_ID } from "../lib/hubspotForms";
+import { notifyPortalRepeat, PORTAL_FORM_ID } from "../lib/hubspotForms";
 import { checkKnownContact } from "../lib/hubspotIdentify";
 import { trackEvent } from "../lib/analytics";
-import { hasAcceptedCurrent, markAccepted, AGREEMENT_VERSION } from "../lib/accessAgreement";
-import AgreementCheckbox from "./AgreementCheckbox";
-import AgreementGate from "./AgreementGate";
 
 const PORTAL_URL = "https://portal.traigent.ai";
 
@@ -35,7 +32,6 @@ const PORTAL_URL = "https://portal.traigent.ai";
  */
 export default function PortalGateModal({ onClose, location = "unknown" }) {
   const [unlocked, setUnlocked] = useState(() => isUnlocked());
-  const [accepted, setAccepted] = useState(() => hasAcceptedCurrent());
   const [checkingIdentity, setCheckingIdentity] = useState(() => !isUnlocked());
 
   useEffect(() => {
@@ -82,10 +78,6 @@ export default function PortalGateModal({ onClose, location = "unknown" }) {
 
   const handleSubmitted = (email) => {
     markUnlocked(email);
-    // The agreement checkbox is required before the form mounts — record it.
-    markAccepted(email);
-    if (email) notifyAgreementAccepted({ email, location: `portal_${location}`, version: AGREEMENT_VERSION });
-    setAccepted(true);
     setUnlocked(true);
     trackEvent("portal_form_submitted", { location });
   };
@@ -120,15 +112,7 @@ export default function PortalGateModal({ onClose, location = "unknown" }) {
         {checkingIdentity ? (
           <CheckingView />
         ) : unlocked ? (
-          accepted ? (
-            <UnlockedView onOpenPortal={handleOpenPortal} />
-          ) : (
-            <AgreementGate
-              email={getUnlockedEmail()}
-              surface={`portal_${location}`}
-              onAccepted={() => setAccepted(true)}
-            />
-          )
+          <UnlockedView onOpenPortal={handleOpenPortal} />
         ) : (
           <LockedView onSubmitted={handleSubmitted} />
         )}
@@ -150,7 +134,6 @@ function CheckingView() {
 
 function LockedView({ onSubmitted }) {
   const [agreed, setAgreed] = useState(false);
-  const [agreedTerms, setAgreedTerms] = useState(false);
   return (
     <>
       <h2 id="portal-gate-title" className="text-2xl font-bold text-white mb-2">
@@ -161,21 +144,14 @@ function LockedView({ onSubmitted }) {
         submit.
       </p>
       <ConsentGate>
-        <div className="mb-3">
+        <div className="mb-4">
           <ConsentCheckbox
             id="portal-gate-consent"
             checked={agreed}
             onChange={setAgreed}
           />
         </div>
-        <div className="mb-4">
-          <AgreementCheckbox
-            id="portal-gate-agreement"
-            checked={agreedTerms}
-            onChange={setAgreedTerms}
-          />
-        </div>
-        {agreed && agreedTerms ? (
+        {agreed ? (
           <HubSpotStartNowForm
             formId={PORTAL_FORM_ID}
             onSuccess={onSubmitted}
@@ -183,7 +159,7 @@ function LockedView({ onSubmitted }) {
           />
         ) : (
           <p className="text-xs text-slate-500">
-            Tick both boxes above to load the form.
+            Tick the box above to load the form.
           </p>
         )}
       </ConsentGate>

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -13,7 +13,6 @@ import {
   shouldNotifyForGate,
 } from "../lib/startNowGate";
 import { notifyPortalRepeat } from "../lib/hubspotForms";
-import { hasAcceptedCurrent } from "../lib/accessAgreement";
 import { checkKnownContact } from "../lib/hubspotIdentify";
 
 const PORTAL_URL = "https://portal.traigent.ai";
@@ -220,10 +219,7 @@ export default function TopNav() {
   // The Worker check is cached for 1h in localStorage so repeat clicks are
   // instant after the first.
   const handleOpenPortal = async (loc) => {
-    // Direct open requires BOTH an email unlock AND acceptance of the
-    // current Access & Evaluation Agreement; otherwise the gate modal
-    // handles whichever step is missing.
-    if (isUnlocked() && hasAcceptedCurrent()) {
+    if (isUnlocked()) {
       const email = getUnlockedEmail();
       if (email && shouldNotifyForGate("portal")) {
         notifyPortalRepeat({ email, location: loc });
@@ -232,19 +228,14 @@ export default function TopNav() {
       window.open(PORTAL_URL, "_blank", "noopener,noreferrer");
       return;
     }
-    if (!isUnlocked()) {
-      const result = await checkKnownContact();
-      if (result && result.known && result.email) {
-        markUnlocked(result.email);
-        if (shouldNotifyForGate("portal")) notifyPortalRepeat({ email: result.email, location: loc });
-        trackEvent("portal_auto_unlocked", { location: loc });
-        // Fall through to the gate modal if the agreement is still pending.
-        if (hasAcceptedCurrent()) {
-          trackEvent("portal_opened", { location: loc });
-          window.open(PORTAL_URL, "_blank", "noopener,noreferrer");
-          return;
-        }
-      }
+    const result = await checkKnownContact();
+    if (result && result.known && result.email) {
+      markUnlocked(result.email);
+      if (shouldNotifyForGate("portal")) notifyPortalRepeat({ email: result.email, location: loc });
+      trackEvent("portal_opened", { location: loc });
+      trackEvent("portal_auto_unlocked", { location: loc });
+      window.open(PORTAL_URL, "_blank", "noopener,noreferrer");
+      return;
     }
     trackEvent("portal_clicked_gated", { location: loc });
     setShowPortalGate(true);

--- a/src/components/academy/AcademyEmailGate.jsx
+++ b/src/components/academy/AcademyEmailGate.jsx
@@ -3,9 +3,6 @@ import { trackEvent } from "../../lib/analytics";
 import { checkKnownContact } from "../../lib/hubspotIdentify";
 import ConsentGate from "../ConsentGate";
 import ConsentCheckbox from "../ConsentCheckbox";
-import AgreementCheckbox from "../AgreementCheckbox";
-import AgreementGate from "../AgreementGate";
-import { hasAcceptedCurrent, markAccepted, AGREEMENT_VERSION } from "../../lib/accessAgreement";
 
 // One notification per visitor per course per 24h. Matches the global
 // gate's throttle window so the inbox volume stays sane in prod.
@@ -141,8 +138,6 @@ const STARTNOW_FALLBACK_FORM_ID = "35384a3e-7386-45b0-924e-84e5d6f637e4";
 export default function AcademyEmailGate({ courseSlug, courseTitle, formId, children }) {
   const effectiveFormId = formId || ACADEMY_FORM_ID || STARTNOW_FALLBACK_FORM_ID;
   const [unlocked, setUnlocked] = useState(() => !!readUnlockEntry(courseSlug));
-  // Access & Evaluation Agreement acceptance (site-wide, versioned).
-  const [acceptedAgreement, setAcceptedAgreement] = useState(() => hasAcceptedCurrent());
 
   // When an already-unlocked visitor reopens a course, silently re-submit
   // their stored email to HubSpot — gives the founder a notification that
@@ -197,28 +192,10 @@ export default function AcademyEmailGate({ courseSlug, courseTitle, formId, chil
   }, []);
   const [email, setEmail] = useState("");
   const [agreed, setAgreed] = useState(false);
-  const [agreedTerms, setAgreedTerms] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
 
-  if (unlocked && acceptedAgreement) return <>{children}</>;
-
-  // Email-unlocked (returning / auto-recognized) but the current agreement
-  // version hasn't been accepted yet — agreement-only step, no email re-entry.
-  if (unlocked && !acceptedAgreement) {
-    const entry = readUnlockEntry(courseSlug);
-    return (
-      <div className="max-w-2xl mx-auto py-12">
-        <div className="bg-slate-900/60 border border-slate-800 rounded-2xl p-8 md:p-10">
-          <AgreementGate
-            email={(entry && entry.email) || ""}
-            surface={`academy_${courseSlug}`}
-            onAccepted={() => setAcceptedAgreement(true)}
-          />
-        </div>
-      </div>
-    );
-  }
+  if (unlocked) return <>{children}</>;
 
   // The form is always shown. If HubSpot env vars / form id are missing in
   // this environment, submissions will surface a friendly error via setError
@@ -234,13 +211,7 @@ export default function AcademyEmailGate({ courseSlug, courseTitle, formId, chil
       if (!isConfigured) {
         throw new Error("HubSpot form not configured");
       }
-      // pageName carries the acceptance record: the agreement checkbox is
-      // required before submit, so this submission evidences acceptance.
-      await submitToHubSpot({
-        email,
-        courseTitle: `${courseTitle} · Access Agreement v${AGREEMENT_VERSION} accepted`,
-        formId: effectiveFormId,
-      });
+      await submitToHubSpot({ email, courseTitle, formId: effectiveFormId });
       writeUnlockEntry(courseSlug, {
         email,
         ts: Date.now(),
@@ -248,8 +219,6 @@ export default function AcademyEmailGate({ courseSlug, courseTitle, formId, chil
         // useEffect doesn't immediately re-fire on the same render cycle.
         lastNotifiedTs: Date.now(),
       });
-      markAccepted(email);
-      setAcceptedAgreement(true);
       trackEvent("academy_email_submitted", { course: courseSlug });
       setUnlocked(true);
     } catch (err) {
@@ -296,14 +265,9 @@ export default function AcademyEmailGate({ courseSlug, courseTitle, formId, chil
               checked={agreed}
               onChange={setAgreed}
             />
-            <AgreementCheckbox
-              id={`academy-agreement-${courseSlug}`}
-              checked={agreedTerms}
-              onChange={setAgreedTerms}
-            />
             <button
               type="submit"
-              disabled={submitting || !email || !agreed || !agreedTerms}
+              disabled={submitting || !email || !agreed}
               className="w-full bg-[#1A6BF5] hover:bg-[#4D8EF8] disabled:opacity-60 disabled:cursor-not-allowed text-white px-5 py-3 rounded-lg font-medium transition-colors"
             >
               {submitting ? "Sending…" : "Send me the access link"}

--- a/src/lib/accessAgreement.js
+++ b/src/lib/accessAgreement.js
@@ -10,7 +10,11 @@
 // whose pageName records the version + surface — a per-contact, timestamped
 // acceptance record on the CRM side.
 
-export const AGREEMENT_VERSION = "1.0";
+// 1.1 (2026-06-13): personal-capacity acceptance only (no binding the
+// employer); use restricted to the signee alone on a personal computer
+// under their sole control; no disclosure to anyone (employee/advisor
+// exception removed). Version bump re-prompts all v1.0 acceptors.
+export const AGREEMENT_VERSION = "1.1";
 export const AGREEMENT_PATH = "/access-agreement";
 
 const STORAGE_KEY = "traigent_access_agreement";


### PR DESCRIPTION
- **v1.1 text**: personal-capacity acceptance (binds the individual, not the employer); use by the signee alone on a personal computer under their sole control; no disclosure to anyone. Version bump re-prompts all v1.0 acceptors.
- **Scope narrowed per founder**: agreement clickwrap applies only to Start Now / SDK access (all 8 shared-modal mounts + /get-started). Portal + Academy return to email-only gates; their unrelated hardening (24h throttle, form fallback) is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)