### PR TITLE
CI deploy: pass VITE_OTP_WORKER_URL (activates OTP gate in prod)

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -42,6 +42,9 @@ jobs:
           VITE_HUBSPOT_ACADEMY_FORM_ID: ${{ vars.VITE_HUBSPOT_ACADEMY_FORM_ID }}
           VITE_HSUTK_CHECK_URL: ${{ vars.VITE_HSUTK_CHECK_URL }}
           VITE_HSUTK_IDENTIFY_ENABLED: ${{ vars.VITE_HSUTK_IDENTIFY_ENABLED }}
+          # Start Now OTP gate — public Worker endpoint (workers/access-otp).
+          # Empty = OTP dormant, legacy email-form gate.
+          VITE_OTP_WORKER_URL: ${{ vars.VITE_OTP_WORKER_URL }}
           VITE_POSTHOG_KEY: ${{ vars.VITE_POSTHOG_KEY }}
           VITE_POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST }}
           VITE_GA4_ID: ${{ vars.VITE_GA4_ID }}


### PR DESCRIPTION
Adds VITE_OTP_WORKER_URL to the deploy workflow env (Actions Variable already set to https://otp.traigent.ai). Merging this triggers the CI deploy that actually activates the Start Now OTP gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)