### PR TITLE
ci: migrate traigent-web PR checks to triagent-dev ARC runners (RD-1446)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   code-quality:
-    runs-on: ubuntu-latest
+    runs-on: medium
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   security-checks:
-    runs-on: ubuntu-latest
+    runs-on: light
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Move the docker-free node PR checks onto the self-hosted runners (buildah/no-dind):
- **code-quality.yml** -> `medium` (npm ci/lint/prettier/build)
- **security-checks.yml** -> `light` (npm audit + secret scan)

`deploy-gh-pages.yml` left on `ubuntu-latest` (low-frequency deploy; keep safe). No ECR build here, so no `DEV_AWS_ROLE_ARN` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)