### PR TITLE
Start Now OTP gate: email verification + acceptance receipts (dormant until worker URL set)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ VITE_HUBSPOT_REGION=
 VITE_HSUTK_IDENTIFY_ENABLED=false
 VITE_HSUTK_CHECK_URL=
 
+# Start Now email verification (OTP) — URL of the access-otp Cloudflare Worker
+# (see workers/access-otp/README.md). Empty = OTP dormant, legacy email-form
+# gate runs. When set, Start Now requires a 6-digit emailed code; each
+# verification writes a permanent acceptance receipt server-side (Worker KV).
+VITE_OTP_WORKER_URL=
+
 # HubSpot Academy form GUID — the form embedded on /academy/* pages to gate
 # course content behind email submission. Create the form in HubSpot UI
 # (Marketing → Forms → Create form), then paste its GUID here. When unset,

--- a/src/components/OtpGate.jsx
+++ b/src/components/OtpGate.jsx
@@ -1,0 +1,185 @@
+/* eslint-disable react/prop-types */
+import { useEffect, useRef, useState } from "react";
+import { Mail, ShieldCheck } from "lucide-react";
+import ConsentGate from "./ConsentGate";
+import ConsentCheckbox from "./ConsentCheckbox";
+import AgreementCheckbox from "./AgreementCheckbox";
+import { requestCode, verifyCode, otpErrorMessage } from "../lib/otpAccess";
+import { getUnlockedEmail } from "../lib/startNowGate";
+import { trackEvent } from "../lib/analytics";
+
+const RESEND_COOLDOWN_S = 30;
+
+/**
+ * Email + one-time-code gate for Start Now. Two steps:
+ *   1. email + consent + agreement tick → "Email me a code"
+ *   2. 6-digit code entry → verify → onVerified(email)
+ *
+ * Verification writes the server-side acceptance receipt in the Worker —
+ * by the time onVerified fires, the evidence record already exists.
+ * The email field prefills from the legacy unlock stamp when present:
+ * returning visitors are asked to verify, not to start from scratch.
+ */
+export default function OtpGate({ surface = "start_now", onVerified }) {
+  const [step, setStep] = useState("email"); // email | code
+  const [email, setEmail] = useState(() => getUnlockedEmail());
+  const [consent, setConsent] = useState(false);
+  const [agreed, setAgreed] = useState(false);
+  const [code, setCode] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [cooldown, setCooldown] = useState(0);
+  const codeInputRef = useRef(null);
+
+  useEffect(() => {
+    if (cooldown <= 0) return undefined;
+    const t = setTimeout(() => setCooldown((s) => s - 1), 1000);
+    return () => clearTimeout(t);
+  }, [cooldown]);
+
+  useEffect(() => {
+    if (step === "code" && codeInputRef.current) codeInputRef.current.focus();
+  }, [step]);
+
+  const sendCode = async () => {
+    setBusy(true);
+    setError("");
+    const result = await requestCode(email.trim());
+    setBusy(false);
+    if (result.ok) {
+      setStep("code");
+      setCode("");
+      setCooldown(RESEND_COOLDOWN_S);
+      trackEvent("start_now_otp_requested", { location: surface });
+    } else {
+      setError(otpErrorMessage(result.error));
+    }
+  };
+
+  const submitCode = async () => {
+    setBusy(true);
+    setError("");
+    const result = await verifyCode({ email: email.trim(), code: code.trim(), surface });
+    setBusy(false);
+    if (result.ok) {
+      trackEvent("start_now_otp_verified", { location: surface });
+      onVerified(email.trim().toLowerCase());
+    } else {
+      setError(otpErrorMessage(result.error, result.remaining));
+      if (result.error === "expired" || result.error === "too_many_attempts") {
+        setStep("email");
+        setCode("");
+      }
+    }
+  };
+
+  if (step === "code") {
+    return (
+      <div>
+        <p className="text-slate-300 mb-1 flex items-center gap-2">
+          <Mail className="w-4 h-4 text-blue-400 shrink-0" />
+          We emailed a 6-digit code to <span className="font-semibold text-white">{email}</span>
+        </p>
+        <p className="text-xs text-slate-500 mb-4">
+          It expires in 10 minutes. Check spam if it hasn&apos;t arrived within a minute.
+        </p>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!busy && code.trim().length === 6) submitCode();
+          }}
+        >
+          <input
+            ref={codeInputRef}
+            type="text"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            pattern="\d{6}"
+            maxLength={6}
+            value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+            placeholder="123456"
+            aria-label="6-digit verification code"
+            className="w-full bg-slate-950 border border-slate-700 focus:border-blue-500 outline-none rounded-lg px-4 py-3 text-white text-2xl tracking-[0.5em] text-center font-mono mb-3"
+          />
+          {error && <p className="text-sm text-red-400 mb-3">{error}</p>}
+          <button
+            type="submit"
+            disabled={busy || code.trim().length !== 6}
+            className="w-full inline-flex items-center justify-center bg-[#1A6BF5] hover:bg-[#4D8EF8] disabled:opacity-40 disabled:cursor-not-allowed text-white px-6 py-3 rounded-lg text-sm font-medium transition-colors"
+          >
+            <ShieldCheck className="mr-2 h-4 w-4" />
+            {busy ? "Verifying…" : "Verify & unlock"}
+          </button>
+        </form>
+        <div className="flex items-center justify-between mt-4 text-xs text-slate-500">
+          <button
+            type="button"
+            onClick={() => {
+              if (cooldown <= 0 && !busy) sendCode();
+            }}
+            disabled={cooldown > 0 || busy}
+            className="underline underline-offset-2 hover:text-slate-300 disabled:no-underline disabled:cursor-default"
+          >
+            {cooldown > 0 ? `Resend code in ${cooldown}s` : "Resend code"}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setStep("email");
+              setError("");
+              setCode("");
+            }}
+            className="underline underline-offset-2 hover:text-slate-300"
+          >
+            Use a different email
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ConsentGate>
+      <div className="mb-3">
+        <ConsentCheckbox id={`${surface}-consent`} checked={consent} onChange={setConsent} />
+      </div>
+      <div className="mb-4">
+        <AgreementCheckbox id={`${surface}-agreement`} checked={agreed} onChange={setAgreed} />
+      </div>
+      {consent && agreed ? (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!busy && email.trim()) sendCode();
+          }}
+        >
+          <label htmlFor={`${surface}-email`} className="block text-xs text-slate-400 mb-1.5">
+            Work email — we&apos;ll send a 6-digit code to verify it&apos;s yours
+          </label>
+          <input
+            id={`${surface}-email`}
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@company.com"
+            aria-label="Work email"
+            className="w-full bg-slate-950 border border-slate-700 focus:border-blue-500 outline-none rounded-lg px-4 py-3 text-white mb-3"
+          />
+          {error && <p className="text-sm text-red-400 mb-3">{error}</p>}
+          <button
+            type="submit"
+            disabled={busy || !email.trim()}
+            className="w-full inline-flex items-center justify-center bg-[#1A6BF5] hover:bg-[#4D8EF8] disabled:opacity-40 disabled:cursor-not-allowed text-white px-6 py-3 rounded-lg text-sm font-medium transition-colors"
+          >
+            <Mail className="mr-2 h-4 w-4" />
+            {busy ? "Sending…" : "Email me a code"}
+          </button>
+        </form>
+      ) : (
+        <p className="text-xs text-slate-500">Tick both boxes above to continue.</p>
+      )}
+    </ConsentGate>
+  );
+}

--- a/src/components/StartNowModal.jsx
+++ b/src/components/StartNowModal.jsx
@@ -11,12 +11,14 @@ import {
   getUnlockedEmail,
   shouldNotifyForGate,
 } from "../lib/startNowGate";
-import { notifyStartNowRepeat, notifyAgreementAccepted } from "../lib/hubspotForms";
+import { notifyStartNowRepeat, notifyAgreementAccepted, notifyOtpVerified } from "../lib/hubspotForms";
 import { checkKnownContact } from "../lib/hubspotIdentify";
 import { trackEvent } from "../lib/analytics";
 import { hasAcceptedCurrent, markAccepted, AGREEMENT_VERSION } from "../lib/accessAgreement";
 import AgreementCheckbox from "./AgreementCheckbox";
 import AgreementGate from "./AgreementGate";
+import OtpGate from "./OtpGate";
+import { isOtpEnabled, isVerified } from "../lib/otpAccess";
 
 /**
  * Two-state modal:
@@ -29,14 +31,20 @@ import AgreementGate from "./AgreementGate";
  * straight to the analytics event so we can see which surfaces convert.
  */
 export default function StartNowModal({ onClose, location = "unknown" }) {
+  // When the OTP Worker is configured, Start Now requires its own stronger
+  // stamp: email verified by code on THIS browser. Prior unlocks from other
+  // gates (or HubSpot recognition) deliberately do NOT satisfy it.
+  const otpMode = isOtpEnabled();
+  const [verified, setVerified] = useState(() => isVerified());
   // Initialize from localStorage so repeat visitors skip the form.
   const [unlocked, setUnlocked] = useState(() => isUnlocked());
   // Access & Evaluation Agreement acceptance (versioned; re-prompts on bump).
   const [accepted, setAccepted] = useState(() => hasAcceptedCurrent());
   // Briefly check whether the hubspotutk cookie maps to a known HubSpot
   // contact (Contact Us submitter, meeting booker, BCC'd lead, etc.). If
-  // it does, auto-unlock without showing the form.
-  const [checkingIdentity, setCheckingIdentity] = useState(() => !isUnlocked());
+  // it does, auto-unlock without showing the form. Skipped in OTP mode —
+  // recognition can't substitute for mailbox proof.
+  const [checkingIdentity, setCheckingIdentity] = useState(() => !otpMode && !isUnlocked());
 
   useEffect(() => {
     const onKey = (e) => {
@@ -55,7 +63,7 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
   // they came back. Throttled by shouldNotifyRepeatVisit so the inbox
   // stays sane.
   useEffect(() => {
-    if (!unlocked) return;
+    if (otpMode ? !verified : !unlocked) return;
     if (!shouldNotifyForGate("startnow")) return;
     const email = getUnlockedEmail();
     if (!email) return;
@@ -71,7 +79,7 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
   // HubSpot contact, auto-unlock + fire the re-notify to this gate's
   // form. Falls through to the form on any failure / timeout / no match.
   useEffect(() => {
-    if (unlocked) return;
+    if (otpMode || unlocked) return;
     let cancelled = false;
     checkKnownContact().then((result) => {
       if (cancelled) return;
@@ -98,6 +106,19 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
     trackEvent("start_now_form_submitted", { location });
   };
 
+  // OTP path: by the time this fires, the Worker has verified the mailbox
+  // and written the permanent acceptance receipt. The client-side stamps
+  // and HubSpot notifications are the convenience layer on top.
+  const handleVerified = (email) => {
+    markUnlocked(email);
+    markAccepted(email);
+    notifyOtpVerified({ email, location });
+    notifyAgreementAccepted({ email, location, version: AGREEMENT_VERSION });
+    setAccepted(true);
+    setUnlocked(true);
+    setVerified(true);
+  };
+
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
       <div
@@ -119,7 +140,13 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
           <X className="w-5 h-5" />
         </button>
 
-        {checkingIdentity ? (
+        {otpMode ? (
+          verified ? (
+            <UnlockedView />
+          ) : (
+            <OtpLockedView surface={`start_now_${location}`} onVerified={handleVerified} />
+          )
+        ) : checkingIdentity ? (
           <CheckingView />
         ) : unlocked ? (
           accepted ? (
@@ -146,6 +173,21 @@ function CheckingView() {
         Start Now — Free
       </h2>
       <p className="text-slate-400 mb-6 animate-pulse">Checking your access…</p>
+    </>
+  );
+}
+
+function OtpLockedView({ surface, onVerified }) {
+  return (
+    <>
+      <h2 id="start-now-title" className="text-2xl font-bold text-white mb-2">
+        Start Now — Free
+      </h2>
+      <p className="text-slate-400 mb-6">
+        Run the keyless demo on your laptop in under a minute. Verify your work
+        email with a one-time code — the install command unlocks right after.
+      </p>
+      <OtpGate surface={surface} onVerified={onVerified} />
     </>
   );
 }

--- a/src/lib/hubspotForms.js
+++ b/src/lib/hubspotForms.js
@@ -92,6 +92,21 @@ export function notifyPitchDeckViewed({ email, location }) {
 }
 
 /**
+ * OTP success record: the visitor entered the code sent to their mailbox, so
+ * this email is VERIFIED (not just claimed). Creates/updates the HubSpot
+ * contact and fires the founder notification. The authoritative receipt
+ * lives server-side in the access-otp Worker's KV; this is the CRM echo.
+ */
+export function notifyOtpVerified({ email, location }) {
+  return notifyRepeatVisit({
+    email,
+    formId: STARTNOW_FORM_ID,
+    location,
+    label: "Start Now email VERIFIED (OTP)",
+  });
+}
+
+/**
  * Acceptance-evidence record for the Access & Evaluation Agreement: fires a
  * silent submission whose pageName carries the version + surface, giving the
  * contact a timestamped acceptance entry in HubSpot.

--- a/src/lib/otpAccess.js
+++ b/src/lib/otpAccess.js
@@ -1,0 +1,132 @@
+// Client for the access-OTP Worker (workers/access-otp) — email verification
+// for the Start Now gate.
+//
+// Feature switch: the whole flow is dormant until VITE_OTP_WORKER_URL is set
+// in .env.local and the site rebuilt. While dormant, gates use the legacy
+// email-form flow and this module is never consulted.
+//
+// The "verified" stamp is deliberately SEPARATE from (and stronger than) the
+// shared startNowGate unlock: a visitor who left their email at the knob
+// explorer, or whom HubSpot recognizes, still does the one-time code check
+// the first time they hit Start Now. Recognition says who they claim to be;
+// the code proves they control the mailbox. The stamp is per-browser, so
+// every device that ever reaches the SDK has its own server-side receipt.
+
+import { AGREEMENT_VERSION } from "./accessAgreement";
+
+const WORKER_URL = (import.meta.env.VITE_OTP_WORKER_URL || "").replace(/\/+$/, "");
+const VERIFIED_KEY = "traigent_verified_access";
+const TTL_MS = 90 * 24 * 60 * 60 * 1000; // mirrors startNowGate's horizon
+
+export function isOtpEnabled() {
+  return Boolean(WORKER_URL);
+}
+
+function readStamp() {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(VERIFIED_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verified = code entered on THIS browser, within TTL, for the CURRENT
+ * agreement version. A version bump therefore re-runs the full email+code
+ * flow — each new acceptance gets its own fresh server-side receipt.
+ */
+export function isVerified() {
+  const stamp = readStamp();
+  if (!stamp) return false;
+  if (Date.now() - (Number(stamp.ts) || 0) > TTL_MS) return false;
+  return stamp.version === AGREEMENT_VERSION;
+}
+
+export function getVerifiedEmail() {
+  const stamp = readStamp();
+  return stamp && typeof stamp.email === "string" ? stamp.email : "";
+}
+
+function markVerified(email, receiptId) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      VERIFIED_KEY,
+      JSON.stringify({ email, receiptId, version: AGREEMENT_VERSION, ts: Date.now() }),
+    );
+  } catch {
+    /* private mode — the worst case is a re-verify next visit */
+  }
+}
+
+async function post(path, body) {
+  const res = await fetch(`${WORKER_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    credentials: "omit",
+    referrerPolicy: "no-referrer",
+  });
+  let data = null;
+  try {
+    data = await res.json();
+  } catch {
+    /* non-JSON error body — fall through to generic error */
+  }
+  return { ok: res.ok, data: data || {} };
+}
+
+/** Ask the Worker to email a 6-digit code. Returns { ok, error? }. */
+export async function requestCode(email) {
+  try {
+    const { ok, data } = await post("/otp/start", { email });
+    return ok ? { ok: true } : { ok: false, error: data.error || "send_failed" };
+  } catch {
+    return { ok: false, error: "network" };
+  }
+}
+
+/**
+ * Verify the code. On success the Worker has already written the permanent
+ * acceptance receipt; we stamp this browser and return the receiptId.
+ */
+export async function verifyCode({ email, code, surface }) {
+  try {
+    const { ok, data } = await post("/otp/verify", {
+      email,
+      code,
+      agreementVersion: AGREEMENT_VERSION,
+      surface,
+    });
+    if (!ok) return { ok: false, error: data.error || "invalid_code", remaining: data.remaining };
+    markVerified(email, data.receiptId || "");
+    return { ok: true, receiptId: data.receiptId || "" };
+  } catch {
+    return { ok: false, error: "network" };
+  }
+}
+
+/** Friendly copy for Worker / network error codes. */
+export function otpErrorMessage(error, remaining) {
+  switch (error) {
+    case "business_email_required":
+      return "Please use your work email — personal email domains aren't accepted.";
+    case "rate_limited":
+      return "Too many code requests — please try again in an hour.";
+    case "invalid_code":
+      return remaining > 0
+        ? `That code didn't match — ${remaining} attempt${remaining === 1 ? "" : "s"} left.`
+        : "That code didn't match.";
+    case "too_many_attempts":
+      return "Too many wrong attempts — request a fresh code.";
+    case "expired":
+      return "That code expired — request a fresh one.";
+    case "otp_unavailable":
+    case "send_failed":
+    case "network":
+    default:
+      return "We couldn't reach the verification service. Please try again in a few minutes.";
+  }
+}

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -11,12 +11,14 @@ import {
   getUnlockedEmail,
   shouldNotifyForGate,
 } from "../lib/startNowGate";
-import { notifyStartNowRepeat, notifyAgreementAccepted } from "../lib/hubspotForms";
+import { notifyStartNowRepeat, notifyAgreementAccepted, notifyOtpVerified } from "../lib/hubspotForms";
 import { checkKnownContact } from "../lib/hubspotIdentify";
 import { trackEvent } from "../lib/analytics";
 import { hasAcceptedCurrent, markAccepted, AGREEMENT_VERSION } from "../lib/accessAgreement";
 import AgreementCheckbox from "../components/AgreementCheckbox";
 import AgreementGate from "../components/AgreementGate";
+import OtpGate from "../components/OtpGate";
+import { isOtpEnabled, isVerified } from "../lib/otpAccess";
 
 const createPageUrl = (path) => path;
 const { installPresets, goals: AGENT_GOALS } = skillOnboarding;
@@ -56,6 +58,10 @@ function composeAgentPrompt(goals) {
 }
 
 export default function GetStarted() {
+  // When the OTP Worker is configured, SDK access requires the stronger
+  // verified-email stamp (code entered on this browser) — see StartNowModal.
+  const otpMode = isOtpEnabled();
+  const [verified, setVerified] = useState(() => isVerified());
   // Gate the install commands behind the HubSpot form on first visit.
   // Same 90-day localStorage memory as the Start Now modal so a visitor
   // who unlocked there doesn't see the form again here, and vice versa.
@@ -65,10 +71,12 @@ export default function GetStarted() {
   const [agreedTerms, setAgreedTerms] = useState(false);
   const [selectedGoalIds, setSelectedGoalIds] = useState(DEFAULT_AGENT_GOAL_IDS);
   const [copiedPrompt, setCopiedPrompt] = useState(false);
+  // Install commands render only behind the active gate's success state.
+  const hasAccess = otpMode ? verified : unlocked && accepted;
 
   // Repeat-visit notification — see StartNowModal for the rationale.
   useEffect(() => {
-    if (!unlocked) return;
+    if (otpMode ? !verified : !unlocked) return;
     if (!shouldNotifyForGate("get_started_page")) return;
     const email = getUnlockedEmail();
     if (!email) return;
@@ -78,8 +86,9 @@ export default function GetStarted() {
   }, []);
 
   // Identity check via the hsutk Worker — auto-unlock known contacts.
+  // Skipped in OTP mode: recognition can't substitute for mailbox proof.
   useEffect(() => {
-    if (unlocked) return;
+    if (otpMode || unlocked) return;
     let cancelled = false;
     checkKnownContact().then((result) => {
       if (cancelled) return;
@@ -102,6 +111,17 @@ export default function GetStarted() {
     setAccepted(true);
     setUnlocked(true);
     trackEvent("start_now_form_submitted", { location: "get_started_page" });
+  };
+
+  // OTP path: Worker has verified the mailbox + written the receipt already.
+  const handleVerified = (email) => {
+    markUnlocked(email);
+    markAccepted(email);
+    notifyOtpVerified({ email, location: "get_started_page" });
+    notifyAgreementAccepted({ email, location: "get_started_page", version: AGREEMENT_VERSION });
+    setAccepted(true);
+    setUnlocked(true);
+    setVerified(true);
   };
 
   const selectedGoals = useMemo(
@@ -159,7 +179,17 @@ export default function GetStarted() {
           Start bottom-up with the SDK, or start foundational with TVL. Either way: specify, evaluate, optimize, and apply—like software.
         </p>
 
-        {!unlocked && (
+        {otpMode && !verified && (
+          <div className="mb-10 p-6 rounded-xl bg-slate-900/60 border border-slate-800 max-w-2xl">
+            <h2 className="text-xl font-semibold mb-2">First, verify your work email</h2>
+            <p className="text-slate-300 mb-4 max-w-3xl">
+              We&apos;ll send a 6-digit code to confirm the address is yours — the
+              install commands below appear as soon as you enter it.
+            </p>
+            <OtpGate surface="get_started_page" onVerified={handleVerified} />
+          </div>
+        )}
+        {!otpMode && !unlocked && (
           <div className="mb-10 p-6 rounded-xl bg-slate-900/60 border border-slate-800">
             <h2 className="text-xl font-semibold mb-2">First, tell us where to send setup tips</h2>
             <p className="text-slate-300 mb-4 max-w-3xl">
@@ -183,7 +213,7 @@ export default function GetStarted() {
             )}
           </div>
         )}
-        {unlocked && !accepted && (
+        {!otpMode && unlocked && !accepted && (
           <div className="mb-10 p-6 rounded-xl bg-slate-900/60 border border-slate-800 max-w-2xl">
             <AgreementGate
               email={getUnlockedEmail()}
@@ -217,7 +247,7 @@ export default function GetStarted() {
             <p className="text-slate-300 mb-4">
               Install the published Python SDK from your terminal. The bootstrap is a thin shell script that installs <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent[recommended]</code>, verifies <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent info</code>, refuses root/container installs unless <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">TRAIGENT_ALLOW_ROOT=1</code> is explicitly set, and never prompts for or reads credentials. The installer detects <code className="px-1 py-0.5 rounded bg-slate-800 text-sm">traigent onboard</code> (included in the published SDK) and suggests it next — it sets up device login against <a href="https://portal.traigent.ai" target="_blank" rel="noopener noreferrer" className="text-blue-300 hover:text-blue-200 underline underline-offset-4">portal.traigent.ai</a> and your coding agent.
             </p>
-            {unlocked && accepted && (
+            {hasAccess && (
               <>
                 <InstallCommand
                   command={TERMINAL_INSTALL_COMMAND}
@@ -284,7 +314,7 @@ export default function GetStarted() {
           <p className="text-slate-300 mb-4 max-w-3xl">
             Claude Code, Cursor, Codex, Gemini CLI and 30+ other agents pick up the Traigent skill bundle automatically. They&apos;ll guide you through dry-run-first setup, generate the eval dataset, and apply the best config — without you leaving your editor. Coding agent? Point it at <a href="/agent.md" className="text-blue-300 hover:text-blue-200 underline underline-offset-4">traigent.ai/agent.md</a>.
           </p>
-          {unlocked && accepted && (
+          {hasAccess && (
             <InstallCommand
               command={SDK_SKILL_INSTALL_PRESET.command}
               label={SDK_SKILL_INSTALL_PRESET.label}

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "v-https://github.com/Traigent/traigent-web/-agreement-v14-purpose-first-2026-06-12-21:45",
+  "version": "v-https://github.com/Traigent/traigent-web/-startnow-otp-gate-2026-06-12-22:18",
   "repo": "https://github.com/Traigent/traigent-web/",
-  "branch": "agreement-v14-purpose-first",
-  "buildTime": "2026-06-12-21:45"
+  "branch": "startnow-otp-gate",
+  "buildTime": "2026-06-12-22:18"
 }

--- a/workers/access-otp/README.md
+++ b/workers/access-otp/README.md
@@ -1,0 +1,70 @@
+# Access OTP Worker
+
+Email-verification (OTP) backend for the **Start Now** gate, plus permanent
+server-side **acceptance receipts** for the Access & Evaluation Agreement.
+
+Why it exists: the site is static, so without a backend the acceptance record
+is fired from the visitor's browser and the email is merely *claimed*. This
+Worker makes the email *verified* (a code is sent to the mailbox and must be
+entered back) and writes the acceptance receipt server-side at the moment of
+verification — no receipt, no unlock.
+
+## What a receipt contains
+
+`receipt:<epoch-ms>:<email>` in KV, written only after a correct code:
+
+```json
+{
+  "receiptId": "1781290521000-a1b2c3d4",
+  "email": "dana@bigcorp.com",
+  "verifiedAt": "2026-06-12T19:02:01.000Z",
+  "ip": "203.0.113.7",
+  "country": "IL",
+  "userAgent": "Mozilla/5.0 …",
+  "agreementVersion": "1.4",
+  "agreementTextSha256": "<sha of AgreementText.jsx at deploy>",
+  "surface": "start_now_topnav"
+}
+```
+
+Together with the git history of `src/components/AgreementText.jsx` (exact
+text per version) this is the attribution package: verified mailbox control +
+assent + content + time + device context.
+
+## Deploy (first time)
+
+```bash
+cd workers/access-otp
+npx wrangler login                          # browser OAuth
+npx wrangler kv namespace create ACCESS_KV  # paste resulting id into wrangler.jsonc
+# Pin the agreement text hash (PowerShell):
+#   Get-FileHash -Algorithm SHA256 ..\..\src\components\AgreementText.jsx
+# put the hex into "AGREEMENT_SHA" in wrangler.jsonc — redo on version bumps.
+npx wrangler secret put RESEND_API_KEY      # from resend.com (verify traigent.ai domain first)
+npx wrangler secret put OTP_PEPPER          # any long random string
+npx wrangler secret put ADMIN_KEY           # bearer token for GET /receipts
+npx wrangler deploy
+```
+
+Then set the Worker URL in the site's `.env.local` as `VITE_OTP_WORKER_URL`
+and rebuild/redeploy the site. An empty `VITE_OTP_WORKER_URL` keeps the whole
+OTP flow dormant (site behaves exactly as before).
+
+## Audit receipts
+
+```bash
+curl -H "Authorization: Bearer <ADMIN_KEY>" https://<worker-url>/receipts
+```
+
+## Endpoints
+
+| Method | Path          | Body                                          | Success            |
+| ------ | ------------- | --------------------------------------------- | ------------------ |
+| POST   | `/otp/start`  | `{ email }`                                    | `{ sent: true }`   |
+| POST   | `/otp/verify` | `{ email, code, agreementVersion, surface }`   | `{ verified, receiptId }` |
+| GET    | `/receipts`   | — (Bearer ADMIN_KEY)                           | `{ count, receipts }` |
+
+Errors: `business_email_required`, `rate_limited` (10/IP/h, 5/email/h),
+`otp_unavailable` (no Resend key configured), `send_failed`, `expired`
+(10-minute code TTL), `invalid_code` (with `remaining`), `too_many_attempts`
+(5 wrong tries burns the code).

--- a/workers/access-otp/src/index.js
+++ b/workers/access-otp/src/index.js
@@ -1,0 +1,252 @@
+// Traigent Access OTP Worker
+//
+// Proves mailbox control at the moment of agreement acceptance, and writes a
+// permanent server-side acceptance receipt. This is the evidentiary backbone
+// of the Start Now gate: the localStorage stamp on the visitor's machine is
+// convenience; the KV receipt written here is the record.
+//
+// Endpoints (all JSON):
+//   POST /otp/start   { email }                              → { sent: true }
+//   POST /otp/verify  { email, code, agreementVersion, surface }
+//                                              → { verified: true, receiptId }
+//   GET  /receipts    Authorization: Bearer <ADMIN_KEY>      → { receipts: [...] }
+//
+// KV layout (single namespace ACCESS_KV):
+//   otp:<email>            pending code: { codeHash, tries, ts }   TTL 10 min
+//   rl:ip:<ip>             send counter per IP                     TTL 1 h
+//   rl:email:<email>       send counter per email                  TTL 1 h
+//   receipt:<ts>:<email>   acceptance receipt — NO TTL (permanent evidence)
+//   verified:<email>       latest verification pointer — no TTL
+
+const OTP_TTL_S = 600; // codes live 10 minutes
+const MAX_TRIES = 5; // wrong-code attempts per issued code
+const RL_WINDOW_S = 3600; // rate-limit window
+const RL_MAX_PER_IP = 10; // code sends per IP per window
+const RL_MAX_PER_EMAIL = 5; // code sends per email per window
+
+// Free-mail domains rejected server-side. HubSpot blocks these on its forms;
+// the Worker must enforce independently because verification IS the gate.
+const FREE_MAIL = new Set([
+  "gmail.com", "googlemail.com", "yahoo.com", "yahoo.co.uk", "yahoo.fr",
+  "hotmail.com", "hotmail.co.uk", "hotmail.fr", "outlook.com", "outlook.fr",
+  "live.com", "live.co.uk", "msn.com", "aol.com", "icloud.com", "me.com",
+  "mac.com", "proton.me", "protonmail.com", "pm.me", "gmx.com", "gmx.de",
+  "gmx.net", "mail.com", "mail.ru", "yandex.com", "yandex.ru", "zoho.com",
+  "fastmail.com", "hey.com", "tutanota.com", "tuta.io", "qq.com", "163.com",
+  "126.com", "naver.com", "walla.co.il", "duck.com", "mailinator.com",
+  "guerrillamail.com", "10minutemail.com", "temp-mail.org", "yopmail.com",
+]);
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const cors = corsHeaders(request, env);
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: cors });
+    }
+
+    try {
+      if (request.method === "POST" && url.pathname === "/otp/start") {
+        return await handleStart(request, env, cors);
+      }
+      if (request.method === "POST" && url.pathname === "/otp/verify") {
+        return await handleVerify(request, env, cors);
+      }
+      if (request.method === "GET" && url.pathname === "/receipts") {
+        return await handleReceipts(request, env, cors);
+      }
+      return json({ error: "not_found" }, 404, cors);
+    } catch (err) {
+      // Never leak internals; the frontend maps this to "try again shortly".
+      console.error("unhandled", err && err.message);
+      return json({ error: "internal" }, 500, cors);
+    }
+  },
+};
+
+function corsHeaders(request, env) {
+  const origin = request.headers.get("Origin") || "";
+  const allowed = (env.ALLOWED_ORIGINS || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const headers = {
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Access-Control-Max-Age": "86400",
+    Vary: "Origin",
+  };
+  if (allowed.includes(origin)) headers["Access-Control-Allow-Origin"] = origin;
+  return headers;
+}
+
+function json(body, status, cors) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...cors },
+  });
+}
+
+function normalizeEmail(raw) {
+  return String(raw || "").trim().toLowerCase();
+}
+
+function isBusinessEmail(email) {
+  if (!EMAIL_RE.test(email)) return false;
+  const domain = email.split("@")[1];
+  return !FREE_MAIL.has(domain);
+}
+
+async function sha256Hex(text) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// Counter with TTL window. KV has no atomic increment; for a marketing-site
+// gate, lost updates under race just make the limit marginally looser —
+// acceptable. Returns the count AFTER incrementing.
+async function bumpCounter(env, key, ttlSeconds) {
+  const current = Number((await env.ACCESS_KV.get(key)) || "0") + 1;
+  await env.ACCESS_KV.put(key, String(current), { expirationTtl: ttlSeconds });
+  return current;
+}
+
+async function handleStart(request, env, cors) {
+  const body = await request.json().catch(() => ({}));
+  const email = normalizeEmail(body.email);
+
+  if (!isBusinessEmail(email)) {
+    return json({ error: "business_email_required" }, 400, cors);
+  }
+
+  const ip = request.headers.get("CF-Connecting-IP") || "unknown";
+  if ((await bumpCounter(env, `rl:ip:${ip}`, RL_WINDOW_S)) > RL_MAX_PER_IP) {
+    return json({ error: "rate_limited" }, 429, cors);
+  }
+  if ((await bumpCounter(env, `rl:email:${email}`, RL_WINDOW_S)) > RL_MAX_PER_EMAIL) {
+    return json({ error: "rate_limited" }, 429, cors);
+  }
+
+  if (!env.RESEND_API_KEY) {
+    return json({ error: "otp_unavailable" }, 503, cors);
+  }
+
+  // 6 digits, crypto-random, no modulo bias worth caring about at 10^6.
+  const buf = new Uint32Array(1);
+  crypto.getRandomValues(buf);
+  const code = String(buf[0] % 1000000).padStart(6, "0");
+
+  await env.ACCESS_KV.put(
+    `otp:${email}`,
+    JSON.stringify({ codeHash: await sha256Hex(`${code}|${env.OTP_PEPPER || ""}`), tries: 0, ts: Date.now() }),
+    { expirationTtl: OTP_TTL_S },
+  );
+
+  const sendRes = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: env.FROM_EMAIL || "Traigent Access <access@traigent.ai>",
+      to: [email],
+      subject: `${code} is your Traigent access code`,
+      html: codeEmailHtml(code),
+      text: `Your Traigent access code is ${code}. It expires in 10 minutes.\n\nYou're receiving this because this address was entered at traigent.ai to unlock SDK access. If this wasn't you, you can ignore this email.`,
+    }),
+  });
+
+  if (!sendRes.ok) {
+    const detail = await sendRes.text().catch(() => "");
+    console.error("resend_failed", sendRes.status, detail.slice(0, 300));
+    return json({ error: "send_failed" }, 502, cors);
+  }
+
+  return json({ sent: true }, 200, cors);
+}
+
+async function handleVerify(request, env, cors) {
+  const body = await request.json().catch(() => ({}));
+  const email = normalizeEmail(body.email);
+  const code = String(body.code || "").trim();
+
+  if (!isBusinessEmail(email) || !/^\d{6}$/.test(code)) {
+    return json({ error: "invalid_request" }, 400, cors);
+  }
+
+  const otpKey = `otp:${email}`;
+  const pendingRaw = await env.ACCESS_KV.get(otpKey);
+  if (!pendingRaw) {
+    return json({ error: "expired" }, 400, cors);
+  }
+  const pending = JSON.parse(pendingRaw);
+
+  if (pending.tries >= MAX_TRIES) {
+    await env.ACCESS_KV.delete(otpKey);
+    return json({ error: "too_many_attempts" }, 429, cors);
+  }
+
+  const codeHash = await sha256Hex(`${code}|${env.OTP_PEPPER || ""}`);
+  if (codeHash !== pending.codeHash) {
+    pending.tries += 1;
+    await env.ACCESS_KV.put(otpKey, JSON.stringify(pending), { expirationTtl: OTP_TTL_S });
+    return json({ error: "invalid_code", remaining: MAX_TRIES - pending.tries }, 400, cors);
+  }
+
+  // Verified: burn the code, write the permanent acceptance receipt.
+  await env.ACCESS_KV.delete(otpKey);
+
+  const now = new Date();
+  const receiptId = `${now.getTime()}-${crypto.randomUUID().slice(0, 8)}`;
+  const receipt = {
+    receiptId,
+    email,
+    verifiedAt: now.toISOString(),
+    ip: request.headers.get("CF-Connecting-IP") || "",
+    country: (request.cf && request.cf.country) || "",
+    userAgent: request.headers.get("User-Agent") || "",
+    agreementVersion: String(body.agreementVersion || ""),
+    agreementTextSha256: env.AGREEMENT_SHA || "",
+    surface: String(body.surface || "").slice(0, 80),
+  };
+
+  await env.ACCESS_KV.put(`receipt:${now.getTime()}:${email}`, JSON.stringify(receipt));
+  await env.ACCESS_KV.put(`verified:${email}`, JSON.stringify({ receiptId, verifiedAt: receipt.verifiedAt }));
+
+  return json({ verified: true, receiptId }, 200, cors);
+}
+
+async function handleReceipts(request, env, cors) {
+  const auth = request.headers.get("Authorization") || "";
+  if (!env.ADMIN_KEY || auth !== `Bearer ${env.ADMIN_KEY}`) {
+    return json({ error: "unauthorized" }, 401, cors);
+  }
+  const list = await env.ACCESS_KV.list({ prefix: "receipt:", limit: 1000 });
+  const receipts = [];
+  for (const key of list.keys) {
+    const raw = await env.ACCESS_KV.get(key.name);
+    if (raw) receipts.push(JSON.parse(raw));
+  }
+  receipts.sort((a, b) => (a.verifiedAt < b.verifiedAt ? 1 : -1));
+  return json({ count: receipts.length, receipts }, 200, cors);
+}
+
+function codeEmailHtml(code) {
+  return `<!DOCTYPE html>
+<html><body style="margin:0;padding:0;background:#0f172a;font-family:Arial,Helvetica,sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0f172a;padding:32px 16px;">
+    <tr><td align="center">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px;background:#1e293b;border:1px solid #334155;border-radius:12px;padding:32px;">
+        <tr><td style="color:#ffffff;font-size:18px;font-weight:bold;padding-bottom:8px;">Traigent access code</td></tr>
+        <tr><td style="color:#94a3b8;font-size:14px;line-height:1.5;padding-bottom:24px;">Enter this code at traigent.ai to verify your email and unlock SDK access. It expires in 10 minutes.</td></tr>
+        <tr><td align="center" style="padding-bottom:24px;"><div style="display:inline-block;background:#0f172a;border:1px solid #1a6bf5;border-radius:8px;padding:14px 28px;color:#ffffff;font-size:32px;font-weight:bold;letter-spacing:8px;">${code}</div></td></tr>
+        <tr><td style="color:#64748b;font-size:12px;line-height:1.5;">You're receiving this because this address was entered at traigent.ai to unlock SDK access. If this wasn't you, you can safely ignore this email — no access is granted without the code.</td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body></html>`;
+}

--- a/workers/access-otp/wrangler.jsonc
+++ b/workers/access-otp/wrangler.jsonc
@@ -1,0 +1,25 @@
+// Cloudflare Worker: OTP email verification + acceptance receipts for the
+// Start Now gate. Deploy from this directory:
+//   npx wrangler deploy
+// Secrets (set once via `npx wrangler secret put <NAME>`):
+//   RESEND_API_KEY — Resend.com API key for sending the code emails
+//   OTP_PEPPER     — random string mixed into the stored code hashes
+//   ADMIN_KEY      — bearer token for GET /receipts (founder audit)
+{
+  "name": "traigent-access-otp",
+  "main": "src/index.js",
+  "compatibility_date": "2026-05-01",
+  "kv_namespaces": [
+    // id is created with: npx wrangler kv namespace create ACCESS_KV
+    { "binding": "ACCESS_KV", "id": "REPLACE_AFTER_CREATE" }
+  ],
+  "vars": {
+    // Sender must be on a Resend-verified domain before real sends work.
+    "FROM_EMAIL": "Traigent Access <access@traigent.ai>",
+    "ALLOWED_ORIGINS": "https://traigent.ai,https://www.traigent.ai,http://localhost:5173",
+    // SHA-256 of src/components/AgreementText.jsx at deploy time — pins the
+    // exact agreement text each receipt was issued against. Update on
+    // AGREEMENT_VERSION bumps (see workers/access-otp/README.md).
+    "AGREEMENT_SHA": ""
+  }
+}


### PR DESCRIPTION
Adds the access-otp Cloudflare Worker (OTP send/verify, permanent server-side acceptance receipts, rate limits, free-mail blocklist, founder audit endpoint) and the frontend OTP flow (OtpGate component + separate verified-email stamp for Start Now / Get Started). Entirely dormant until VITE_OTP_WORKER_URL is set at build time — this PR changes no live behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)