### PR TITLE
Start Now: drop Access Agreement, keep email+OTP

### DIFF
--- a/src/components/OtpGate.jsx
+++ b/src/components/OtpGate.jsx
@@ -3,8 +3,6 @@ import { useEffect, useRef, useState } from "react";
 import { Mail, ShieldCheck } from "lucide-react";
 import ConsentGate from "./ConsentGate";
 import ConsentCheckbox from "./ConsentCheckbox";
-import AgreementCheckbox from "./AgreementCheckbox";
-import AgreementText from "./AgreementText";
 import { requestCode, verifyCode, otpErrorMessage } from "../lib/otpAccess";
 import { getUnlockedEmail } from "../lib/startNowGate";
 import { trackEvent } from "../lib/analytics";
@@ -13,19 +11,18 @@ const RESEND_COOLDOWN_S = 30;
 
 /**
  * Email + one-time-code gate for Start Now. Two steps:
- *   1. email + consent + agreement tick → "Email me a code"
+ *   1. email + consent tick → "Email me a code"
  *   2. 6-digit code entry → verify → onVerified(email)
  *
- * Verification writes the server-side acceptance receipt in the Worker —
- * by the time onVerified fires, the evidence record already exists.
- * The email field prefills from the legacy unlock stamp when present:
+ * Verification writes the server-side receipt in the Worker (verified email,
+ * IP, time, device) — by the time onVerified fires, the access record already
+ * exists. The email field prefills from the legacy unlock stamp when present:
  * returning visitors are asked to verify, not to start from scratch.
  */
 export default function OtpGate({ surface = "start_now", onVerified }) {
   const [step, setStep] = useState("email"); // email | code
   const [email, setEmail] = useState(() => getUnlockedEmail());
   const [consent, setConsent] = useState(false);
-  const [agreed, setAgreed] = useState(false);
   const [code, setCode] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
@@ -142,18 +139,10 @@ export default function OtpGate({ surface = "start_now", onVerified }) {
 
   return (
     <ConsentGate>
-      <div className="mb-3">
+      <div className="mb-4">
         <ConsentCheckbox id={`${surface}-consent`} checked={consent} onChange={setConsent} />
       </div>
-      {/* The full agreement, scrollable in-place so acceptance is informed
-          without leaving the gate — same presentation as AgreementGate. */}
-      <div className="max-h-60 overflow-y-auto rounded-lg border border-slate-700/60 bg-slate-950/60 p-4 mb-3">
-        <AgreementText compact />
-      </div>
-      <div className="mb-4">
-        <AgreementCheckbox id={`${surface}-agreement`} checked={agreed} onChange={setAgreed} />
-      </div>
-      {consent && agreed ? (
+      {consent ? (
         <form
           onSubmit={(e) => {
             e.preventDefault();
@@ -184,7 +173,7 @@ export default function OtpGate({ surface = "start_now", onVerified }) {
           </button>
         </form>
       ) : (
-        <p className="text-xs text-slate-500">Tick both boxes above to continue.</p>
+        <p className="text-xs text-slate-500">Tick the box above to continue.</p>
       )}
     </ConsentGate>
   );

--- a/src/components/StartNowModal.jsx
+++ b/src/components/StartNowModal.jsx
@@ -11,12 +11,9 @@ import {
   getUnlockedEmail,
   shouldNotifyForGate,
 } from "../lib/startNowGate";
-import { notifyStartNowRepeat, notifyAgreementAccepted, notifyOtpVerified } from "../lib/hubspotForms";
+import { notifyStartNowRepeat, notifyOtpVerified } from "../lib/hubspotForms";
 import { checkKnownContact } from "../lib/hubspotIdentify";
 import { trackEvent } from "../lib/analytics";
-import { hasAcceptedCurrent, markAccepted, AGREEMENT_VERSION } from "../lib/accessAgreement";
-import AgreementCheckbox from "./AgreementCheckbox";
-import AgreementGate from "./AgreementGate";
 import OtpGate from "./OtpGate";
 import { isOtpEnabled, isVerified } from "../lib/otpAccess";
 
@@ -38,8 +35,6 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
   const [verified, setVerified] = useState(() => isVerified());
   // Initialize from localStorage so repeat visitors skip the form.
   const [unlocked, setUnlocked] = useState(() => isUnlocked());
-  // Access & Evaluation Agreement acceptance (versioned; re-prompts on bump).
-  const [accepted, setAccepted] = useState(() => hasAcceptedCurrent());
   // Briefly check whether the hubspotutk cookie maps to a known HubSpot
   // contact (Contact Us submitter, meeting booker, BCC'd lead, etc.). If
   // it does, auto-unlock without showing the form. Skipped in OTP mode —
@@ -97,25 +92,16 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
 
   const handleSubmitted = (email) => {
     markUnlocked(email);
-    // The agreement checkbox is required before the form mounts, so the
-    // submission itself evidences acceptance — record it.
-    markAccepted(email);
-    if (email) notifyAgreementAccepted({ email, location, version: AGREEMENT_VERSION });
-    setAccepted(true);
     setUnlocked(true);
     trackEvent("start_now_form_submitted", { location });
   };
 
-  // OTP path: by the time this fires, the Worker has verified the mailbox
-  // and written the permanent acceptance receipt. The client-side stamps
-  // and HubSpot notifications are the convenience layer on top.
+  // OTP path: by the time this fires, the Worker has verified the mailbox and
+  // written the server-side access receipt (verified email, IP, time, device).
+  // The client-side stamp + HubSpot notification are the convenience layer.
   const handleVerified = (email) => {
     markUnlocked(email);
-    markAccepted(email);
     notifyOtpVerified({ email, location });
-    notifyAgreementAccepted({ email, location, version: AGREEMENT_VERSION });
-    setAccepted(true);
-    setUnlocked(true);
     setVerified(true);
   };
 
@@ -149,15 +135,7 @@ export default function StartNowModal({ onClose, location = "unknown" }) {
         ) : checkingIdentity ? (
           <CheckingView />
         ) : unlocked ? (
-          accepted ? (
-            <UnlockedView />
-          ) : (
-            <AgreementGate
-              email={getUnlockedEmail()}
-              surface={`start_now_${location}`}
-              onAccepted={() => setAccepted(true)}
-            />
-          )
+          <UnlockedView />
         ) : (
           <LockedView onSubmitted={handleSubmitted} />
         )}
@@ -194,7 +172,6 @@ function OtpLockedView({ surface, onVerified }) {
 
 function LockedView({ onSubmitted }) {
   const [agreed, setAgreed] = useState(false);
-  const [agreedTerms, setAgreedTerms] = useState(false);
   return (
     <>
       <h2 id="start-now-title" className="text-2xl font-bold text-white mb-2">
@@ -205,25 +182,18 @@ function LockedView({ onSubmitted }) {
         send setup tips — the install command unlocks as soon as you submit.
       </p>
       <ConsentGate>
-        <div className="mb-3">
+        <div className="mb-4">
           <ConsentCheckbox
             id="start-now-consent"
             checked={agreed}
             onChange={setAgreed}
           />
         </div>
-        <div className="mb-4">
-          <AgreementCheckbox
-            id="start-now-agreement"
-            checked={agreedTerms}
-            onChange={setAgreedTerms}
-          />
-        </div>
-        {agreed && agreedTerms ? (
+        {agreed ? (
           <HubSpotStartNowForm onSuccess={onSubmitted} />
         ) : (
           <p className="text-xs text-slate-500">
-            Tick both boxes above to load the form.
+            Tick the box above to load the form.
           </p>
         )}
       </ConsentGate>

--- a/src/pages/GetStarted.jsx
+++ b/src/pages/GetStarted.jsx
@@ -11,12 +11,9 @@ import {
   getUnlockedEmail,
   shouldNotifyForGate,
 } from "../lib/startNowGate";
-import { notifyStartNowRepeat, notifyAgreementAccepted, notifyOtpVerified } from "../lib/hubspotForms";
+import { notifyStartNowRepeat, notifyOtpVerified } from "../lib/hubspotForms";
 import { checkKnownContact } from "../lib/hubspotIdentify";
 import { trackEvent } from "../lib/analytics";
-import { hasAcceptedCurrent, markAccepted, AGREEMENT_VERSION } from "../lib/accessAgreement";
-import AgreementCheckbox from "../components/AgreementCheckbox";
-import AgreementGate from "../components/AgreementGate";
 import OtpGate from "../components/OtpGate";
 import { isOtpEnabled, isVerified } from "../lib/otpAccess";
 
@@ -66,13 +63,10 @@ export default function GetStarted() {
   // Same 90-day localStorage memory as the Start Now modal so a visitor
   // who unlocked there doesn't see the form again here, and vice versa.
   const [unlocked, setUnlocked] = useState(() => isUnlocked());
-  // Access & Evaluation Agreement acceptance (site-wide, versioned).
-  const [accepted, setAccepted] = useState(() => hasAcceptedCurrent());
-  const [agreedTerms, setAgreedTerms] = useState(false);
   const [selectedGoalIds, setSelectedGoalIds] = useState(DEFAULT_AGENT_GOAL_IDS);
   const [copiedPrompt, setCopiedPrompt] = useState(false);
   // Install commands render only behind the active gate's success state.
-  const hasAccess = otpMode ? verified : unlocked && accepted;
+  const hasAccess = otpMode ? verified : unlocked;
 
   // Repeat-visit notification — see StartNowModal for the rationale.
   useEffect(() => {
@@ -105,22 +99,14 @@ export default function GetStarted() {
 
   const handleSubmitted = (email) => {
     markUnlocked(email);
-    // The agreement checkbox is required before the form mounts — record it.
-    markAccepted(email);
-    if (email) notifyAgreementAccepted({ email, location: "get_started_page", version: AGREEMENT_VERSION });
-    setAccepted(true);
     setUnlocked(true);
     trackEvent("start_now_form_submitted", { location: "get_started_page" });
   };
 
-  // OTP path: Worker has verified the mailbox + written the receipt already.
+  // OTP path: Worker has verified the mailbox + written the access receipt.
   const handleVerified = (email) => {
     markUnlocked(email);
-    markAccepted(email);
     notifyOtpVerified({ email, location: "get_started_page" });
-    notifyAgreementAccepted({ email, location: "get_started_page", version: AGREEMENT_VERSION });
-    setAccepted(true);
-    setUnlocked(true);
     setVerified(true);
   };
 
@@ -197,29 +183,7 @@ export default function GetStarted() {
               email you more than once a month, and you can unsubscribe with one
               click.
             </p>
-            <div className="mb-4 max-w-3xl">
-              <AgreementCheckbox
-                id="get-started-agreement"
-                checked={agreedTerms}
-                onChange={setAgreedTerms}
-              />
-            </div>
-            {agreedTerms ? (
-              <HubSpotStartNowForm onSuccess={handleSubmitted} targetId="hs-form-getstarted" />
-            ) : (
-              <p className="text-xs text-slate-500">
-                Accept the agreement above to load the form.
-              </p>
-            )}
-          </div>
-        )}
-        {!otpMode && unlocked && !accepted && (
-          <div className="mb-10 p-6 rounded-xl bg-slate-900/60 border border-slate-800 max-w-2xl">
-            <AgreementGate
-              email={getUnlockedEmail()}
-              surface="get_started_page"
-              onAccepted={() => setAccepted(true)}
-            />
+            <HubSpotStartNowForm onSuccess={handleSubmitted} targetId="hs-form-getstarted" />
           </div>
         )}
 

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "v-https://github.com/Traigent/traigent-web/-hero-drop-emdash-2026-06-13-11:32",
+  "version": "v-https://github.com/Traigent/traigent-web/-startnow-drop-agreement-2026-06-13-11:54",
   "repo": "https://github.com/Traigent/traigent-web/",
-  "branch": "hero-drop-emdash",
-  "buildTime": "2026-06-13-11:32"
+  "branch": "startnow-drop-agreement",
+  "buildTime": "2026-06-13-11:54"
 }


### PR DESCRIPTION
Removes the legal clickwrap from the Start Now gate while keeping the email + one-time-code verification (and its server-side access receipt + HubSpot 'VERIFIED (OTP)' notification). Agreement infra left dormant in the repo for easy reinstatement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)