### PR TITLE
OTP gate: restore inline scrollable agreement text

### DIFF
--- a/src/components/OtpGate.jsx
+++ b/src/components/OtpGate.jsx
@@ -4,6 +4,7 @@ import { Mail, ShieldCheck } from "lucide-react";
 import ConsentGate from "./ConsentGate";
 import ConsentCheckbox from "./ConsentCheckbox";
 import AgreementCheckbox from "./AgreementCheckbox";
+import AgreementText from "./AgreementText";
 import { requestCode, verifyCode, otpErrorMessage } from "../lib/otpAccess";
 import { getUnlockedEmail } from "../lib/startNowGate";
 import { trackEvent } from "../lib/analytics";
@@ -143,6 +144,11 @@ export default function OtpGate({ surface = "start_now", onVerified }) {
     <ConsentGate>
       <div className="mb-3">
         <ConsentCheckbox id={`${surface}-consent`} checked={consent} onChange={setConsent} />
+      </div>
+      {/* The full agreement, scrollable in-place so acceptance is informed
+          without leaving the gate — same presentation as AgreementGate. */}
+      <div className="max-h-60 overflow-y-auto rounded-lg border border-slate-700/60 bg-slate-950/60 p-4 mb-3">
+        <AgreementText compact />
       </div>
       <div className="mb-4">
         <AgreementCheckbox id={`${surface}-agreement`} checked={agreed} onChange={setAgreed} />

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "v-https://github.com/Traigent/traigent-web/-otp-csp-connect-2026-06-12-23:29",
+  "version": "v-https://github.com/Traigent/traigent-web/-otp-gate-scrollable-agreement-2026-06-12-23:38",
   "repo": "https://github.com/Traigent/traigent-web/",
-  "branch": "otp-csp-connect",
-  "buildTime": "2026-06-12-23:29"
+  "branch": "otp-gate-scrollable-agreement",
+  "buildTime": "2026-06-12-23:38"
 }


### PR DESCRIPTION
The OTP email step showed only the agreement checkbox+link; this restores the scrollable in-place agreement text (AgreementGate presentation) above it. Applies to the Start Now modal and Get Started page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)