### PR TITLE
Hero: drop em-dash after 'AI Agent Optimization'

### DIFF
--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -133,7 +133,7 @@ export default function Homepage() {
               className="text-5xl md:text-6xl lg:text-7xl font-bold leading-[1.55] tracking-tight mb-6"
               style={{ fontFamily: "'Inter', sans-serif", letterSpacing: '-0.03em' }}
             >
-              AI Agent Optimization —<br />
+              AI Agent Optimization<br />
               <span className="text-[#4D8EF8]">Fully Automated</span>
             </motion.h1>
             <motion.p

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "v-https://github.com/Traigent/traigent-web/-story-run2-label-2026-06-13-07:32",
+  "version": "v-https://github.com/Traigent/traigent-web/-hero-drop-emdash-2026-06-13-11:32",
   "repo": "https://github.com/Traigent/traigent-web/",
-  "branch": "story-run2-label",
-  "buildTime": "2026-06-13-07:32"
+  "branch": "hero-drop-emdash",
+  "buildTime": "2026-06-13-11:32"
 }


### PR DESCRIPTION
Removes the trailing em-dash in the homepage hero h1 so it reads 'AI Agent Optimization' / 'Fully Automated'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)